### PR TITLE
feat: dsp 2025 apis

### DIFF
--- a/core/negotiation-manager/src/main/java/org/eclipse/edc/virtualized/controlplane/contract/negotiation/ContractManagerExtension.java
+++ b/core/negotiation-manager/src/main/java/org/eclipse/edc/virtualized/controlplane/contract/negotiation/ContractManagerExtension.java
@@ -18,7 +18,6 @@ import org.eclipse.edc.connector.controlplane.contract.spi.negotiation.ConsumerC
 import org.eclipse.edc.connector.controlplane.contract.spi.negotiation.ContractNegotiationPendingGuard;
 import org.eclipse.edc.connector.controlplane.contract.spi.negotiation.observe.ContractNegotiationObservable;
 import org.eclipse.edc.connector.controlplane.contract.spi.negotiation.store.ContractNegotiationStore;
-import org.eclipse.edc.protocol.spi.DataspaceProfileContextRegistry;
 import org.eclipse.edc.runtime.metamodel.annotation.Extension;
 import org.eclipse.edc.runtime.metamodel.annotation.Inject;
 import org.eclipse.edc.runtime.metamodel.annotation.Provider;
@@ -28,6 +27,7 @@ import org.eclipse.edc.spi.system.ServiceExtension;
 import org.eclipse.edc.spi.system.ServiceExtensionContext;
 import org.eclipse.edc.transaction.spi.TransactionContext;
 import org.eclipse.edc.virtualized.controlplane.contract.spi.negotiation.ContractNegotiationStateMachineService;
+import org.eclipse.edc.virtualized.controlplane.participantcontext.spi.ParticipantWebhookResolver;
 
 import java.time.Clock;
 
@@ -50,7 +50,7 @@ public class ContractManagerExtension implements ServiceExtension {
     private Monitor monitor;
 
     @Inject
-    private DataspaceProfileContextRegistry dataspaceProfileContextRegistry;
+    private ParticipantWebhookResolver dataspaceProfileContextRegistry;
 
     @Inject
     private RemoteMessageDispatcherRegistry dispatcherRegistry;

--- a/core/transfer-process-manager/src/main/java/org/eclipse/edc/virtualized/controlplane/transfer/process/TransferManagerExtension.java
+++ b/core/transfer-process-manager/src/main/java/org/eclipse/edc/virtualized/controlplane/transfer/process/TransferManagerExtension.java
@@ -21,7 +21,6 @@ import org.eclipse.edc.connector.controlplane.transfer.spi.TransferProcessPendin
 import org.eclipse.edc.connector.controlplane.transfer.spi.flow.DataFlowManager;
 import org.eclipse.edc.connector.controlplane.transfer.spi.observe.TransferProcessObservable;
 import org.eclipse.edc.connector.controlplane.transfer.spi.store.TransferProcessStore;
-import org.eclipse.edc.protocol.spi.DataspaceProfileContextRegistry;
 import org.eclipse.edc.runtime.metamodel.annotation.Extension;
 import org.eclipse.edc.runtime.metamodel.annotation.Inject;
 import org.eclipse.edc.runtime.metamodel.annotation.Provider;
@@ -31,6 +30,7 @@ import org.eclipse.edc.spi.security.Vault;
 import org.eclipse.edc.spi.system.ServiceExtension;
 import org.eclipse.edc.spi.system.ServiceExtensionContext;
 import org.eclipse.edc.transaction.spi.TransactionContext;
+import org.eclipse.edc.virtualized.controlplane.participantcontext.spi.ParticipantWebhookResolver;
 import org.eclipse.edc.virtualized.controlplane.transfer.spi.TransferProcessStateMachineService;
 
 import java.time.Clock;
@@ -55,7 +55,7 @@ public class TransferManagerExtension implements ServiceExtension {
     private Monitor monitor;
 
     @Inject
-    private DataspaceProfileContextRegistry dataspaceProfileContextRegistry;
+    private ParticipantWebhookResolver webhookResolver;
 
     @Inject
     private RemoteMessageDispatcherRegistry dispatcherRegistry;
@@ -90,7 +90,7 @@ public class TransferManagerExtension implements ServiceExtension {
                 .transactionContext(transactionContext)
                 .dataFlowManager(dataFlowManager)
                 .dispatcherRegistry(dispatcherRegistry)
-                .dataspaceProfileContextRegistry(dataspaceProfileContextRegistry)
+                .webhookResolver(webhookResolver)
                 .vault(vault)
                 .addressResolver(dataAddressResolver)
                 .monitor(monitor)

--- a/core/transfer-process-manager/src/test/java/org/eclipse/edc/virtualized/controlplane/transfer/process/TransferProcessStateMachineServiceImplTest.java
+++ b/core/transfer-process-manager/src/test/java/org/eclipse/edc/virtualized/controlplane/transfer/process/TransferProcessStateMachineServiceImplTest.java
@@ -25,13 +25,13 @@ import org.eclipse.edc.connector.controlplane.transfer.spi.types.TransferProcess
 import org.eclipse.edc.connector.controlplane.transfer.spi.types.TransferProcessStates;
 import org.eclipse.edc.connector.controlplane.transfer.spi.types.protocol.TransferProcessAck;
 import org.eclipse.edc.policy.model.Policy;
-import org.eclipse.edc.protocol.spi.DataspaceProfileContextRegistry;
 import org.eclipse.edc.spi.message.RemoteMessageDispatcherRegistry;
 import org.eclipse.edc.spi.monitor.Monitor;
 import org.eclipse.edc.spi.response.StatusResult;
 import org.eclipse.edc.spi.security.Vault;
 import org.eclipse.edc.spi.types.domain.DataAddress;
 import org.eclipse.edc.transaction.spi.NoopTransactionContext;
+import org.eclipse.edc.virtualized.controlplane.participantcontext.spi.ParticipantWebhookResolver;
 import org.eclipse.edc.virtualized.controlplane.transfer.spi.TransferProcessStateMachineService;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -84,7 +84,7 @@ public class TransferProcessStateMachineServiceImplTest {
     private final DataFlowManager dataFlowManager = mock();
     private final Vault vault = mock();
     private final TransferProcessListener listener = mock();
-    private final DataspaceProfileContextRegistry dataspaceProfileContextRegistry = mock();
+    private final ParticipantWebhookResolver participantWebhookResolver = mock();
     private final DataAddressResolver addressResolver = mock();
     private final String protocolWebhookUrl = "http://protocol.webhook/url";
     private final TransferProcessPendingGuard pendingGuard = mock();
@@ -102,7 +102,7 @@ public class TransferProcessStateMachineServiceImplTest {
                 .policyArchive(policyArchive)
                 .vault(vault)
                 .addressResolver(addressResolver)
-                .dataspaceProfileContextRegistry(dataspaceProfileContextRegistry)
+                .webhookResolver(participantWebhookResolver)
                 .pendingGuard(pendingGuard)
                 .transactionContext(new NoopTransactionContext())
                 .build();
@@ -122,7 +122,7 @@ public class TransferProcessStateMachineServiceImplTest {
         when(addressResolver.resolveForAsset(any())).thenReturn(DataAddress.Builder.newInstance().type("type").build());
 
         when(dispatcherRegistry.dispatch(any(), any())).thenReturn(completedFuture(StatusResult.success(TransferProcessAck.Builder.newInstance().build())));
-        when(dataspaceProfileContextRegistry.getWebhook(any())).thenReturn(() -> protocolWebhookUrl);
+        when(participantWebhookResolver.getWebhook(any(), any())).thenReturn(() -> protocolWebhookUrl);
         var transferProcess = TransferProcess.Builder.newInstance()
                 .id(transferProcessId)
                 .type(type)

--- a/core/v-connector-core/build.gradle.kts
+++ b/core/v-connector-core/build.gradle.kts
@@ -1,0 +1,24 @@
+/*
+ *  Copyright (c) 2025 Metaform Systems, Inc.
+ *
+ *  This program and the accompanying materials are made available under the
+ *  terms of the Apache License, Version 2.0 which is available at
+ *  https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Contributors:
+ *       Metaform Systems, Inc. - initial API and implementation
+ *
+ */
+
+plugins {
+    `java-library`
+}
+
+dependencies {
+    api(project(":spi:v-core-spi"))
+    api(libs.edc.spi.core)
+    api(libs.edc.spi.protocol)
+}
+

--- a/core/v-connector-core/src/main/java/org/eclipse/edc/virtualized/controlplane/VirtualCoreServicesExtension.java
+++ b/core/v-connector-core/src/main/java/org/eclipse/edc/virtualized/controlplane/VirtualCoreServicesExtension.java
@@ -1,0 +1,39 @@
+/*
+ *  Copyright (c) 2025 Metaform Systems, Inc.
+ *
+ *  This program and the accompanying materials are made available under the
+ *  terms of the Apache License, Version 2.0 which is available at
+ *  https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Contributors:
+ *       Metaform Systems, Inc. - initial API and implementation
+ *
+ */
+
+package org.eclipse.edc.virtualized.controlplane;
+
+import org.eclipse.edc.protocol.spi.DataspaceProfileContextRegistry;
+import org.eclipse.edc.runtime.metamodel.annotation.Extension;
+import org.eclipse.edc.runtime.metamodel.annotation.Inject;
+import org.eclipse.edc.runtime.metamodel.annotation.Provider;
+import org.eclipse.edc.spi.system.ServiceExtension;
+import org.eclipse.edc.virtualized.controlplane.participantcontext.ParticipantWebhookResolverImpl;
+import org.eclipse.edc.virtualized.controlplane.participantcontext.spi.ParticipantWebhookResolver;
+
+import static org.eclipse.edc.virtualized.controlplane.VirtualCoreServicesExtension.NAME;
+
+@Extension(NAME)
+public class VirtualCoreServicesExtension implements ServiceExtension {
+
+    public static final String NAME = "EDC-V Core Services";
+
+    @Inject
+    private DataspaceProfileContextRegistry dataspaceProfileContextRegistry;
+
+    @Provider
+    public ParticipantWebhookResolver participantWebhookResolver() {
+        return new ParticipantWebhookResolverImpl(dataspaceProfileContextRegistry);
+    }
+}

--- a/core/v-connector-core/src/main/java/org/eclipse/edc/virtualized/controlplane/participantcontext/ParticipantWebhookResolverImpl.java
+++ b/core/v-connector-core/src/main/java/org/eclipse/edc/virtualized/controlplane/participantcontext/ParticipantWebhookResolverImpl.java
@@ -1,0 +1,43 @@
+/*
+ *  Copyright (c) 2025 Metaform Systems, Inc.
+ *
+ *  This program and the accompanying materials are made available under the
+ *  terms of the Apache License, Version 2.0 which is available at
+ *  https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Contributors:
+ *       Metaform Systems, Inc. - initial API and implementation
+ *
+ */
+
+package org.eclipse.edc.virtualized.controlplane.participantcontext;
+
+import org.eclipse.edc.protocol.spi.DataspaceProfileContextRegistry;
+import org.eclipse.edc.protocol.spi.ProtocolWebhook;
+import org.eclipse.edc.virtualized.controlplane.participantcontext.spi.ParticipantWebhookResolver;
+
+import java.util.Optional;
+
+public class ParticipantWebhookResolverImpl implements ParticipantWebhookResolver {
+
+    private final DataspaceProfileContextRegistry registry;
+
+    public ParticipantWebhookResolverImpl(DataspaceProfileContextRegistry registry) {
+        this.registry = registry;
+    }
+
+    @Override
+    public ProtocolWebhook getWebhook(String participantContextId, String protocol) {
+        return Optional.ofNullable(registry.getWebhook(protocol))
+                .map(protocolWebhook -> wrap(participantContextId, protocolWebhook))
+                .orElse(null);
+    }
+
+    private ProtocolWebhook wrap(String participantContextId, ProtocolWebhook protocolWebhook) {
+        return () -> protocolWebhook.url() + "/" + participantContextId;
+
+    }
+
+}

--- a/core/v-connector-core/src/main/resources/META-INF/services/org.eclipse.edc.spi.system.ServiceExtension
+++ b/core/v-connector-core/src/main/resources/META-INF/services/org.eclipse.edc.spi.system.ServiceExtension
@@ -1,0 +1,14 @@
+#
+#  Copyright (c) 2025 Metaform Systems, Inc.
+#
+#  This program and the accompanying materials are made available under the
+#  terms of the Apache License, Version 2.0 which is available at
+#  https://www.apache.org/licenses/LICENSE-2.0
+#
+#  SPDX-License-Identifier: Apache-2.0
+#
+#  Contributors:
+#       Metaform Systems, Inc. - initial API and implementation
+#
+#
+org.eclipse.edc.virtualized.controlplane.VirtualCoreServicesExtension

--- a/data-protocols/dsp/build.gradle.kts
+++ b/data-protocols/dsp/build.gradle.kts
@@ -1,0 +1,27 @@
+/*
+ *  Copyright (c) 2025 Metaform Systems, Inc.
+ *
+ *  This program and the accompanying materials are made available under the
+ *  terms of the Apache License, Version 2.0 which is available at
+ *  https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Contributors:
+ *       Metaform Systems, Inc. - initial API and implementation
+ *
+ */
+
+plugins {
+    `java-library`
+}
+
+dependencies {
+    api(project(":data-protocols:dsp:dsp-2025"))
+    api(libs.edc.core.dsp.http)
+    api(libs.edc.core.dsp.http.configuration)
+    api(libs.edc.core.dsp.http.catalog.dispatcher)
+    api(libs.edc.core.dsp.http.negotiation.dispatcher)
+    api(libs.edc.core.dsp.http.transferprocess.dispatcher)
+    api(libs.edc.core.dsp.version.http.api)
+}

--- a/data-protocols/dsp/dsp-2025/build.gradle.kts
+++ b/data-protocols/dsp/dsp-2025/build.gradle.kts
@@ -1,0 +1,26 @@
+/*
+ *  Copyright (c) 2025 Metaform Systems, Inc.
+ *
+ *  This program and the accompanying materials are made available under the
+ *  terms of the Apache License, Version 2.0 which is available at
+ *  https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Contributors:
+ *       Metaform Systems, Inc. - initial API and implementation
+ *
+ */
+
+plugins {
+    `java-library`
+}
+
+dependencies {
+    api(project(":data-protocols:dsp:dsp-2025:dsp-catalog-2025"))
+    api(project(":data-protocols:dsp:dsp-2025:dsp-negotiation-2025"))
+    api(project(":data-protocols:dsp:dsp-2025:dsp-transfer-process-2025"))
+    api(libs.edc.core.dsp.http.configuration.v2025)
+    api(libs.edc.core.dsp.http.dispatcher.v2025)
+
+}

--- a/data-protocols/dsp/dsp-2025/dsp-catalog-2025/build.gradle.kts
+++ b/data-protocols/dsp/dsp-2025/dsp-catalog-2025/build.gradle.kts
@@ -1,0 +1,22 @@
+/*
+ *  Copyright (c) 2025 Metaform Systems, Inc.
+ *
+ *  This program and the accompanying materials are made available under the
+ *  terms of the Apache License, Version 2.0 which is available at
+ *  https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Contributors:
+ *       Metaform Systems, Inc. - initial API and implementation
+ *
+ */
+
+plugins {
+    `java-library`
+}
+
+dependencies {
+    api(project(":data-protocols:dsp:dsp-2025:dsp-catalog-2025:dsp-catalog-http-api-2025"))
+    api(libs.edc.core.dsp.catalog.transform.v2025)
+}

--- a/data-protocols/dsp/dsp-2025/dsp-catalog-2025/dsp-catalog-http-api-2025/build.gradle.kts
+++ b/data-protocols/dsp/dsp-2025/dsp-catalog-2025/dsp-catalog-http-api-2025/build.gradle.kts
@@ -1,0 +1,35 @@
+/*
+ *  Copyright (c) 2025 Metaform Systems, Inc.
+ *
+ *  This program and the accompanying materials are made available under the
+ *  terms of the Apache License, Version 2.0 which is available at
+ *  https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Contributors:
+ *       Metaform Systems, Inc. - initial API and implementation
+ *
+ */
+
+plugins {
+    `java-library`
+}
+
+dependencies {
+    api(libs.edc.spi.core)
+    api(libs.edc.spi.jsonld)
+    api(libs.edc.spi.web)
+    api(libs.edc.spi.dsp)
+    api(libs.edc.spi.dsp.v2025)
+    api(libs.edc.spi.dsp.http)
+
+    implementation(libs.edc.lib.jersey.providers)
+    implementation(libs.edc.lib.dsp.catalog.validation)
+    implementation(libs.edc.lib.dsp.catalog.http)
+
+    testImplementation(testFixtures(libs.edc.core.jersey))
+
+    testImplementation(testFixtures(libs.edc.lib.dsp.catalog.http));
+
+}

--- a/data-protocols/dsp/dsp-2025/dsp-catalog-2025/dsp-catalog-http-api-2025/src/main/java/org/eclipse/edc/virtual/protocol/dsp/catalog/http/api/v2025/DspCatalogApi2025Extension.java
+++ b/data-protocols/dsp/dsp-2025/dsp-catalog-2025/dsp-catalog-http-api-2025/src/main/java/org/eclipse/edc/virtual/protocol/dsp/catalog/http/api/v2025/DspCatalogApi2025Extension.java
@@ -1,0 +1,121 @@
+/*
+ *  Copyright (c) 2025 Metaform Systems, Inc.
+ *
+ *  This program and the accompanying materials are made available under the
+ *  terms of the Apache License, Version 2.0 which is available at
+ *  https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Contributors:
+ *       Metaform Systems, Inc. - initial API and implementation
+ *
+ */
+
+package org.eclipse.edc.virtual.protocol.dsp.catalog.http.api.v2025;
+
+import org.eclipse.edc.connector.controlplane.catalog.spi.DataService;
+import org.eclipse.edc.connector.controlplane.catalog.spi.DataServiceRegistry;
+import org.eclipse.edc.connector.controlplane.services.spi.catalog.CatalogProtocolService;
+import org.eclipse.edc.jsonld.spi.JsonLd;
+import org.eclipse.edc.participantcontext.spi.service.ParticipantContextService;
+import org.eclipse.edc.protocol.dsp.catalog.http.api.decorator.Base64continuationTokenSerDes;
+import org.eclipse.edc.protocol.dsp.catalog.http.api.decorator.ContinuationTokenManagerImpl;
+import org.eclipse.edc.protocol.dsp.catalog.validation.CatalogRequestMessageValidator;
+import org.eclipse.edc.protocol.dsp.http.spi.message.ContinuationTokenManager;
+import org.eclipse.edc.protocol.dsp.http.spi.message.DspRequestHandler;
+import org.eclipse.edc.protocol.spi.DataspaceProfileContextRegistry;
+import org.eclipse.edc.runtime.metamodel.annotation.Extension;
+import org.eclipse.edc.runtime.metamodel.annotation.Inject;
+import org.eclipse.edc.spi.monitor.Monitor;
+import org.eclipse.edc.spi.query.CriterionOperatorRegistry;
+import org.eclipse.edc.spi.system.ServiceExtension;
+import org.eclipse.edc.spi.system.ServiceExtensionContext;
+import org.eclipse.edc.spi.types.TypeManager;
+import org.eclipse.edc.transform.spi.TypeTransformerRegistry;
+import org.eclipse.edc.validator.spi.JsonObjectValidatorRegistry;
+import org.eclipse.edc.virtual.protocol.dsp.catalog.http.api.v2025.controller.DspCatalogApiController20251;
+import org.eclipse.edc.web.jersey.providers.jsonld.JerseyJsonLdInterceptor;
+import org.eclipse.edc.web.spi.WebService;
+import org.eclipse.edc.web.spi.configuration.ApiContext;
+
+import java.util.Objects;
+
+import static org.eclipse.edc.protocol.dsp.spi.type.Dsp2025Constants.DATASPACE_PROTOCOL_HTTP_V_2025_1;
+import static org.eclipse.edc.protocol.dsp.spi.type.Dsp2025Constants.DSP_NAMESPACE_V_2025_1;
+import static org.eclipse.edc.protocol.dsp.spi.type.Dsp2025Constants.DSP_SCOPE_V_2025_1;
+import static org.eclipse.edc.protocol.dsp.spi.type.Dsp2025Constants.DSP_TRANSFORMER_CONTEXT_V_2025_1;
+import static org.eclipse.edc.protocol.dsp.spi.type.DspCatalogPropertyAndTypeNames.DSPACE_TYPE_CATALOG_REQUEST_MESSAGE_TERM;
+import static org.eclipse.edc.spi.constants.CoreConstants.JSON_LD;
+
+/**
+ * Creates and registers the controller for dataspace protocol v2025/1 catalog requests.
+ */
+@Extension(value = DspCatalogApi2025Extension.NAME)
+public class DspCatalogApi2025Extension implements ServiceExtension {
+
+    public static final String NAME = "Dataspace Protocol 2025/1 API Catalog Extension";
+
+    @Inject
+    private WebService webService;
+    @Inject
+    private CatalogProtocolService service;
+    @Inject
+    private DataServiceRegistry dataServiceRegistry;
+    @Inject
+    private JsonObjectValidatorRegistry validatorRegistry;
+    @Inject
+    private DspRequestHandler dspRequestHandler;
+    @Inject
+    private CriterionOperatorRegistry criterionOperatorRegistry;
+    @Inject
+    private DataspaceProfileContextRegistry dataspaceProfileContextRegistry;
+    @Inject
+    private TypeTransformerRegistry transformerRegistry;
+    @Inject
+    private Monitor monitor;
+    @Inject
+    private TypeManager typeManager;
+    @Inject
+    private JsonLd jsonLd;
+
+    @Inject
+    private ParticipantContextService participantContextService;
+
+    @Override
+    public String name() {
+        return NAME;
+    }
+
+    @Override
+    public void initialize(ServiceExtensionContext context) {
+        registerValidators();
+
+        webService.registerResource(ApiContext.PROTOCOL, new DspCatalogApiController20251(service, participantContextService, dspRequestHandler, continuationTokenManager(monitor), DATASPACE_PROTOCOL_HTTP_V_2025_1, DSP_NAMESPACE_V_2025_1));
+        webService.registerDynamicResource(ApiContext.PROTOCOL, DspCatalogApiController20251.class, new JerseyJsonLdInterceptor(jsonLd, typeManager, JSON_LD, DSP_SCOPE_V_2025_1));
+    }
+
+    private ContinuationTokenManager continuationTokenManager(Monitor monitor) {
+        var continuationTokenSerDes = new Base64continuationTokenSerDes(transformerRegistry.forContext(DSP_TRANSFORMER_CONTEXT_V_2025_1), jsonLd);
+        return new ContinuationTokenManagerImpl(continuationTokenSerDes, DSP_NAMESPACE_V_2025_1, monitor);
+    }
+
+    private void registerValidators() {
+        validatorRegistry.register(DSP_NAMESPACE_V_2025_1.toIri(DSPACE_TYPE_CATALOG_REQUEST_MESSAGE_TERM), CatalogRequestMessageValidator.instance(criterionOperatorRegistry, DSP_NAMESPACE_V_2025_1));
+    }
+
+    @Override
+    public void prepare() {
+        registerDataService();
+    }
+
+    // TODO refactor this upstream in order to resolve the endpoint url dynamically based on the participant context
+    private void registerDataService() {
+
+        var endpointUrl = Objects.requireNonNull(dataspaceProfileContextRegistry.getWebhook(DATASPACE_PROTOCOL_HTTP_V_2025_1)).url();
+        dataServiceRegistry.register(DATASPACE_PROTOCOL_HTTP_V_2025_1, DataService.Builder.newInstance()
+                .endpointDescription("dspace:connector")
+                .endpointUrl(endpointUrl)
+                .build());
+    }
+}

--- a/data-protocols/dsp/dsp-2025/dsp-catalog-2025/dsp-catalog-http-api-2025/src/main/java/org/eclipse/edc/virtual/protocol/dsp/catalog/http/api/v2025/controller/DspCatalogApiController20251.java
+++ b/data-protocols/dsp/dsp-2025/dsp-catalog-2025/dsp-catalog-http-api-2025/src/main/java/org/eclipse/edc/virtual/protocol/dsp/catalog/http/api/v2025/controller/DspCatalogApiController20251.java
@@ -1,0 +1,121 @@
+/*
+ *  Copyright (c) 2025 Metaform Systems, Inc.
+ *
+ *  This program and the accompanying materials are made available under the
+ *  terms of the Apache License, Version 2.0 which is available at
+ *  https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Contributors:
+ *       Metaform Systems, Inc. - initial API and implementation
+ *
+ */
+
+package org.eclipse.edc.virtual.protocol.dsp.catalog.http.api.v2025.controller;
+
+import jakarta.json.JsonObject;
+import jakarta.ws.rs.BadRequestException;
+import jakarta.ws.rs.Consumes;
+import jakarta.ws.rs.GET;
+import jakarta.ws.rs.HeaderParam;
+import jakarta.ws.rs.POST;
+import jakarta.ws.rs.Path;
+import jakarta.ws.rs.PathParam;
+import jakarta.ws.rs.Produces;
+import jakarta.ws.rs.QueryParam;
+import jakarta.ws.rs.core.Context;
+import jakarta.ws.rs.core.Response;
+import jakarta.ws.rs.core.UriInfo;
+import org.eclipse.edc.connector.controlplane.catalog.spi.Catalog;
+import org.eclipse.edc.connector.controlplane.catalog.spi.CatalogError;
+import org.eclipse.edc.connector.controlplane.catalog.spi.CatalogRequestMessage;
+import org.eclipse.edc.connector.controlplane.catalog.spi.Dataset;
+import org.eclipse.edc.connector.controlplane.services.spi.catalog.CatalogProtocolService;
+import org.eclipse.edc.jsonld.spi.JsonLdNamespace;
+import org.eclipse.edc.participantcontext.spi.service.ParticipantContextService;
+import org.eclipse.edc.participantcontext.spi.service.ParticipantContextSupplier;
+import org.eclipse.edc.protocol.dsp.http.spi.message.ContinuationTokenManager;
+import org.eclipse.edc.protocol.dsp.http.spi.message.DspRequestHandler;
+import org.eclipse.edc.protocol.dsp.http.spi.message.GetDspRequest;
+import org.eclipse.edc.protocol.dsp.http.spi.message.PostDspRequest;
+
+import static jakarta.ws.rs.core.HttpHeaders.AUTHORIZATION;
+import static jakarta.ws.rs.core.MediaType.APPLICATION_JSON;
+import static org.eclipse.edc.protocol.dsp.catalog.http.api.CatalogApiPaths.BASE_PATH;
+import static org.eclipse.edc.protocol.dsp.catalog.http.api.CatalogApiPaths.CATALOG_REQUEST;
+import static org.eclipse.edc.protocol.dsp.catalog.http.api.CatalogApiPaths.DATASET_REQUEST;
+import static org.eclipse.edc.protocol.dsp.spi.type.Dsp2025Constants.V_2025_1_PATH;
+import static org.eclipse.edc.protocol.dsp.spi.type.DspCatalogPropertyAndTypeNames.DSPACE_TYPE_CATALOG_REQUEST_MESSAGE_TERM;
+
+/**
+ * Versioned Catalog endpoint for 2025/1 protocol version
+ */
+@Consumes({APPLICATION_JSON})
+@Produces({APPLICATION_JSON})
+@Path(V_2025_1_PATH + "/{participantContextId}" + BASE_PATH)
+public class DspCatalogApiController20251 {
+
+    private final CatalogProtocolService service;
+    private final ParticipantContextService participantContextService;
+    private final DspRequestHandler dspRequestHandler;
+    private final ContinuationTokenManager continuationTokenManager;
+    private final String protocol;
+    private final JsonLdNamespace namespace;
+
+    public DspCatalogApiController20251(CatalogProtocolService service, ParticipantContextService participantContextService, DspRequestHandler dspRequestHandler,
+                                        ContinuationTokenManager continuationTokenManager, String protocol, JsonLdNamespace namespace) {
+        this.service = service;
+        this.participantContextService = participantContextService;
+        this.dspRequestHandler = dspRequestHandler;
+        this.continuationTokenManager = continuationTokenManager;
+        this.protocol = protocol;
+        this.namespace = namespace;
+    }
+
+    @POST
+    @Path(CATALOG_REQUEST)
+    public Response requestCatalog(@PathParam("participantContextId") String participantContextId, JsonObject jsonObject, @HeaderParam(AUTHORIZATION) String token, @Context UriInfo uriInfo,
+                                   @QueryParam("continuationToken") String continuationToken) {
+        JsonObject messageJson;
+        if (continuationToken == null) {
+            messageJson = jsonObject;
+        } else {
+            messageJson = continuationTokenManager.applyQueryFromToken(jsonObject, continuationToken)
+                    .orElseThrow(f -> new BadRequestException(f.getFailureDetail()));
+        }
+
+        var request = PostDspRequest.Builder.newInstance(CatalogRequestMessage.class, Catalog.class, CatalogError.class)
+                .token(token)
+                .expectedMessageType(namespace.toIri(DSPACE_TYPE_CATALOG_REQUEST_MESSAGE_TERM))
+                .message(messageJson)
+                .serviceCall(service::getCatalog)
+                .errorProvider(CatalogError.Builder::newInstance)
+                .protocol(protocol)
+                .participantContextProvider(participantContextSupplier(participantContextId))
+                .build();
+
+        var responseDecorator = continuationTokenManager.createResponseDecorator(uriInfo.getAbsolutePath().toString());
+        return dspRequestHandler.createResource(request, responseDecorator);
+    }
+
+    @GET
+    @Path(DATASET_REQUEST + "/{id}")
+    public Response getDataset(@PathParam("participantContextId") String participantContextId, @PathParam("id") String id, @HeaderParam(AUTHORIZATION) String token) {
+        var request = GetDspRequest.Builder.newInstance(Dataset.class, CatalogError.class)
+                .token(token)
+                .id(id)
+                .serviceCall((ctx, datasetId, tokenRepresentation) -> service.getDataset(ctx, datasetId, tokenRepresentation, protocol))
+                .errorProvider(CatalogError.Builder::newInstance)
+                .participantContextProvider(participantContextSupplier(participantContextId))
+                .protocol(protocol)
+                .build();
+
+        return dspRequestHandler.getResource(request);
+    }
+
+    // TODO refactor upstream to use ServiceResult
+    private ParticipantContextSupplier participantContextSupplier(String id) {
+        return () -> participantContextService.getParticipantContext(id).getContent();
+    }
+}

--- a/data-protocols/dsp/dsp-2025/dsp-catalog-2025/dsp-catalog-http-api-2025/src/main/resources/META-INF/services/org.eclipse.edc.spi.system.ServiceExtension
+++ b/data-protocols/dsp/dsp-2025/dsp-catalog-2025/dsp-catalog-http-api-2025/src/main/resources/META-INF/services/org.eclipse.edc.spi.system.ServiceExtension
@@ -1,0 +1,15 @@
+#
+#  Copyright (c) 2025 Metaform Systems, Inc.
+#
+#  This program and the accompanying materials are made available under the
+#  terms of the Apache License, Version 2.0 which is available at
+#  https://www.apache.org/licenses/LICENSE-2.0
+#
+#  SPDX-License-Identifier: Apache-2.0
+#
+#  Contributors:
+#       Metaform Systems, Inc. - initial API and implementation
+#
+#
+
+org.eclipse.edc.virtual.protocol.dsp.catalog.http.api.v2025.DspCatalogApi2025Extension

--- a/data-protocols/dsp/dsp-2025/dsp-catalog-2025/dsp-catalog-http-api-2025/src/test/java/org/eclipse/edc/virtual/protocol/dsp/catalog/http/api/v2025/controller/DspCatalogApiControllerV20251Test.java
+++ b/data-protocols/dsp/dsp-2025/dsp-catalog-2025/dsp-catalog-http-api-2025/src/test/java/org/eclipse/edc/virtual/protocol/dsp/catalog/http/api/v2025/controller/DspCatalogApiControllerV20251Test.java
@@ -1,0 +1,57 @@
+/*
+ *  Copyright (c) 2025 Metaform Systems, Inc.
+ *
+ *  This program and the accompanying materials are made available under the
+ *  terms of the Apache License, Version 2.0 which is available at
+ *  https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Contributors:
+ *       Metaform Systems, Inc. - initial API and implementation
+ *
+ */
+
+package org.eclipse.edc.virtual.protocol.dsp.catalog.http.api.v2025.controller;
+
+import org.eclipse.edc.jsonld.spi.JsonLdNamespace;
+import org.eclipse.edc.junit.annotations.ApiTest;
+import org.eclipse.edc.participantcontext.spi.service.ParticipantContextService;
+import org.eclipse.edc.participantcontext.spi.types.ParticipantContext;
+import org.eclipse.edc.protocol.dsp.catalog.http.api.controller.DspCatalogApiControllerTestBase;
+import org.eclipse.edc.spi.result.ServiceResult;
+
+import static org.eclipse.edc.protocol.dsp.catalog.http.api.CatalogApiPaths.BASE_PATH;
+import static org.eclipse.edc.protocol.dsp.spi.type.Dsp2025Constants.DATASPACE_PROTOCOL_HTTP_V_2025_1;
+import static org.eclipse.edc.protocol.dsp.spi.type.Dsp2025Constants.DSP_NAMESPACE_V_2025_1;
+import static org.eclipse.edc.protocol.dsp.spi.type.Dsp2025Constants.V_2025_1_PATH;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+@ApiTest
+public class DspCatalogApiControllerV20251Test extends DspCatalogApiControllerTestBase {
+
+    private final ParticipantContextService participantContextService = mock();
+    private final ParticipantContext participantContext = new ParticipantContext("participantContextId");
+
+
+    void beforeAll() {
+        when(participantContextService.getParticipantContext(participantContext.getParticipantContextId()))
+                .thenReturn(ServiceResult.success(participantContext));
+    }
+
+    @Override
+    protected String basePath() {
+        return V_2025_1_PATH + "/%s".formatted(participantContext.getParticipantContextId()) + BASE_PATH;
+    }
+
+    @Override
+    protected JsonLdNamespace namespace() {
+        return DSP_NAMESPACE_V_2025_1;
+    }
+
+    @Override
+    protected Object controller() {
+        return new DspCatalogApiController20251(service, participantContextService, dspRequestHandler, continuationTokenManager, DATASPACE_PROTOCOL_HTTP_V_2025_1, DSP_NAMESPACE_V_2025_1);
+    }
+}

--- a/data-protocols/dsp/dsp-2025/dsp-negotiation-2025/build.gradle.kts
+++ b/data-protocols/dsp/dsp-2025/dsp-negotiation-2025/build.gradle.kts
@@ -1,0 +1,22 @@
+/*
+ *  Copyright (c) 2025 Metaform Systems, Inc.
+ *
+ *  This program and the accompanying materials are made available under the
+ *  terms of the Apache License, Version 2.0 which is available at
+ *  https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Contributors:
+ *       Metaform Systems, Inc. - initial API and implementation
+ *
+ */
+
+plugins {
+    `java-library`
+}
+
+dependencies {
+    api(project(":data-protocols:dsp:dsp-2025:dsp-negotiation-2025:dsp-negotiation-http-api-2025"))
+    api(libs.edc.core.dsp.negotiation.transform.v2025)
+}

--- a/data-protocols/dsp/dsp-2025/dsp-negotiation-2025/dsp-negotiation-http-api-2025/build.gradle.kts
+++ b/data-protocols/dsp/dsp-2025/dsp-negotiation-2025/dsp-negotiation-http-api-2025/build.gradle.kts
@@ -1,0 +1,35 @@
+/*
+ *  Copyright (c) 2025 Metaform Systems, Inc.
+ *
+ *  This program and the accompanying materials are made available under the
+ *  terms of the Apache License, Version 2.0 which is available at
+ *  https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Contributors:
+ *       Metaform Systems, Inc. - initial API and implementation
+ *
+ */
+
+plugins {
+    `java-library`
+}
+
+dependencies {
+    api(libs.edc.spi.core)
+    api(libs.edc.spi.jsonld)
+    api(libs.edc.spi.web)
+    api(libs.edc.spi.dsp)
+    api(libs.edc.spi.dsp.v2025)
+    api(libs.edc.spi.dsp.http)
+
+    implementation(libs.edc.lib.jersey.providers)
+    implementation(libs.edc.lib.dsp.negotiation.validation)
+    implementation(libs.edc.lib.dsp.negotiation.http)
+
+    testImplementation(testFixtures(libs.edc.core.jersey))
+
+    testImplementation(testFixtures(libs.edc.lib.dsp.negotiation.http));
+
+}

--- a/data-protocols/dsp/dsp-2025/dsp-negotiation-2025/dsp-negotiation-http-api-2025/src/main/java/org/eclipse/edc/virtual/protocol/dsp/negotiation/http/api/v2025/DspNegotiationApi2025Extension.java
+++ b/data-protocols/dsp/dsp-2025/dsp-negotiation-2025/dsp-negotiation-http-api-2025/src/main/java/org/eclipse/edc/virtual/protocol/dsp/negotiation/http/api/v2025/DspNegotiationApi2025Extension.java
@@ -1,0 +1,100 @@
+/*
+ *  Copyright (c) 2025 Metaform Systems, Inc.
+ *
+ *  This program and the accompanying materials are made available under the
+ *  terms of the Apache License, Version 2.0 which is available at
+ *  https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Contributors:
+ *       Metaform Systems, Inc. - initial API and implementation
+ *
+ */
+
+package org.eclipse.edc.virtual.protocol.dsp.negotiation.http.api.v2025;
+
+import org.eclipse.edc.connector.controlplane.services.spi.contractnegotiation.ContractNegotiationProtocolService;
+import org.eclipse.edc.jsonld.spi.JsonLd;
+import org.eclipse.edc.participantcontext.spi.service.ParticipantContextService;
+import org.eclipse.edc.protocol.dsp.http.spi.message.DspRequestHandler;
+import org.eclipse.edc.protocol.dsp.negotiation.validation.ContractAgreementMessageValidator;
+import org.eclipse.edc.protocol.dsp.negotiation.validation.ContractAgreementVerificationMessageValidator;
+import org.eclipse.edc.protocol.dsp.negotiation.validation.ContractNegotiationEventMessageValidator;
+import org.eclipse.edc.protocol.dsp.negotiation.validation.ContractNegotiationTerminationMessageValidator;
+import org.eclipse.edc.protocol.dsp.negotiation.validation.ContractOfferMessageValidator;
+import org.eclipse.edc.protocol.dsp.negotiation.validation.ContractRequestMessageValidator;
+import org.eclipse.edc.protocol.spi.DataspaceProfileContextRegistry;
+import org.eclipse.edc.runtime.metamodel.annotation.Extension;
+import org.eclipse.edc.runtime.metamodel.annotation.Inject;
+import org.eclipse.edc.spi.system.ServiceExtension;
+import org.eclipse.edc.spi.system.ServiceExtensionContext;
+import org.eclipse.edc.spi.types.TypeManager;
+import org.eclipse.edc.validator.spi.JsonObjectValidatorRegistry;
+import org.eclipse.edc.virtual.protocol.dsp.negotiation.http.api.v2025.controller.DspNegotiationApiController20251;
+import org.eclipse.edc.web.jersey.providers.jsonld.JerseyJsonLdInterceptor;
+import org.eclipse.edc.web.spi.WebService;
+import org.eclipse.edc.web.spi.configuration.ApiContext;
+
+import static org.eclipse.edc.protocol.dsp.spi.type.Dsp2025Constants.DATASPACE_PROTOCOL_HTTP_V_2025_1;
+import static org.eclipse.edc.protocol.dsp.spi.type.Dsp2025Constants.DSP_NAMESPACE_V_2025_1;
+import static org.eclipse.edc.protocol.dsp.spi.type.Dsp2025Constants.DSP_SCOPE_V_2025_1;
+import static org.eclipse.edc.protocol.dsp.spi.type.DspNegotiationPropertyAndTypeNames.DSPACE_TYPE_CONTRACT_AGREEMENT_MESSAGE_TERM;
+import static org.eclipse.edc.protocol.dsp.spi.type.DspNegotiationPropertyAndTypeNames.DSPACE_TYPE_CONTRACT_AGREEMENT_VERIFICATION_MESSAGE_TERM;
+import static org.eclipse.edc.protocol.dsp.spi.type.DspNegotiationPropertyAndTypeNames.DSPACE_TYPE_CONTRACT_NEGOTIATION_EVENT_MESSAGE_TERM;
+import static org.eclipse.edc.protocol.dsp.spi.type.DspNegotiationPropertyAndTypeNames.DSPACE_TYPE_CONTRACT_NEGOTIATION_TERMINATION_MESSAGE_TERM;
+import static org.eclipse.edc.protocol.dsp.spi.type.DspNegotiationPropertyAndTypeNames.DSPACE_TYPE_CONTRACT_OFFER_MESSAGE_TERM;
+import static org.eclipse.edc.protocol.dsp.spi.type.DspNegotiationPropertyAndTypeNames.DSPACE_TYPE_CONTRACT_REQUEST_MESSAGE_TERM;
+import static org.eclipse.edc.spi.constants.CoreConstants.JSON_LD;
+
+/**
+ * Creates and registers the controller for dataspace protocol v2025/1 negotiation requests.
+ */
+@Extension(value = DspNegotiationApi2025Extension.NAME)
+public class DspNegotiationApi2025Extension implements ServiceExtension {
+
+    public static final String NAME = "Dataspace Protocol Negotiation Api v2025/1";
+
+    @Inject
+    private WebService webService;
+    @Inject
+    private ContractNegotiationProtocolService protocolService;
+    @Inject
+    private JsonObjectValidatorRegistry validatorRegistry;
+    @Inject
+    private DspRequestHandler dspRequestHandler;
+    @Inject
+    private DataspaceProfileContextRegistry versionRegistry;
+
+    @Inject
+    private JsonLd jsonLd;
+
+    @Inject
+    private TypeManager typeManager;
+
+    @Inject
+    private ParticipantContextService participantContextService;
+
+    @Override
+    public String name() {
+        return NAME;
+    }
+
+    @Override
+    public void initialize(ServiceExtensionContext context) {
+        registerValidators();
+
+        webService.registerResource(ApiContext.PROTOCOL, new DspNegotiationApiController20251(protocolService, participantContextService, dspRequestHandler, DATASPACE_PROTOCOL_HTTP_V_2025_1, DSP_NAMESPACE_V_2025_1));
+        webService.registerDynamicResource(ApiContext.PROTOCOL, DspNegotiationApiController20251.class, new JerseyJsonLdInterceptor(jsonLd, typeManager, JSON_LD, DSP_SCOPE_V_2025_1));
+    }
+
+
+    private void registerValidators() {
+        validatorRegistry.register(DSP_NAMESPACE_V_2025_1.toIri(DSPACE_TYPE_CONTRACT_REQUEST_MESSAGE_TERM), ContractRequestMessageValidator.instance(DSP_NAMESPACE_V_2025_1, false));
+        validatorRegistry.register(DSP_NAMESPACE_V_2025_1.toIri(DSPACE_TYPE_CONTRACT_OFFER_MESSAGE_TERM), ContractOfferMessageValidator.instance(DSP_NAMESPACE_V_2025_1, false));
+        validatorRegistry.register(DSP_NAMESPACE_V_2025_1.toIri(DSPACE_TYPE_CONTRACT_NEGOTIATION_EVENT_MESSAGE_TERM), ContractNegotiationEventMessageValidator.instance(DSP_NAMESPACE_V_2025_1));
+        validatorRegistry.register(DSP_NAMESPACE_V_2025_1.toIri(DSPACE_TYPE_CONTRACT_AGREEMENT_MESSAGE_TERM), ContractAgreementMessageValidator.instance(DSP_NAMESPACE_V_2025_1));
+        validatorRegistry.register(DSP_NAMESPACE_V_2025_1.toIri(DSPACE_TYPE_CONTRACT_AGREEMENT_VERIFICATION_MESSAGE_TERM), ContractAgreementVerificationMessageValidator.instance(DSP_NAMESPACE_V_2025_1));
+        validatorRegistry.register(DSP_NAMESPACE_V_2025_1.toIri(DSPACE_TYPE_CONTRACT_NEGOTIATION_TERMINATION_MESSAGE_TERM), ContractNegotiationTerminationMessageValidator.instance(DSP_NAMESPACE_V_2025_1));
+    }
+}

--- a/data-protocols/dsp/dsp-2025/dsp-negotiation-2025/dsp-negotiation-http-api-2025/src/main/java/org/eclipse/edc/virtual/protocol/dsp/negotiation/http/api/v2025/controller/DspNegotiationApiController20251.java
+++ b/data-protocols/dsp/dsp-2025/dsp-negotiation-2025/dsp-negotiation-http-api-2025/src/main/java/org/eclipse/edc/virtual/protocol/dsp/negotiation/http/api/v2025/controller/DspNegotiationApiController20251.java
@@ -1,0 +1,319 @@
+/*
+ *  Copyright (c) 2025 Metaform Systems, Inc.
+ *
+ *  This program and the accompanying materials are made available under the
+ *  terms of the Apache License, Version 2.0 which is available at
+ *  https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Contributors:
+ *       Metaform Systems, Inc. - initial API and implementation
+ *
+ */
+
+package org.eclipse.edc.virtual.protocol.dsp.negotiation.http.api.v2025.controller;
+
+import jakarta.json.JsonObject;
+import jakarta.ws.rs.Consumes;
+import jakarta.ws.rs.GET;
+import jakarta.ws.rs.HeaderParam;
+import jakarta.ws.rs.POST;
+import jakarta.ws.rs.Path;
+import jakarta.ws.rs.PathParam;
+import jakarta.ws.rs.Produces;
+import jakarta.ws.rs.core.MediaType;
+import jakarta.ws.rs.core.Response;
+import org.eclipse.edc.connector.controlplane.contract.spi.types.agreement.ContractAgreementMessage;
+import org.eclipse.edc.connector.controlplane.contract.spi.types.agreement.ContractAgreementVerificationMessage;
+import org.eclipse.edc.connector.controlplane.contract.spi.types.agreement.ContractNegotiationEventMessage;
+import org.eclipse.edc.connector.controlplane.contract.spi.types.negotiation.ContractNegotiation;
+import org.eclipse.edc.connector.controlplane.contract.spi.types.negotiation.ContractNegotiationError;
+import org.eclipse.edc.connector.controlplane.contract.spi.types.negotiation.ContractNegotiationTerminationMessage;
+import org.eclipse.edc.connector.controlplane.contract.spi.types.negotiation.ContractOfferMessage;
+import org.eclipse.edc.connector.controlplane.contract.spi.types.negotiation.ContractRequestMessage;
+import org.eclipse.edc.connector.controlplane.services.spi.contractnegotiation.ContractNegotiationProtocolService;
+import org.eclipse.edc.jsonld.spi.JsonLdNamespace;
+import org.eclipse.edc.participantcontext.spi.service.ParticipantContextService;
+import org.eclipse.edc.participantcontext.spi.service.ParticipantContextSupplier;
+import org.eclipse.edc.protocol.dsp.http.spi.message.DspRequestHandler;
+import org.eclipse.edc.protocol.dsp.http.spi.message.GetDspRequest;
+import org.eclipse.edc.protocol.dsp.http.spi.message.PostDspRequest;
+
+import static jakarta.ws.rs.core.HttpHeaders.AUTHORIZATION;
+import static org.eclipse.edc.protocol.dsp.negotiation.http.api.NegotiationApiPaths.AGREEMENT;
+import static org.eclipse.edc.protocol.dsp.negotiation.http.api.NegotiationApiPaths.BASE_PATH;
+import static org.eclipse.edc.protocol.dsp.negotiation.http.api.NegotiationApiPaths.CONTRACT_OFFERS;
+import static org.eclipse.edc.protocol.dsp.negotiation.http.api.NegotiationApiPaths.CONTRACT_REQUEST;
+import static org.eclipse.edc.protocol.dsp.negotiation.http.api.NegotiationApiPaths.EVENT;
+import static org.eclipse.edc.protocol.dsp.negotiation.http.api.NegotiationApiPaths.INITIAL_CONTRACT_OFFERS;
+import static org.eclipse.edc.protocol.dsp.negotiation.http.api.NegotiationApiPaths.INITIAL_CONTRACT_REQUEST;
+import static org.eclipse.edc.protocol.dsp.negotiation.http.api.NegotiationApiPaths.TERMINATION;
+import static org.eclipse.edc.protocol.dsp.negotiation.http.api.NegotiationApiPaths.VERIFICATION;
+import static org.eclipse.edc.protocol.dsp.spi.type.Dsp2025Constants.V_2025_1_PATH;
+import static org.eclipse.edc.protocol.dsp.spi.type.DspNegotiationPropertyAndTypeNames.DSPACE_TYPE_CONTRACT_AGREEMENT_MESSAGE_TERM;
+import static org.eclipse.edc.protocol.dsp.spi.type.DspNegotiationPropertyAndTypeNames.DSPACE_TYPE_CONTRACT_AGREEMENT_VERIFICATION_MESSAGE_TERM;
+import static org.eclipse.edc.protocol.dsp.spi.type.DspNegotiationPropertyAndTypeNames.DSPACE_TYPE_CONTRACT_NEGOTIATION_EVENT_MESSAGE_TERM;
+import static org.eclipse.edc.protocol.dsp.spi.type.DspNegotiationPropertyAndTypeNames.DSPACE_TYPE_CONTRACT_NEGOTIATION_TERMINATION_MESSAGE_TERM;
+import static org.eclipse.edc.protocol.dsp.spi.type.DspNegotiationPropertyAndTypeNames.DSPACE_TYPE_CONTRACT_OFFER_MESSAGE_TERM;
+import static org.eclipse.edc.protocol.dsp.spi.type.DspNegotiationPropertyAndTypeNames.DSPACE_TYPE_CONTRACT_REQUEST_MESSAGE_TERM;
+
+/**
+ * Versioned Negotiation endpoint for 2025/1 protocol version
+ */
+@Consumes({MediaType.APPLICATION_JSON})
+@Produces({MediaType.APPLICATION_JSON})
+@Path(V_2025_1_PATH + "/{participantContextId}" + BASE_PATH)
+public class DspNegotiationApiController20251 {
+
+    private final ContractNegotiationProtocolService protocolService;
+    private final ParticipantContextService participantContextService;
+    private final DspRequestHandler dspRequestHandler;
+    private final String protocol;
+    private final JsonLdNamespace namespace;
+
+    public DspNegotiationApiController20251(ContractNegotiationProtocolService protocolService, ParticipantContextService participantContextService, DspRequestHandler dspRequestHandler,
+                                            String protocol, JsonLdNamespace namespace) {
+        this.protocolService = protocolService;
+        this.participantContextService = participantContextService;
+        this.dspRequestHandler = dspRequestHandler;
+        this.protocol = protocol;
+        this.namespace = namespace;
+    }
+
+    /**
+     * Consumer-specific endpoint.
+     *
+     * @param id    of contract negotiation.
+     * @param body  dspace:ContractOfferMessage sent by a provider.
+     * @param token identity token.
+     * @return empty response or error.
+     */
+    @POST
+    @Path("{id}" + CONTRACT_OFFERS)
+    public Response providerOffer(@PathParam("participantContextId") String participantContextId, @PathParam("id") String id, JsonObject body, @HeaderParam(AUTHORIZATION) String token) {
+        var request = PostDspRequest.Builder.newInstance(ContractOfferMessage.class, ContractNegotiation.class, ContractNegotiationError.class)
+                .expectedMessageType(namespace.toIri(DSPACE_TYPE_CONTRACT_OFFER_MESSAGE_TERM))
+                .processId(id)
+                .message(body)
+                .token(token)
+                .serviceCall(protocolService::notifyOffered)
+                .errorProvider(ContractNegotiationError.Builder::newInstance)
+                .protocol(protocol)
+                .participantContextProvider(participantContextSupplier(participantContextId))
+                .build();
+
+        return dspRequestHandler.updateResource(request);
+    }
+
+    /**
+     * Consumer-specific endpoint.
+     *
+     * @param jsonObject dspace:ContractOfferMessage sent by a consumer.
+     * @param token      identity token.
+     * @return the created contract negotiation or an error.
+     */
+    @POST
+    @Path(INITIAL_CONTRACT_OFFERS)
+    public Response initialContractOffer(@PathParam("participantContextId") String participantContextId, JsonObject jsonObject, @HeaderParam(AUTHORIZATION) String token) {
+        var request = PostDspRequest.Builder.newInstance(ContractOfferMessage.class, ContractNegotiation.class, ContractNegotiationError.class)
+                .expectedMessageType(namespace.toIri(DSPACE_TYPE_CONTRACT_OFFER_MESSAGE_TERM))
+                .message(jsonObject)
+                .token(token)
+                .serviceCall(protocolService::notifyOffered)
+                .errorProvider(ContractNegotiationError.Builder::newInstance)
+                .protocol(protocol)
+                .participantContextProvider(participantContextSupplier(participantContextId))
+                .build();
+
+        return dspRequestHandler.createResource(request);
+    }
+
+    /**
+     * Provider-specific endpoint.
+     *
+     * @param id    of contract negotiation.
+     * @param token identity token.
+     * @return the requested contract negotiation or an error.
+     */
+    @GET
+    @Path("{id}")
+    public Response getNegotiation(@PathParam("participantContextId") String participantContextId, @PathParam("id") String id, @HeaderParam(AUTHORIZATION) String token) {
+        var request = GetDspRequest.Builder.newInstance(ContractNegotiation.class, ContractNegotiationError.class)
+                .id(id)
+                .token(token)
+                .serviceCall((ctx, cnId, tr) -> protocolService.findById(ctx, cnId, tr, protocol))
+                .errorProvider(ContractNegotiationError.Builder::newInstance)
+                .protocol(protocol)
+                .participantContextProvider(participantContextSupplier(participantContextId))
+                .build();
+
+        return dspRequestHandler.getResource(request);
+    }
+
+    /**
+     * Provider-specific endpoint.
+     *
+     * @param jsonObject dspace:ContractRequestMessage sent by a consumer.
+     * @param token      identity token.
+     * @return the created contract negotiation or an error.
+     */
+    @POST
+    @Path(INITIAL_CONTRACT_REQUEST)
+    public Response initialContractRequest(@PathParam("participantContextId") String participantContextId, JsonObject jsonObject, @HeaderParam(AUTHORIZATION) String token) {
+        var request = PostDspRequest.Builder.newInstance(ContractRequestMessage.class, ContractNegotiation.class, ContractNegotiationError.class)
+                .expectedMessageType(namespace.toIri(DSPACE_TYPE_CONTRACT_REQUEST_MESSAGE_TERM))
+                .message(jsonObject)
+                .token(token)
+                .serviceCall(protocolService::notifyRequested)
+                .errorProvider(ContractNegotiationError.Builder::newInstance)
+                .protocol(protocol)
+                .participantContextProvider(participantContextSupplier(participantContextId))
+                .build();
+
+        return dspRequestHandler.createResource(request);
+    }
+
+    /**
+     * Provider-specific endpoint.
+     *
+     * @param id         of contract negotiation.
+     * @param jsonObject dspace:ContractRequestMessage sent by a consumer.
+     * @param token      identity token.
+     * @return the created contract negotiation or an error.
+     */
+    @POST
+    @Path("{id}" + CONTRACT_REQUEST)
+    public Response contractRequest(@PathParam("participantContextId") String participantContextId, @PathParam("id") String id,
+                                    JsonObject jsonObject,
+                                    @HeaderParam(AUTHORIZATION) String token) {
+        var request = PostDspRequest.Builder.newInstance(ContractRequestMessage.class, ContractNegotiation.class, ContractNegotiationError.class)
+                .expectedMessageType(namespace.toIri(DSPACE_TYPE_CONTRACT_REQUEST_MESSAGE_TERM))
+                .processId(id)
+                .message(jsonObject)
+                .token(token)
+                .serviceCall(protocolService::notifyRequested)
+                .errorProvider(ContractNegotiationError.Builder::newInstance)
+                .protocol(protocol)
+                .participantContextProvider(participantContextSupplier(participantContextId))
+                .build();
+
+        return dspRequestHandler.updateResource(request);
+    }
+
+    /**
+     * Endpoint on provider and consumer side.
+     *
+     * @param id         of contract negotiation.
+     * @param jsonObject dspace:ContractNegotiationEventMessage sent by consumer or provider.
+     * @param token      identity token.
+     * @return empty response or error.
+     */
+    @POST
+    @Path("{id}" + EVENT)
+    public Response createEvent(@PathParam("participantContextId") String participantContextId, @PathParam("id") String id,
+                                JsonObject jsonObject,
+                                @HeaderParam(AUTHORIZATION) String token) {
+        var request = PostDspRequest.Builder.newInstance(ContractNegotiationEventMessage.class, ContractNegotiation.class, ContractNegotiationError.class)
+                .expectedMessageType(namespace.toIri(DSPACE_TYPE_CONTRACT_NEGOTIATION_EVENT_MESSAGE_TERM))
+                .processId(id)
+                .message(jsonObject)
+                .token(token)
+                .serviceCall((ctx, message, claimToken) -> switch (message.getType()) {
+                    case FINALIZED -> protocolService.notifyFinalized(ctx, message, claimToken);
+                    case ACCEPTED -> protocolService.notifyAccepted(ctx, message, claimToken);
+                })
+                .errorProvider(ContractNegotiationError.Builder::newInstance)
+                .protocol(protocol)
+                .participantContextProvider(participantContextSupplier(participantContextId))
+                .build();
+
+        return dspRequestHandler.updateResource(request);
+    }
+
+    /**
+     * Provider-specific endpoint.
+     *
+     * @param id         of contract negotiation.
+     * @param jsonObject dspace:ContractAgreementVerificationMessage sent by a consumer.
+     * @param token      identity token.
+     * @return empty response or error.
+     */
+    @POST
+    @Path("{id}" + AGREEMENT + VERIFICATION)
+    public Response verifyAgreement(@PathParam("participantContextId") String participantContextId, @PathParam("id") String id,
+                                    JsonObject jsonObject,
+                                    @HeaderParam(AUTHORIZATION) String token) {
+        var request = PostDspRequest.Builder.newInstance(ContractAgreementVerificationMessage.class, ContractNegotiation.class, ContractNegotiationError.class)
+                .expectedMessageType(namespace.toIri(DSPACE_TYPE_CONTRACT_AGREEMENT_VERIFICATION_MESSAGE_TERM))
+                .processId(id)
+                .message(jsonObject)
+                .token(token)
+                .serviceCall(protocolService::notifyVerified)
+                .errorProvider(ContractNegotiationError.Builder::newInstance)
+                .protocol(protocol)
+                .participantContextProvider(participantContextSupplier(participantContextId))
+                .build();
+
+        return dspRequestHandler.updateResource(request);
+    }
+
+    /**
+     * Endpoint on provider and consumer side.
+     *
+     * @param id         of contract negotiation.
+     * @param jsonObject dspace:ContractNegotiationTerminationMessage sent by consumer or provider.
+     * @param token      identity token.
+     * @return empty response or error.
+     */
+    @POST
+    @Path("{id}" + TERMINATION)
+    public Response terminateNegotiation(@PathParam("participantContextId") String participantContextId, @PathParam("id") String id,
+                                         JsonObject jsonObject,
+                                         @HeaderParam(AUTHORIZATION) String token) {
+        var request = PostDspRequest.Builder.newInstance(ContractNegotiationTerminationMessage.class, ContractNegotiation.class, ContractNegotiationError.class)
+                .expectedMessageType(namespace.toIri(DSPACE_TYPE_CONTRACT_NEGOTIATION_TERMINATION_MESSAGE_TERM))
+                .processId(id)
+                .message(jsonObject)
+                .token(token)
+                .serviceCall(protocolService::notifyTerminated)
+                .errorProvider(ContractNegotiationError.Builder::newInstance)
+                .protocol(protocol)
+                .participantContextProvider(participantContextSupplier(participantContextId))
+                .build();
+
+        return dspRequestHandler.updateResource(request);
+    }
+
+    /**
+     * Consumer-specific endpoint.
+     *
+     * @param id         of contract negotiation.
+     * @param jsonObject dspace:ContractAgreementMessage sent by a provider.
+     * @param token      identity token.
+     * @return empty response or error.
+     */
+    @POST
+    @Path("{id}" + AGREEMENT)
+    public Response createAgreement(@PathParam("participantContextId") String participantContextId, @PathParam("id") String id,
+                                    JsonObject jsonObject,
+                                    @HeaderParam(AUTHORIZATION) String token) {
+        var request = PostDspRequest.Builder.newInstance(ContractAgreementMessage.class, ContractNegotiation.class, ContractNegotiationError.class)
+                .expectedMessageType(namespace.toIri(DSPACE_TYPE_CONTRACT_AGREEMENT_MESSAGE_TERM))
+                .processId(id)
+                .message(jsonObject)
+                .token(token)
+                .serviceCall(protocolService::notifyAgreed)
+                .errorProvider(ContractNegotiationError.Builder::newInstance)
+                .protocol(protocol)
+                .participantContextProvider(participantContextSupplier(participantContextId))
+                .build();
+
+        return dspRequestHandler.updateResource(request);
+    }
+
+    // TODO refactor upstream to use ServiceResult
+    private ParticipantContextSupplier participantContextSupplier(String id) {
+        return () -> participantContextService.getParticipantContext(id).getContent();
+    }
+}

--- a/data-protocols/dsp/dsp-2025/dsp-negotiation-2025/dsp-negotiation-http-api-2025/src/main/resources/META-INF/services/org.eclipse.edc.spi.system.ServiceExtension
+++ b/data-protocols/dsp/dsp-2025/dsp-negotiation-2025/dsp-negotiation-http-api-2025/src/main/resources/META-INF/services/org.eclipse.edc.spi.system.ServiceExtension
@@ -1,0 +1,15 @@
+#
+#  Copyright (c) 2025 Metaform Systems, Inc.
+#
+#  This program and the accompanying materials are made available under the
+#  terms of the Apache License, Version 2.0 which is available at
+#  https://www.apache.org/licenses/LICENSE-2.0
+#
+#  SPDX-License-Identifier: Apache-2.0
+#
+#  Contributors:
+#       Metaform Systems, Inc. - initial API and implementation
+#
+#
+
+org.eclipse.edc.virtual.protocol.dsp.negotiation.http.api.v2025.DspNegotiationApi2025Extension

--- a/data-protocols/dsp/dsp-2025/dsp-negotiation-2025/dsp-negotiation-http-api-2025/src/test/java/org/eclipse/edc/virtual/protocol/dsp/negotiation/http/api/v2025/controller/DspNegotiationApiControllerV20251Test.java
+++ b/data-protocols/dsp/dsp-2025/dsp-negotiation-2025/dsp-negotiation-http-api-2025/src/test/java/org/eclipse/edc/virtual/protocol/dsp/negotiation/http/api/v2025/controller/DspNegotiationApiControllerV20251Test.java
@@ -1,0 +1,69 @@
+/*
+ *  Copyright (c) 2025 Metaform Systems, Inc.
+ *
+ *  This program and the accompanying materials are made available under the
+ *  terms of the Apache License, Version 2.0 which is available at
+ *  https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Contributors:
+ *       Metaform Systems, Inc. - initial API and implementation
+ *
+ */
+
+package org.eclipse.edc.virtual.protocol.dsp.negotiation.http.api.v2025.controller;
+
+import org.eclipse.edc.jsonld.spi.JsonLdNamespace;
+import org.eclipse.edc.junit.annotations.ApiTest;
+import org.eclipse.edc.participantcontext.spi.service.ParticipantContextService;
+import org.eclipse.edc.participantcontext.spi.types.ParticipantContext;
+import org.eclipse.edc.protocol.dsp.negotiation.http.api.controller.DspNegotiationApiControllerTestBase;
+import org.eclipse.edc.spi.result.ServiceResult;
+
+import static org.eclipse.edc.protocol.dsp.negotiation.http.api.NegotiationApiPaths.BASE_PATH;
+import static org.eclipse.edc.protocol.dsp.negotiation.http.api.NegotiationApiPaths.CONTRACT_OFFERS;
+import static org.eclipse.edc.protocol.dsp.negotiation.http.api.NegotiationApiPaths.INITIAL_CONTRACT_OFFERS;
+import static org.eclipse.edc.protocol.dsp.spi.type.Dsp2025Constants.DATASPACE_PROTOCOL_HTTP_V_2025_1;
+import static org.eclipse.edc.protocol.dsp.spi.type.Dsp2025Constants.DSP_NAMESPACE_V_2025_1;
+import static org.eclipse.edc.protocol.dsp.spi.type.Dsp2025Constants.V_2025_1_PATH;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+@ApiTest
+class DspNegotiationApiControllerV20251Test extends DspNegotiationApiControllerTestBase {
+
+    private final ParticipantContextService participantContextService = mock();
+    private final ParticipantContext participantContext = new ParticipantContext("participantContextId");
+
+
+    void beforeAll() {
+        when(participantContextService.getParticipantContext(participantContext.getParticipantContextId()))
+                .thenReturn(ServiceResult.success(participantContext));
+    }
+
+    @Override
+    protected String basePath() {
+        return V_2025_1_PATH + "/%s".formatted(participantContext.getParticipantContextId()) + BASE_PATH;
+    }
+
+    @Override
+    protected JsonLdNamespace namespace() {
+        return DSP_NAMESPACE_V_2025_1;
+    }
+
+    @Override
+    protected Object controller() {
+        return new DspNegotiationApiController20251(protocolService, participantContextService, dspRequestHandler, DATASPACE_PROTOCOL_HTTP_V_2025_1, DSP_NAMESPACE_V_2025_1);
+    }
+
+    @Override
+    protected String initialOffersPath() {
+        return INITIAL_CONTRACT_OFFERS;
+    }
+
+    @Override
+    protected String offersPath() {
+        return CONTRACT_OFFERS;
+    }
+}

--- a/data-protocols/dsp/dsp-2025/dsp-transfer-process-2025/build.gradle.kts
+++ b/data-protocols/dsp/dsp-2025/dsp-transfer-process-2025/build.gradle.kts
@@ -1,0 +1,22 @@
+/*
+ *  Copyright (c) 2025 Metaform Systems, Inc.
+ *
+ *  This program and the accompanying materials are made available under the
+ *  terms of the Apache License, Version 2.0 which is available at
+ *  https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Contributors:
+ *       Metaform Systems, Inc. - initial API and implementation
+ *
+ */
+
+plugins {
+    `java-library`
+}
+
+dependencies {
+    api(project(":data-protocols:dsp:dsp-2025:dsp-transfer-process-2025:dsp-transfer-process-http-api-2025"))
+    api(libs.edc.core.dsp.transferprocess.transform.v2025)
+}

--- a/data-protocols/dsp/dsp-2025/dsp-transfer-process-2025/dsp-transfer-process-http-api-2025/build.gradle.kts
+++ b/data-protocols/dsp/dsp-2025/dsp-transfer-process-2025/dsp-transfer-process-http-api-2025/build.gradle.kts
@@ -1,0 +1,35 @@
+/*
+ *  Copyright (c) 2025 Metaform Systems, Inc.
+ *
+ *  This program and the accompanying materials are made available under the
+ *  terms of the Apache License, Version 2.0 which is available at
+ *  https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Contributors:
+ *       Metaform Systems, Inc. - initial API and implementation
+ *
+ */
+
+plugins {
+    `java-library`
+}
+
+dependencies {
+    api(libs.edc.spi.core)
+    api(libs.edc.spi.jsonld)
+    api(libs.edc.spi.web)
+    api(libs.edc.spi.dsp)
+    api(libs.edc.spi.dsp.v2025)
+    api(libs.edc.spi.dsp.http)
+
+    implementation(libs.edc.lib.jersey.providers)
+    implementation(libs.edc.lib.dsp.transferprocess.validation)
+    implementation(libs.edc.lib.dsp.transferprocess.http)
+
+    testImplementation(testFixtures(libs.edc.core.jersey))
+
+    testImplementation(testFixtures(libs.edc.lib.dsp.transferprocess.http));
+
+}

--- a/data-protocols/dsp/dsp-2025/dsp-transfer-process-2025/dsp-transfer-process-http-api-2025/src/main/java/org/eclipse/edc/virtual/protocol/dsp/transferprocess/http/api/v2025/DspTransferProcessApi2025Extension.java
+++ b/data-protocols/dsp/dsp-2025/dsp-transfer-process-2025/dsp-transfer-process-http-api-2025/src/main/java/org/eclipse/edc/virtual/protocol/dsp/transferprocess/http/api/v2025/DspTransferProcessApi2025Extension.java
@@ -1,0 +1,85 @@
+/*
+ *  Copyright (c) 2025 Metaform Systems, Inc.
+ *
+ *  This program and the accompanying materials are made available under the
+ *  terms of the Apache License, Version 2.0 which is available at
+ *  https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Contributors:
+ *       Metaform Systems, Inc. - initial API and implementation
+ *
+ */
+
+package org.eclipse.edc.virtual.protocol.dsp.transferprocess.http.api.v2025;
+
+import org.eclipse.edc.connector.controlplane.services.spi.transferprocess.TransferProcessProtocolService;
+import org.eclipse.edc.jsonld.spi.JsonLd;
+import org.eclipse.edc.participantcontext.spi.service.ParticipantContextService;
+import org.eclipse.edc.protocol.dsp.http.spi.message.DspRequestHandler;
+import org.eclipse.edc.protocol.dsp.transferprocess.validation.TransferCompletionMessageValidator;
+import org.eclipse.edc.protocol.dsp.transferprocess.validation.TransferRequestMessageValidator;
+import org.eclipse.edc.protocol.dsp.transferprocess.validation.TransferStartMessageValidator;
+import org.eclipse.edc.protocol.dsp.transferprocess.validation.TransferTerminationMessageValidator;
+import org.eclipse.edc.protocol.spi.DataspaceProfileContextRegistry;
+import org.eclipse.edc.runtime.metamodel.annotation.Extension;
+import org.eclipse.edc.runtime.metamodel.annotation.Inject;
+import org.eclipse.edc.spi.system.ServiceExtension;
+import org.eclipse.edc.spi.system.ServiceExtensionContext;
+import org.eclipse.edc.spi.types.TypeManager;
+import org.eclipse.edc.validator.spi.JsonObjectValidatorRegistry;
+import org.eclipse.edc.virtual.protocol.dsp.transferprocess.http.api.v2025.controller.DspTransferProcessApiController20251;
+import org.eclipse.edc.web.jersey.providers.jsonld.JerseyJsonLdInterceptor;
+import org.eclipse.edc.web.spi.WebService;
+import org.eclipse.edc.web.spi.configuration.ApiContext;
+
+import static org.eclipse.edc.protocol.dsp.spi.type.Dsp2025Constants.DATASPACE_PROTOCOL_HTTP_V_2025_1;
+import static org.eclipse.edc.protocol.dsp.spi.type.Dsp2025Constants.DSP_NAMESPACE_V_2025_1;
+import static org.eclipse.edc.protocol.dsp.spi.type.Dsp2025Constants.DSP_SCOPE_V_2025_1;
+import static org.eclipse.edc.protocol.dsp.spi.type.DspTransferProcessPropertyAndTypeNames.DSPACE_TYPE_TRANSFER_COMPLETION_MESSAGE_TERM;
+import static org.eclipse.edc.protocol.dsp.spi.type.DspTransferProcessPropertyAndTypeNames.DSPACE_TYPE_TRANSFER_REQUEST_MESSAGE_TERM;
+import static org.eclipse.edc.protocol.dsp.spi.type.DspTransferProcessPropertyAndTypeNames.DSPACE_TYPE_TRANSFER_START_MESSAGE_TERM;
+import static org.eclipse.edc.protocol.dsp.spi.type.DspTransferProcessPropertyAndTypeNames.DSPACE_TYPE_TRANSFER_TERMINATION_MESSAGE_TERM;
+import static org.eclipse.edc.spi.constants.CoreConstants.JSON_LD;
+
+/**
+ * Creates and registers the controller for dataspace protocol v2025/1 transfer process requests.
+ */
+@Extension(value = DspTransferProcessApi2025Extension.NAME)
+public class DspTransferProcessApi2025Extension implements ServiceExtension {
+
+    public static final String NAME = "Dataspace Protocol 2025/1: TransferProcess API Extension";
+    @Inject
+    private WebService webService;
+    @Inject
+    private TransferProcessProtocolService transferProcessProtocolService;
+    @Inject
+    private DspRequestHandler dspRequestHandler;
+    @Inject
+    private JsonObjectValidatorRegistry validatorRegistry;
+    @Inject
+    private DataspaceProfileContextRegistry versionRegistry;
+    @Inject
+    private JsonLd jsonLd;
+    @Inject
+    private TypeManager typeManager;
+
+    @Inject
+    private ParticipantContextService participantContextService;
+
+    @Override
+    public void initialize(ServiceExtensionContext context) {
+        registerValidators();
+
+        webService.registerResource(ApiContext.PROTOCOL, new DspTransferProcessApiController20251(transferProcessProtocolService, participantContextService, dspRequestHandler, DATASPACE_PROTOCOL_HTTP_V_2025_1, DSP_NAMESPACE_V_2025_1));
+        webService.registerDynamicResource(ApiContext.PROTOCOL, DspTransferProcessApiController20251.class, new JerseyJsonLdInterceptor(jsonLd, typeManager, JSON_LD, DSP_SCOPE_V_2025_1));
+    }
+
+    private void registerValidators() {
+        validatorRegistry.register(DSP_NAMESPACE_V_2025_1.toIri(DSPACE_TYPE_TRANSFER_REQUEST_MESSAGE_TERM), TransferRequestMessageValidator.instance(DSP_NAMESPACE_V_2025_1));
+        validatorRegistry.register(DSP_NAMESPACE_V_2025_1.toIri(DSPACE_TYPE_TRANSFER_START_MESSAGE_TERM), TransferStartMessageValidator.instance(DSP_NAMESPACE_V_2025_1));
+        validatorRegistry.register(DSP_NAMESPACE_V_2025_1.toIri(DSPACE_TYPE_TRANSFER_COMPLETION_MESSAGE_TERM), TransferCompletionMessageValidator.instance(DSP_NAMESPACE_V_2025_1));
+        validatorRegistry.register(DSP_NAMESPACE_V_2025_1.toIri(DSPACE_TYPE_TRANSFER_TERMINATION_MESSAGE_TERM), TransferTerminationMessageValidator.instance(DSP_NAMESPACE_V_2025_1));
+    }
+}

--- a/data-protocols/dsp/dsp-2025/dsp-transfer-process-2025/dsp-transfer-process-http-api-2025/src/main/java/org/eclipse/edc/virtual/protocol/dsp/transferprocess/http/api/v2025/controller/DspTransferProcessApiController20251.java
+++ b/data-protocols/dsp/dsp-2025/dsp-transfer-process-2025/dsp-transfer-process-http-api-2025/src/main/java/org/eclipse/edc/virtual/protocol/dsp/transferprocess/http/api/v2025/controller/DspTransferProcessApiController20251.java
@@ -1,0 +1,228 @@
+/*
+ *  Copyright (c) 2025 Metaform Systems, Inc.
+ *
+ *  This program and the accompanying materials are made available under the
+ *  terms of the Apache License, Version 2.0 which is available at
+ *  https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Contributors:
+ *       Metaform Systems, Inc. - initial API and implementation
+ *
+ */
+
+package org.eclipse.edc.virtual.protocol.dsp.transferprocess.http.api.v2025.controller;
+
+import jakarta.json.JsonObject;
+import jakarta.ws.rs.Consumes;
+import jakarta.ws.rs.GET;
+import jakarta.ws.rs.HeaderParam;
+import jakarta.ws.rs.POST;
+import jakarta.ws.rs.Path;
+import jakarta.ws.rs.PathParam;
+import jakarta.ws.rs.Produces;
+import jakarta.ws.rs.core.MediaType;
+import jakarta.ws.rs.core.Response;
+import org.eclipse.edc.connector.controlplane.services.spi.transferprocess.TransferProcessProtocolService;
+import org.eclipse.edc.connector.controlplane.transfer.spi.types.TransferProcess;
+import org.eclipse.edc.connector.controlplane.transfer.spi.types.protocol.TransferCompletionMessage;
+import org.eclipse.edc.connector.controlplane.transfer.spi.types.protocol.TransferError;
+import org.eclipse.edc.connector.controlplane.transfer.spi.types.protocol.TransferRequestMessage;
+import org.eclipse.edc.connector.controlplane.transfer.spi.types.protocol.TransferStartMessage;
+import org.eclipse.edc.connector.controlplane.transfer.spi.types.protocol.TransferSuspensionMessage;
+import org.eclipse.edc.connector.controlplane.transfer.spi.types.protocol.TransferTerminationMessage;
+import org.eclipse.edc.jsonld.spi.JsonLdNamespace;
+import org.eclipse.edc.participantcontext.spi.service.ParticipantContextService;
+import org.eclipse.edc.participantcontext.spi.service.ParticipantContextSupplier;
+import org.eclipse.edc.protocol.dsp.http.spi.message.DspRequestHandler;
+import org.eclipse.edc.protocol.dsp.http.spi.message.GetDspRequest;
+import org.eclipse.edc.protocol.dsp.http.spi.message.PostDspRequest;
+
+import static jakarta.ws.rs.core.HttpHeaders.AUTHORIZATION;
+import static org.eclipse.edc.protocol.dsp.spi.type.Dsp2025Constants.V_2025_1_PATH;
+import static org.eclipse.edc.protocol.dsp.spi.type.DspTransferProcessPropertyAndTypeNames.DSPACE_TYPE_TRANSFER_COMPLETION_MESSAGE_TERM;
+import static org.eclipse.edc.protocol.dsp.spi.type.DspTransferProcessPropertyAndTypeNames.DSPACE_TYPE_TRANSFER_REQUEST_MESSAGE_TERM;
+import static org.eclipse.edc.protocol.dsp.spi.type.DspTransferProcessPropertyAndTypeNames.DSPACE_TYPE_TRANSFER_START_MESSAGE_TERM;
+import static org.eclipse.edc.protocol.dsp.spi.type.DspTransferProcessPropertyAndTypeNames.DSPACE_TYPE_TRANSFER_SUSPENSION_MESSAGE_TERM;
+import static org.eclipse.edc.protocol.dsp.spi.type.DspTransferProcessPropertyAndTypeNames.DSPACE_TYPE_TRANSFER_TERMINATION_MESSAGE_TERM;
+import static org.eclipse.edc.protocol.dsp.transferprocess.http.api.TransferProcessApiPaths.BASE_PATH;
+import static org.eclipse.edc.protocol.dsp.transferprocess.http.api.TransferProcessApiPaths.TRANSFER_COMPLETION;
+import static org.eclipse.edc.protocol.dsp.transferprocess.http.api.TransferProcessApiPaths.TRANSFER_INITIAL_REQUEST;
+import static org.eclipse.edc.protocol.dsp.transferprocess.http.api.TransferProcessApiPaths.TRANSFER_START;
+import static org.eclipse.edc.protocol.dsp.transferprocess.http.api.TransferProcessApiPaths.TRANSFER_SUSPENSION;
+import static org.eclipse.edc.protocol.dsp.transferprocess.http.api.TransferProcessApiPaths.TRANSFER_TERMINATION;
+
+
+/**
+ * Versioned Transfer endpoint for 2025/1 protocol version
+ */
+@Consumes({MediaType.APPLICATION_JSON})
+@Produces({MediaType.APPLICATION_JSON})
+@Path(V_2025_1_PATH + "/{participantContextId}" + BASE_PATH)
+public class DspTransferProcessApiController20251 {
+
+    private final TransferProcessProtocolService protocolService;
+    private final ParticipantContextService participantContextService;
+    private final DspRequestHandler dspRequestHandler;
+    private final String protocol;
+    private final JsonLdNamespace namespace;
+
+    public DspTransferProcessApiController20251(TransferProcessProtocolService protocolService, ParticipantContextService participantContextService, DspRequestHandler dspRequestHandler, String protocol, JsonLdNamespace namespace) {
+        this.protocolService = protocolService;
+        this.participantContextService = participantContextService;
+        this.dspRequestHandler = dspRequestHandler;
+        this.protocol = protocol;
+        this.namespace = namespace;
+    }
+
+    /**
+     * Retrieves an existing transfer process. This functionality is not yet supported.
+     *
+     * @param id the ID of the process
+     * @return the requested transfer process or an error.
+     */
+    @GET
+    @Path("/{id}")
+    public Response getTransferProcess(@PathParam("participantContextId") String participantContextId, @PathParam("id") String id, @HeaderParam(AUTHORIZATION) String token) {
+        var request = GetDspRequest.Builder.newInstance(TransferProcess.class, TransferError.class)
+                .id(id)
+                .token(token)
+                .serviceCall((ctx, tpId, tr) -> protocolService.findById(ctx, tpId, tr, protocol))
+                .protocol(protocol)
+                .errorProvider(TransferError.Builder::newInstance)
+                .participantContextProvider(participantContextSupplier(participantContextId))
+                .build();
+
+        return dspRequestHandler.getResource(request);
+    }
+
+    /**
+     * Initiates a new transfer process that has been requested by the counter-party.
+     *
+     * @param jsonObject the {@link TransferRequestMessage} in JSON-LD expanded form
+     * @param token      the authorization header
+     * @return the created transfer process or an error.
+     */
+    @POST
+    @Path(TRANSFER_INITIAL_REQUEST)
+    public Response initiateTransferProcess(@PathParam("participantContextId") String participantContextId, JsonObject jsonObject, @HeaderParam(AUTHORIZATION) String token) {
+        var request = PostDspRequest.Builder.newInstance(TransferRequestMessage.class, TransferProcess.class, TransferError.class)
+                .message(jsonObject)
+                .token(token)
+                .expectedMessageType(namespace.toIri(DSPACE_TYPE_TRANSFER_REQUEST_MESSAGE_TERM))
+                .serviceCall(protocolService::notifyRequested)
+                .errorProvider(TransferError.Builder::newInstance)
+                .protocol(protocol)
+                .participantContextProvider(participantContextSupplier(participantContextId))
+                .build();
+
+        return dspRequestHandler.createResource(request);
+    }
+
+    /**
+     * Notifies the connector that a transfer process has been started by the counter-part.
+     *
+     * @param id         the ID of the process
+     * @param jsonObject the {@link TransferStartMessage} in JSON-LD expanded form
+     * @param token      the authorization header
+     * @return empty response or error.
+     */
+    @POST
+    @Path("{id}" + TRANSFER_START)
+    public Response transferProcessStart(@PathParam("participantContextId") String participantContextId, @PathParam("id") String id, JsonObject jsonObject, @HeaderParam(AUTHORIZATION) String token) {
+        var request = PostDspRequest.Builder.newInstance(TransferStartMessage.class, TransferProcess.class, TransferError.class)
+                .processId(id)
+                .expectedMessageType(namespace.toIri(DSPACE_TYPE_TRANSFER_START_MESSAGE_TERM))
+                .message(jsonObject)
+                .token(token)
+                .serviceCall(protocolService::notifyStarted)
+                .errorProvider(TransferError.Builder::newInstance)
+                .protocol(protocol)
+                .participantContextProvider(participantContextSupplier(participantContextId))
+                .build();
+
+        return dspRequestHandler.updateResource(request);
+    }
+
+    /**
+     * Notifies the connector that a transfer process has been completed by the counter-part.
+     *
+     * @param id         the ID of the process
+     * @param jsonObject the {@link TransferCompletionMessage} in JSON-LD expanded form
+     * @param token      the authorization header
+     * @return empty response or error.
+     */
+    @POST
+    @Path("{id}" + TRANSFER_COMPLETION)
+    public Response transferProcessCompletion(@PathParam("participantContextId") String participantContextId, @PathParam("id") String id, JsonObject jsonObject, @HeaderParam(AUTHORIZATION) String token) {
+        var request = PostDspRequest.Builder.newInstance(TransferCompletionMessage.class, TransferProcess.class, TransferError.class)
+                .processId(id)
+                .expectedMessageType(namespace.toIri(DSPACE_TYPE_TRANSFER_COMPLETION_MESSAGE_TERM))
+                .message(jsonObject)
+                .token(token)
+                .serviceCall(protocolService::notifyCompleted)
+                .errorProvider(TransferError.Builder::newInstance)
+                .protocol(protocol)
+                .participantContextProvider(participantContextSupplier(participantContextId))
+                .build();
+
+        return dspRequestHandler.updateResource(request);
+    }
+
+    /**
+     * Notifies the connector that a transfer process has been terminated by the counter-part.
+     *
+     * @param id         the ID of the process
+     * @param jsonObject the {@link TransferTerminationMessage} in JSON-LD expanded form
+     * @param token      the authorization header
+     * @return empty response or error.
+     */
+    @POST
+    @Path("{id}" + TRANSFER_TERMINATION)
+    public Response transferProcessTermination(@PathParam("participantContextId") String participantContextId, @PathParam("id") String id, JsonObject jsonObject, @HeaderParam(AUTHORIZATION) String token) {
+        var request = PostDspRequest.Builder.newInstance(TransferTerminationMessage.class, TransferProcess.class, TransferError.class)
+                .processId(id)
+                .expectedMessageType(namespace.toIri(DSPACE_TYPE_TRANSFER_TERMINATION_MESSAGE_TERM))
+                .message(jsonObject)
+                .token(token)
+                .serviceCall(protocolService::notifyTerminated)
+                .errorProvider(TransferError.Builder::newInstance)
+                .protocol(protocol)
+                .participantContextProvider(participantContextSupplier(participantContextId))
+                .build();
+
+        return dspRequestHandler.updateResource(request);
+    }
+
+    /**
+     * Notifies the connector that a transfer process has been suspended by the counter-part.
+     *
+     * @param id         the ID of the process
+     * @param jsonObject the {@link TransferSuspensionMessage} in JSON-LD expanded form
+     * @param token      the authorization header
+     * @return empty response or error.
+     */
+    @POST
+    @Path("{id}" + TRANSFER_SUSPENSION)
+    public Response transferProcessSuspension(@PathParam("participantContextId") String participantContextId, @PathParam("id") String id, JsonObject jsonObject, @HeaderParam(AUTHORIZATION) String token) {
+        var request = PostDspRequest.Builder.newInstance(TransferSuspensionMessage.class, TransferProcess.class, TransferError.class)
+                .processId(id)
+                .expectedMessageType(namespace.toIri(DSPACE_TYPE_TRANSFER_SUSPENSION_MESSAGE_TERM))
+                .message(jsonObject)
+                .token(token)
+                .serviceCall(protocolService::notifySuspended)
+                .errorProvider(TransferError.Builder::newInstance)
+                .protocol(protocol)
+                .participantContextProvider(participantContextSupplier(participantContextId))
+                .build();
+
+        return dspRequestHandler.updateResource(request);
+    }
+
+    // TODO refactor upstream to use ServiceResult
+    private ParticipantContextSupplier participantContextSupplier(String id) {
+        return () -> participantContextService.getParticipantContext(id).getContent();
+    }
+
+}

--- a/data-protocols/dsp/dsp-2025/dsp-transfer-process-2025/dsp-transfer-process-http-api-2025/src/main/resources/META-INF/services/org.eclipse.edc.spi.system.ServiceExtension
+++ b/data-protocols/dsp/dsp-2025/dsp-transfer-process-2025/dsp-transfer-process-http-api-2025/src/main/resources/META-INF/services/org.eclipse.edc.spi.system.ServiceExtension
@@ -1,0 +1,15 @@
+#
+#  Copyright (c) 2025 Metaform Systems, Inc.
+#
+#  This program and the accompanying materials are made available under the
+#  terms of the Apache License, Version 2.0 which is available at
+#  https://www.apache.org/licenses/LICENSE-2.0
+#
+#  SPDX-License-Identifier: Apache-2.0
+#
+#  Contributors:
+#       Metaform Systems, Inc. - initial API and implementation
+#
+#
+
+org.eclipse.edc.virtual.protocol.dsp.transferprocess.http.api.v2025.DspTransferProcessApi2025Extension

--- a/data-protocols/dsp/dsp-2025/dsp-transfer-process-2025/dsp-transfer-process-http-api-2025/src/test/java/org/eclipse/edc/virtual/protocol/dsp/negotiation/http/api/v2025/controller/DspTransferProcessApiControllerV20251Test.java
+++ b/data-protocols/dsp/dsp-2025/dsp-transfer-process-2025/dsp-transfer-process-http-api-2025/src/test/java/org/eclipse/edc/virtual/protocol/dsp/negotiation/http/api/v2025/controller/DspTransferProcessApiControllerV20251Test.java
@@ -1,0 +1,59 @@
+/*
+ *  Copyright (c) 2025 Metaform Systems, Inc.
+ *
+ *  This program and the accompanying materials are made available under the
+ *  terms of the Apache License, Version 2.0 which is available at
+ *  https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Contributors:
+ *       Metaform Systems, Inc. - initial API and implementation
+ *
+ */
+
+package org.eclipse.edc.virtual.protocol.dsp.negotiation.http.api.v2025.controller;
+
+import org.eclipse.edc.jsonld.spi.JsonLdNamespace;
+import org.eclipse.edc.junit.annotations.ApiTest;
+import org.eclipse.edc.participantcontext.spi.service.ParticipantContextService;
+import org.eclipse.edc.participantcontext.spi.types.ParticipantContext;
+import org.eclipse.edc.protocol.dsp.transferprocess.http.api.controller.DspTransferProcessApiControllerBaseTest;
+import org.eclipse.edc.spi.result.ServiceResult;
+import org.eclipse.edc.virtual.protocol.dsp.transferprocess.http.api.v2025.controller.DspTransferProcessApiController20251;
+
+import static org.eclipse.edc.protocol.dsp.spi.type.Dsp2025Constants.DATASPACE_PROTOCOL_HTTP_V_2025_1;
+import static org.eclipse.edc.protocol.dsp.spi.type.Dsp2025Constants.DSP_NAMESPACE_V_2025_1;
+import static org.eclipse.edc.protocol.dsp.spi.type.Dsp2025Constants.V_2025_1_PATH;
+import static org.eclipse.edc.protocol.dsp.transferprocess.http.api.TransferProcessApiPaths.BASE_PATH;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+@ApiTest
+class DspTransferProcessApiControllerV20251Test extends DspTransferProcessApiControllerBaseTest {
+
+    private final ParticipantContextService participantContextService = mock();
+    private final ParticipantContext participantContext = new ParticipantContext("participantContextId");
+
+
+    void beforeAll() {
+        when(participantContextService.getParticipantContext(participantContext.getParticipantContextId()))
+                .thenReturn(ServiceResult.success(participantContext));
+    }
+
+    @Override
+    protected String basePath() {
+        return V_2025_1_PATH + "/%s".formatted(participantContext.getParticipantContextId()) + BASE_PATH;
+    }
+
+    @Override
+    protected JsonLdNamespace namespace() {
+        return DSP_NAMESPACE_V_2025_1;
+    }
+
+    @Override
+    protected Object controller() {
+        return new DspTransferProcessApiController20251(protocolService, participantContextService, dspRequestHandler, DATASPACE_PROTOCOL_HTTP_V_2025_1, DSP_NAMESPACE_V_2025_1);
+    }
+
+}

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -14,29 +14,73 @@ parsson = "1.1.7"
 nats = "2.22.0"
 
 [libraries]
-# EDC modules
-edc-vault-hashicorp = { module = "org.eclipse.edc:vault-hashicorp", version.ref = "edc" }
-edc-junit = { module = "org.eclipse.edc:junit", version.ref = "edc" }
+# EDC SPI modules
 edc-spi-core = { module = "org.eclipse.edc:core-spi", version.ref = "edc" }
+edc-spi-participantcontext = { module = "org.eclipse.edc:connector-participant-context-spi", version.ref = "edc" }
 edc-spi-transaction = { module = "org.eclipse.edc:transaction-spi", version.ref = "edc" }
 edc-spi-transaction-datasource = { module = "org.eclipse.edc:transaction-datasource-spi", version.ref = "edc" }
 edc-spi-protocol = { module = "org.eclipse.edc:protocol-spi", version.ref = "edc" }
 edc-spi-contract = { module = "org.eclipse.edc:contract-spi", version.ref = "edc" }
 edc-spi-transfer = { module = "org.eclipse.edc:transfer-spi", version.ref = "edc" }
 edc-spi-policy = { module = "org.eclipse.edc:policy-spi", version.ref = "edc" }
+edc-spi-jsonld = { module = "org.eclipse.edc:json-ld-spi", version.ref = "edc" }
+edc-spi-dsp = { module = "org.eclipse.edc:dsp-spi", version.ref = "edc" }
+edc-spi-dsp-v2025 = { module = "org.eclipse.edc:dsp-spi-2025", version.ref = "edc" }
+edc-spi-dsp-http = { module = "org.eclipse.edc:dsp-http-spi", version.ref = "edc" }
+edc-spi-web = { module = "org.eclipse.edc:web-spi", version.ref = "edc" }
 edc-spi-control-plane = { module = "org.eclipse.edc:control-plane-spi", version.ref = "edc" }
+
+# EDC Core modules
 edc-core-controlplane-client = { module = "org.eclipse.edc:control-plane-api-client", version.ref = "edc" }
 edc-core-controlplane = { module = "org.eclipse.edc:control-plane-core", version.ref = "edc" }
-edc-spi-web = { module = "org.eclipse.edc:web-spi", version.ref = "edc" }
+edc-core-connector = { module = "org.eclipse.edc:connector-core", version.ref = "edc" }
+edc-core-runtime = { module = "org.eclipse.edc:runtime-core", version.ref = "edc" }
+edc-core-token = { module = "org.eclipse.edc:token-core", version.ref = "edc" }
+edc-core-jersey = { module = "org.eclipse.edc:jersey-core", version.ref = "edc" }
+edc-core-jetty = { module = "org.eclipse.edc:jetty-core", version.ref = "edc" }
+edc-core-dsp-http = { module = "org.eclipse.edc:dsp-http-core", version.ref = "edc" }
+edc-core-dsp-http-configuration = { module = "org.eclipse.edc:dsp-http-api-base-configuration", version.ref = "edc" }
+edc-core-dsp-http-configuration-v2025 = { module = "org.eclipse.edc:dsp-http-api-configuration-2025", version.ref = "edc" }
+edc-core-dsp-http-dispatcher-v2025 = { module = "org.eclipse.edc:dsp-http-dispatcher-2025", version.ref = "edc" }
+edc-core-dsp-http-catalog-dispatcher = { module = "org.eclipse.edc:dsp-catalog-http-dispatcher", version.ref = "edc" }
+edc-core-dsp-http-negotiation-dispatcher = { module = "org.eclipse.edc:dsp-negotiation-http-dispatcher", version.ref = "edc" }
+edc-core-dsp-http-transferprocess-dispatcher = { module = "org.eclipse.edc:dsp-transfer-process-http-dispatcher", version.ref = "edc" }
+edc-core-dsp-catalog-transform-v2025 = { module = "org.eclipse.edc:dsp-catalog-transform-2025", version.ref = "edc" }
+edc-core-dsp-negotiation-transform-v2025 = { module = "org.eclipse.edc:dsp-negotiation-transform-2025", version.ref = "edc" }
+edc-core-dsp-transferprocess-transform-v2025 = { module = "org.eclipse.edc:dsp-transfer-process-transform-2025", version.ref = "edc" }
+edc-core-dsp-version-http-api = { module = "org.eclipse.edc:dsp-version-http-api", version.ref = "edc" }
+edc-core-participantcontext-single = { module = "org.eclipse.edc:participant-context-single-core", version.ref = "edc" }
+edc-core-dataplane-selector = { module = "org.eclipse.edc:data-plane-selector-core", version.ref = "edc" }
+edc-core-dataplane-signaling-client = { module = "org.eclipse.edc:data-plane-signaling-client", version.ref = "edc" }
+edc-core-dataplane-signaling-transfer = { module = "org.eclipse.edc:transfer-data-plane-signaling", version.ref = "edc" }
+
+# EDC Lib modules
 edc-lib-store = { module = "org.eclipse.edc:store-lib", version.ref = "edc" }
 edc-lib-query = { module = "org.eclipse.edc:query-lib", version.ref = "edc" }
+edc-lib-jersey-providers = { module = "org.eclipse.edc:jersey-providers-lib", version.ref = "edc" }
+edc-lib-dsp-catalog-validation = { module = "org.eclipse.edc:dsp-catalog-validation-lib", version.ref = "edc" }
+edc-lib-dsp-catalog-http = { module = "org.eclipse.edc:dsp-catalog-http-api-lib", version.ref = "edc" }
+edc-lib-dsp-negotiation-validation = { module = "org.eclipse.edc:dsp-negotiation-validation-lib", version.ref = "edc" }
+edc-lib-dsp-negotiation-http = { module = "org.eclipse.edc:dsp-negotiation-http-api-lib", version.ref = "edc" }
+edc-lib-dsp-transferprocess-validation = { module = "org.eclipse.edc:dsp-transfer-process-validation-lib", version.ref = "edc" }
+edc-lib-dsp-transferprocess-http = { module = "org.eclipse.edc:dsp-transfer-process-http-api-lib", version.ref = "edc" }
 edc-build-plugin = { module = "org.eclipse.edc.edc-build:org.eclipse.edc.edc-build.gradle.plugin", version.ref = "edc" }
 edc-sql-test-fixtures = { module = "org.eclipse.edc:sql-test-fixtures", version.ref = "edc" }
+edc-junit = { module = "org.eclipse.edc:junit", version.ref = "edc" }
+
+# EDC Extensions modules
 edc-iam-mock = { module = "org.eclipse.edc:iam-mock", version.ref = "edc" }
 edc-tck-extension = { module = "org.eclipse.edc:tck-extension", version.ref = "edc" }
+edc-vault-hashicorp = { module = "org.eclipse.edc:vault-hashicorp", version.ref = "edc" }
+edc-crypto-verifiablecredentials-ldp = { module = "org.eclipse.edc:ldp-verifiable-credentials", version.ref = "edc" }
+edc-crypto-verifiablecredentials-jwt = { module = "org.eclipse.edc:jwt-verifiable-credentials", version.ref = "edc" }
+edc-api-observability = { module = "org.eclipse.edc:api-observability", version.ref = "edc" }
+# EDC DCP modules
+edc-iam-dcp-core = { module = "org.eclipse.edc:identity-trust-core", version.ref = "edc" }
+edc-iam-decentralized = { module = "org.eclipse.edc:decentralized-identity", version.ref = "edc" }
+edc-oauth2-client = { module = "org.eclipse.edc:oauth2-client", version.ref = "edc" }
 
 # EDC BOM modules
-edc-bom-controlplane = { module = "org.eclipse.edc:controlplane-dcp-bom", version.ref = "edc" }
 edc-bom-controlplane-sql = { module = "org.eclipse.edc:controlplane-feature-sql-bom", version.ref = "edc" }
 edc-bom-dataplane = { module = "org.eclipse.edc:dataplane-base-bom", version.ref = "edc" }
 
@@ -52,6 +96,16 @@ opentelemetry-instrumentation-annotations = { module = "io.opentelemetry.instrum
 postgres = { module = "org.postgresql:postgresql", version.ref = "postgres" }
 parsson = { module = "org.eclipse.parsson:parsson", version.ref = "parsson" }
 nats-client = { module = "io.nats:jnats", version.ref = "nats" }
+
+
+[bundles]
+dcp = [
+    "edc-crypto-verifiablecredentials-jwt",
+    "edc-crypto-verifiablecredentials-ldp",
+    "edc-iam-dcp-core",
+    "edc-oauth2-client",
+    "edc-iam-decentralized"
+]
 
 [plugins]
 edc-build = { id = "org.eclipse.edc.edc-build", version = "1.1.0" }

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -29,9 +29,19 @@ pluginManagement {
 include(":spi:v-core-spi")
 
 // core
+include(":core:v-connector-core")
 include(":core:negotiation-manager")
 include(":core:transfer-process-manager")
 
+// data-protocols
+include(":data-protocols:dsp")
+include(":data-protocols:dsp:dsp-2025")
+include(":data-protocols:dsp:dsp-2025:dsp-catalog-2025")
+include(":data-protocols:dsp:dsp-2025:dsp-catalog-2025:dsp-catalog-http-api-2025")
+include(":data-protocols:dsp:dsp-2025:dsp-negotiation-2025")
+include(":data-protocols:dsp:dsp-2025:dsp-negotiation-2025:dsp-negotiation-http-api-2025")
+include(":data-protocols:dsp:dsp-2025:dsp-transfer-process-2025")
+include(":data-protocols:dsp:dsp-2025:dsp-transfer-process-2025:dsp-transfer-process-http-api-2025")
 // extensions
 include(":extensions:banner-extension")
 include(":extensions:negotiation-cdc-memory")
@@ -48,6 +58,7 @@ include(":system-tests:runtimes:controlplane-memory")
 include(":system-tests:runtimes:controlplane-postgres")
 include(":system-tests:runtime-tests")
 include(":system-tests:dsp-tck-tests")
+include(":system-tests:extensions:v-tck-extension")
 include(":system-tests:runtimes:tck:tck-controlplane-memory")
 include(":system-tests:runtimes:tck:tck-controlplane-postgres")
 

--- a/spi/v-core-spi/build.gradle.kts
+++ b/spi/v-core-spi/build.gradle.kts
@@ -18,6 +18,7 @@ plugins {
 
 dependencies {
     implementation(libs.edc.spi.core)
+    implementation(libs.edc.spi.protocol)
     implementation(libs.edc.spi.contract)
     implementation(libs.edc.spi.transfer)
 }

--- a/spi/v-core-spi/src/main/java/org/eclipse/edc/virtualized/controlplane/participantcontext/spi/ParticipantWebhookResolver.java
+++ b/spi/v-core-spi/src/main/java/org/eclipse/edc/virtualized/controlplane/participantcontext/spi/ParticipantWebhookResolver.java
@@ -1,0 +1,27 @@
+/*
+ *  Copyright (c) 2025 Metaform Systems, Inc.
+ *
+ *  This program and the accompanying materials are made available under the
+ *  terms of the Apache License, Version 2.0 which is available at
+ *  https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Contributors:
+ *       Metaform Systems, Inc. - initial API and implementation
+ *
+ */
+
+package org.eclipse.edc.virtualized.controlplane.participantcontext.spi;
+
+import org.eclipse.edc.protocol.spi.ProtocolWebhook;
+import org.jetbrains.annotations.Nullable;
+
+/**
+ * Registry for protocol webhooks associated with participant dataspace profile contexts.
+ */
+public interface ParticipantWebhookResolver {
+
+    @Nullable
+    ProtocolWebhook getWebhook(String participantContextId, String protocol);
+}

--- a/system-tests/dsp-tck-tests/src/test/java/org/eclipse/edc/virtualized/tck/dsp/MemoryEdcVirtualCompatibilityDockerTest.java
+++ b/system-tests/dsp-tck-tests/src/test/java/org/eclipse/edc/virtualized/tck/dsp/MemoryEdcVirtualCompatibilityDockerTest.java
@@ -52,7 +52,7 @@ public class MemoryEdcVirtualCompatibilityDockerTest {
     private static Config runtimeConfiguration() {
         return ConfigFactory.fromMap(new HashMap<>() {
             {
-                put("edc.participant.id", "CONNECTOR_UNDER_TEST");
+                put("edc.participant.id", "participantContextId");
                 put("web.http.port", "8080");
                 put("web.http.path", "/api");
                 put("web.http.version.port", String.valueOf(getFreePort()));

--- a/system-tests/dsp-tck-tests/src/test/java/org/eclipse/edc/virtualized/tck/dsp/PostgresVirtualCompatibilityDockerTest.java
+++ b/system-tests/dsp-tck-tests/src/test/java/org/eclipse/edc/virtualized/tck/dsp/PostgresVirtualCompatibilityDockerTest.java
@@ -88,7 +88,7 @@ public class PostgresVirtualCompatibilityDockerTest {
     private static Config runtimeConfiguration() {
         return ConfigFactory.fromMap(new HashMap<>() {
             {
-                put("edc.participant.id", "CONNECTOR_UNDER_TEST");
+                put("edc.participant.id", "participantContextId");
                 put("web.http.port", "8080");
                 put("web.http.path", "/api");
                 put("web.http.version.port", String.valueOf(getFreePort()));

--- a/system-tests/dsp-tck-tests/src/test/resources/docker.tck.properties
+++ b/system-tests/dsp-tck-tests/src/test/resources/docker.tck.properties
@@ -13,8 +13,8 @@
 #
 dataspacetck.debug=true
 dataspacetck.dsp.local.connector=false
-dataspacetck.dsp.connector.agent.id=CONNECTOR_UNDER_TEST
-dataspacetck.dsp.connector.http.url=http://host.docker.internal:8282/api/dsp/2025-1
+dataspacetck.dsp.connector.agent.id=participantContextId
+dataspacetck.dsp.connector.http.url=http://host.docker.internal:8282/api/dsp/2025-1/participantContextId
 dataspacetck.dsp.connector.http.base.url=http://host.docker.internal:8282/api/dsp
 dataspacetck.dsp.connector.http.headers.authorization={\"region\": \"any\", \"audience\": \"any\", \"clientId\":\"TCK_PARTICIPANT\"}
 dataspacetck.dsp.connector.negotiation.initiate.url=http://host.docker.internal:8687/tck/negotiations/requests

--- a/system-tests/extensions/v-tck-extension/build.gradle.kts
+++ b/system-tests/extensions/v-tck-extension/build.gradle.kts
@@ -1,0 +1,23 @@
+/*
+ *  Copyright (c) 2025 Metaform Systems, Inc.
+ *
+ *  This program and the accompanying materials are made available under the
+ *  terms of the Apache License, Version 2.0 which is available at
+ *  https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Contributors:
+ *       Metaform Systems, Inc. - initial API and implementation
+ *
+ */
+
+plugins {
+    java
+}
+
+dependencies {
+    api(libs.edc.spi.core)
+    api(libs.edc.spi.participantcontext)
+}
+

--- a/system-tests/extensions/v-tck-extension/src/main/java/org/eclipse/edc/virtua/tck/dsp/DspTckExtension.java
+++ b/system-tests/extensions/v-tck-extension/src/main/java/org/eclipse/edc/virtua/tck/dsp/DspTckExtension.java
@@ -1,0 +1,37 @@
+/*
+ *  Copyright (c) 2025 Metaform Systems, Inc.
+ *
+ *  This program and the accompanying materials are made available under the
+ *  terms of the Apache License, Version 2.0 which is available at
+ *  https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Contributors:
+ *       Metaform Systems, Inc. - initial API and implementation
+ *
+ */
+
+package org.eclipse.edc.virtua.tck.dsp;
+
+import org.eclipse.edc.participantcontext.spi.service.ParticipantContextService;
+import org.eclipse.edc.participantcontext.spi.types.ParticipantContext;
+import org.eclipse.edc.runtime.metamodel.annotation.Extension;
+import org.eclipse.edc.runtime.metamodel.annotation.Inject;
+import org.eclipse.edc.spi.EdcException;
+import org.eclipse.edc.spi.system.ServiceExtension;
+
+@Extension(DspTckExtension.NAME)
+public class DspTckExtension implements ServiceExtension {
+
+    public static final String NAME = "DSP TCK Extension";
+
+    @Inject
+    private ParticipantContextService participantContextService;
+
+    @Override
+    public void prepare() {
+        participantContextService.createParticipantContext(new ParticipantContext("participantContextId"))
+                .orElseThrow(f -> new EdcException("Failed to create ParticipantContext"));
+    }
+}

--- a/system-tests/extensions/v-tck-extension/src/main/resources/META-INF/services/org.eclipse.edc.spi.system.ServiceExtension
+++ b/system-tests/extensions/v-tck-extension/src/main/resources/META-INF/services/org.eclipse.edc.spi.system.ServiceExtension
@@ -1,0 +1,15 @@
+#
+#  Copyright (c) 2025 Metaform Systems, Inc.
+#
+#  This program and the accompanying materials are made available under the
+#  terms of the Apache License, Version 2.0 which is available at
+#  https://www.apache.org/licenses/LICENSE-2.0
+#
+#  SPDX-License-Identifier: Apache-2.0
+#
+#  Contributors:
+#       Metaform Systems, Inc. - initial API and implementation
+#
+#
+
+org.eclipse.edc.virtua.tck.dsp.DspTckExtension

--- a/system-tests/runtimes/controlplane-base/build.gradle.kts
+++ b/system-tests/runtimes/controlplane-base/build.gradle.kts
@@ -17,13 +17,25 @@ plugins {
 }
 
 dependencies {
+    runtimeOnly(project(":core:v-connector-core"))
     runtimeOnly(project(":core:negotiation-manager"))
     runtimeOnly(project(":core:transfer-process-manager"))
     runtimeOnly(project(":extensions:banner-extension"))
-    runtimeOnly(libs.edc.bom.controlplane) {
+    runtimeOnly(project(":data-protocols:dsp"))
+    runtimeOnly(libs.edc.core.connector)
+    runtimeOnly(libs.edc.core.runtime)
+    runtimeOnly(libs.edc.core.token)
+    runtimeOnly(libs.edc.core.jersey)
+    runtimeOnly(libs.edc.core.jetty)
+    runtimeOnly(libs.edc.api.observability)
+    runtimeOnly(libs.bundles.dcp)
+    runtimeOnly(libs.edc.core.controlplane) {
         exclude("org.eclipse.edc", "control-plane-contract-manager")
         exclude("org.eclipse.edc", "control-plane-transfer-manager")
     }
+    runtimeOnly(libs.edc.core.dataplane.selector)
+    runtimeOnly(libs.edc.core.dataplane.signaling.client)
+    runtimeOnly(libs.edc.core.dataplane.signaling.transfer)
 }
 
 

--- a/system-tests/runtimes/tck/tck-controlplane-memory/build.gradle.kts
+++ b/system-tests/runtimes/tck/tck-controlplane-memory/build.gradle.kts
@@ -17,6 +17,7 @@ plugins {
 }
 
 dependencies {
+    runtimeOnly(project(":system-tests:extensions:v-tck-extension"));
     runtimeOnly(project(":system-tests:runtimes:controlplane-memory")) {
         exclude("org.eclipse.edc", "identity-trust-service")
         exclude("org.eclipse.edc", "identity-trust-core")
@@ -24,6 +25,7 @@ dependencies {
         exclude("org.eclipse.edc", "identity-trust-issuers-configuration")
     }
     runtimeOnly(libs.edc.tck.extension)
+    runtimeOnly(libs.edc.core.participantcontext.single)
     runtimeOnly(libs.edc.bom.dataplane) {
         exclude(module = "data-plane-selector-client")
     }

--- a/system-tests/runtimes/tck/tck-controlplane-postgres/build.gradle.kts
+++ b/system-tests/runtimes/tck/tck-controlplane-postgres/build.gradle.kts
@@ -18,6 +18,7 @@ plugins {
 
 dependencies {
 
+    runtimeOnly(project(":system-tests:extensions:v-tck-extension"));
     runtimeOnly(project(":system-tests:runtimes:controlplane-postgres")) {
         exclude("org.eclipse.edc", "identity-trust-service")
         exclude("org.eclipse.edc", "identity-trust-core")
@@ -31,6 +32,7 @@ dependencies {
     runtimeOnly(project(":extensions:transfer-process-cdc-publisher-nats"))
     runtimeOnly(project(":extensions:transfer-process-subscriber-nats"))
     runtimeOnly(libs.edc.tck.extension)
+    runtimeOnly(libs.edc.core.participantcontext.single)
     runtimeOnly(libs.edc.bom.dataplane) {
         exclude(module = "data-plane-selector-client")
     }


### PR DESCRIPTION
## What this PR changes/adds

Introduced DSP APIs with support of participant context for:

- Catalog
- Negotiation
- TransferProcess


The version api impl has been imported from EDC core in order to pass TCK tests.
This will be fixed in subsequent PRs

## Why it does that

_Briefly state why the change was necessary._

## Further notes

_List other areas of code that have changed but are not necessarily linked to the main feature. This could be method
signature changes, package declarations, bugs that were encountered and were fixed inline, etc._


## Who will sponsor this feature?

_Please @-mention the committer that will sponsor your feature_.


## Linked Issue(s)

Closes #5 
_Please be sure to take a look at the [contributing guidelines](https://github.com/eclipse-edc/.github/blob/main/CONTRIBUTING.md#submit-a-pull-request) and our [etiquette for pull requests](https://github.com/eclipse-edc/.github/blob/main/contributing/pr_etiquette.md)._
