### PR TITLE
feat: dsp 2025 support for multiple webhook based on participant context

### DIFF
--- a/.github/workflows/verify.yaml
+++ b/.github/workflows/verify.yaml
@@ -84,3 +84,13 @@ jobs:
       - uses: ./.github/actions/setup-java
       - name: End to End Integration Tests
         run: ./gradlew test -DincludeTags="EndToEndTest"
+
+  Run-Dsp-Compatibility-Test:
+    name: "Run DSP Compatibility Test"
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v5
+      - uses: ./.github/actions/setup-java
+      - name: DSP Compatibility
+        run: |
+          ./gradlew test -DincludeTags="NightlyTest" -PverboseTest=true

--- a/core/v-connector-core/src/main/java/org/eclipse/edc/virtualized/controlplane/participantcontext/ParticipantWebhookResolverImpl.java
+++ b/core/v-connector-core/src/main/java/org/eclipse/edc/virtualized/controlplane/participantcontext/ParticipantWebhookResolverImpl.java
@@ -36,7 +36,7 @@ public class ParticipantWebhookResolverImpl implements ParticipantWebhookResolve
     }
 
     private ProtocolWebhook wrap(String participantContextId, ProtocolWebhook protocolWebhook) {
-        return () -> protocolWebhook.url() + "/" + participantContextId;
+        return () -> protocolWebhook.url().formatted(participantContextId);
 
     }
 

--- a/data-protocols/dsp/dsp-2025/dsp-catalog-2025/dsp-catalog-http-api-2025/src/main/java/org/eclipse/edc/virtual/protocol/dsp/catalog/http/api/v2025/controller/DspCatalogApiController20251.java
+++ b/data-protocols/dsp/dsp-2025/dsp-catalog-2025/dsp-catalog-http-api-2025/src/main/java/org/eclipse/edc/virtual/protocol/dsp/catalog/http/api/v2025/controller/DspCatalogApiController20251.java
@@ -53,7 +53,7 @@ import static org.eclipse.edc.protocol.dsp.spi.type.DspCatalogPropertyAndTypeNam
  */
 @Consumes({APPLICATION_JSON})
 @Produces({APPLICATION_JSON})
-@Path(V_2025_1_PATH + "/{participantContextId}" + BASE_PATH)
+@Path("/{participantContextId}" + V_2025_1_PATH + BASE_PATH)
 public class DspCatalogApiController20251 {
 
     private final CatalogProtocolService service;

--- a/data-protocols/dsp/dsp-2025/dsp-catalog-2025/dsp-catalog-http-api-2025/src/test/java/org/eclipse/edc/virtual/protocol/dsp/catalog/http/api/v2025/controller/DspCatalogApiControllerV20251Test.java
+++ b/data-protocols/dsp/dsp-2025/dsp-catalog-2025/dsp-catalog-http-api-2025/src/test/java/org/eclipse/edc/virtual/protocol/dsp/catalog/http/api/v2025/controller/DspCatalogApiControllerV20251Test.java
@@ -42,7 +42,7 @@ public class DspCatalogApiControllerV20251Test extends DspCatalogApiControllerTe
 
     @Override
     protected String basePath() {
-        return V_2025_1_PATH + "/%s".formatted(participantContext.getParticipantContextId()) + BASE_PATH;
+        return "/%s".formatted(participantContext.getParticipantContextId()) + V_2025_1_PATH + BASE_PATH;
     }
 
     @Override

--- a/data-protocols/dsp/dsp-2025/dsp-http-api-configuration-2025/build.gradle.kts
+++ b/data-protocols/dsp/dsp-2025/dsp-http-api-configuration-2025/build.gradle.kts
@@ -17,10 +17,11 @@ plugins {
 }
 
 dependencies {
-    api(project(":data-protocols:dsp:dsp-2025:dsp-http-api-configuration-2025"))
-    api(project(":data-protocols:dsp:dsp-2025:dsp-catalog-2025"))
-    api(project(":data-protocols:dsp:dsp-2025:dsp-negotiation-2025"))
-    api(project(":data-protocols:dsp:dsp-2025:dsp-transfer-process-2025"))
-    api(libs.edc.core.dsp.http.dispatcher.v2025)
-
+    api(libs.edc.spi.core)
+    api(libs.edc.spi.protocol)
+    api(libs.edc.spi.jsonld)
+    api(libs.edc.spi.dsp.http)
+    api(libs.edc.spi.dsp.v2025)
+    implementation(libs.edc.lib.transform)
+    implementation(libs.edc.lib.controlplane.transform)
 }

--- a/data-protocols/dsp/dsp-2025/dsp-http-api-configuration-2025/src/main/java/org/eclipse/edc/virtual/protocol/dsp/http/api/configuration/v2025/DspApiConfigurationV2025Extension.java
+++ b/data-protocols/dsp/dsp-2025/dsp-http-api-configuration-2025/src/main/java/org/eclipse/edc/virtual/protocol/dsp/http/api/configuration/v2025/DspApiConfigurationV2025Extension.java
@@ -1,0 +1,119 @@
+/*
+ *  Copyright (c) 2025 Metaform Systems, Inc.
+ *
+ *  This program and the accompanying materials are made available under the
+ *  terms of the Apache License, Version 2.0 which is available at
+ *  https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Contributors:
+ *       Metaform Systems, Inc. - initial API and implementation
+ *
+ */
+
+package org.eclipse.edc.virtual.protocol.dsp.http.api.configuration.v2025;
+
+import jakarta.json.Json;
+import org.eclipse.edc.connector.controlplane.transform.edc.from.JsonObjectFromAssetTransformer;
+import org.eclipse.edc.connector.controlplane.transform.edc.to.JsonObjectToAssetTransformer;
+import org.eclipse.edc.connector.controlplane.transform.odrl.OdrlTransformersFactory;
+import org.eclipse.edc.connector.controlplane.transform.odrl.from.JsonObjectFromPolicyTransformer;
+import org.eclipse.edc.jsonld.spi.JsonLd;
+import org.eclipse.edc.participant.spi.ParticipantIdMapper;
+import org.eclipse.edc.protocol.dsp.http.spi.api.DspBaseWebhookAddress;
+import org.eclipse.edc.protocol.spi.DataspaceProfileContext;
+import org.eclipse.edc.protocol.spi.DataspaceProfileContextRegistry;
+import org.eclipse.edc.protocol.spi.DefaultParticipantIdExtractionFunction;
+import org.eclipse.edc.runtime.metamodel.annotation.Extension;
+import org.eclipse.edc.runtime.metamodel.annotation.Inject;
+import org.eclipse.edc.spi.system.ServiceExtension;
+import org.eclipse.edc.spi.system.ServiceExtensionContext;
+import org.eclipse.edc.spi.types.TypeManager;
+import org.eclipse.edc.transform.spi.TypeTransformerRegistry;
+import org.eclipse.edc.transform.transformer.dspace.to.JsonObjectToDataAddressDspaceTransformer;
+import org.eclipse.edc.transform.transformer.dspace.v2024.from.JsonObjectFromDataAddressDspace2024Transformer;
+import org.eclipse.edc.transform.transformer.edc.from.JsonObjectFromCriterionTransformer;
+import org.eclipse.edc.transform.transformer.edc.from.JsonObjectFromQuerySpecTransformer;
+import org.eclipse.edc.transform.transformer.edc.to.JsonObjectToCriterionTransformer;
+import org.eclipse.edc.transform.transformer.edc.to.JsonObjectToQuerySpecTransformer;
+import org.eclipse.edc.transform.transformer.edc.to.JsonValueToGenericTypeTransformer;
+
+import java.util.Map;
+
+import static org.eclipse.edc.jsonld.spi.Namespaces.DSPACE_CONTEXT_2025_1;
+import static org.eclipse.edc.jsonld.spi.Namespaces.EDC_DSPACE_CONTEXT;
+import static org.eclipse.edc.protocol.dsp.spi.type.Dsp2025Constants.DATASPACE_PROTOCOL_HTTP_V_2025_1;
+import static org.eclipse.edc.protocol.dsp.spi.type.Dsp2025Constants.DSP_NAMESPACE_V_2025_1;
+import static org.eclipse.edc.protocol.dsp.spi.type.Dsp2025Constants.DSP_SCOPE_V_2025_1;
+import static org.eclipse.edc.protocol.dsp.spi.type.Dsp2025Constants.DSP_TRANSFORMER_CONTEXT_V_2025_1;
+import static org.eclipse.edc.protocol.dsp.spi.type.Dsp2025Constants.V_2025_1;
+import static org.eclipse.edc.protocol.dsp.spi.type.Dsp2025Constants.V_2025_1_PATH;
+import static org.eclipse.edc.spi.constants.CoreConstants.JSON_LD;
+
+/**
+ * Registers protocol webhook, API transformers and namespaces for DSP v2025/1.
+ */
+@Extension(value = DspApiConfigurationV2025Extension.NAME)
+public class DspApiConfigurationV2025Extension implements ServiceExtension {
+
+    public static final String NAME = "Dataspace Protocol 2025/1 API Configuration Extension";
+
+    @Inject
+    private TypeManager typeManager;
+    @Inject
+    private JsonLd jsonLd;
+    @Inject
+    private TypeTransformerRegistry transformerRegistry;
+    @Inject
+    private ParticipantIdMapper participantIdMapper;
+    @Inject
+    private DspBaseWebhookAddress dspWebhookAddress;
+    @Inject
+    private DataspaceProfileContextRegistry dataspaceProfileContextRegistry;
+    @Inject
+    private DefaultParticipantIdExtractionFunction participantIdExtractionFunction;
+
+    @Override
+    public String name() {
+        return NAME;
+    }
+
+    @Override
+    public void initialize(ServiceExtensionContext context) {
+        // registers ns for DSP 2025/1 scope
+        registerNamespaces();
+        registerTransformers();
+
+        // dynamic webhook registration based on participant context
+        dataspaceProfileContextRegistry.register(new DataspaceProfileContext(DATASPACE_PROTOCOL_HTTP_V_2025_1, V_2025_1, () -> dspWebhookAddress.get() + "/%s" + V_2025_1_PATH, context.getParticipantId(), participantIdExtractionFunction));
+    }
+
+    private void registerNamespaces() {
+        jsonLd.registerContext(DSPACE_CONTEXT_2025_1, DSP_SCOPE_V_2025_1);
+        jsonLd.registerContext(EDC_DSPACE_CONTEXT, DSP_SCOPE_V_2025_1);
+    }
+
+    private void registerTransformers() {
+        var jsonBuilderFactory = Json.createBuilderFactory(Map.of());
+
+        // EDC model to JSON-LD transformers
+        var dspApiTransformerRegistry = transformerRegistry.forContext(DSP_TRANSFORMER_CONTEXT_V_2025_1);
+        dspApiTransformerRegistry.register(new JsonObjectFromAssetTransformer(jsonBuilderFactory, typeManager, JSON_LD));
+        dspApiTransformerRegistry.register(new JsonObjectFromQuerySpecTransformer(jsonBuilderFactory));
+        dspApiTransformerRegistry.register(new JsonObjectFromCriterionTransformer(jsonBuilderFactory, typeManager, JSON_LD));
+
+        // JSON-LD to EDC model transformers
+        // ODRL Transformers
+        OdrlTransformersFactory.jsonObjectToOdrlTransformers(participantIdMapper).forEach(dspApiTransformerRegistry::register);
+
+        dspApiTransformerRegistry.register(new JsonValueToGenericTypeTransformer(typeManager, JSON_LD));
+        dspApiTransformerRegistry.register(new JsonObjectToAssetTransformer());
+        dspApiTransformerRegistry.register(new JsonObjectToQuerySpecTransformer());
+        dspApiTransformerRegistry.register(new JsonObjectToCriterionTransformer());
+        dspApiTransformerRegistry.register(new JsonObjectToDataAddressDspaceTransformer(DSP_NAMESPACE_V_2025_1));
+        dspApiTransformerRegistry.register(new JsonObjectFromPolicyTransformer(jsonBuilderFactory, participantIdMapper, new JsonObjectFromPolicyTransformer.TransformerConfig(true, true)));
+        dspApiTransformerRegistry.register(new JsonObjectFromDataAddressDspace2024Transformer(jsonBuilderFactory, typeManager, JSON_LD, DSP_NAMESPACE_V_2025_1));
+    }
+}
+

--- a/data-protocols/dsp/dsp-2025/dsp-http-api-configuration-2025/src/main/resources/META-INF/services/org.eclipse.edc.spi.system.ServiceExtension
+++ b/data-protocols/dsp/dsp-2025/dsp-http-api-configuration-2025/src/main/resources/META-INF/services/org.eclipse.edc.spi.system.ServiceExtension
@@ -1,0 +1,15 @@
+#
+#  Copyright (c) 2025 Metaform Systems, Inc.
+#
+#  This program and the accompanying materials are made available under the
+#  terms of the Apache License, Version 2.0 which is available at
+#  https://www.apache.org/licenses/LICENSE-2.0
+#
+#  SPDX-License-Identifier: Apache-2.0
+#
+#  Contributors:
+#       Metaform Systems, Inc. - initial API and implementation
+#
+#
+
+org.eclipse.edc.virtual.protocol.dsp.http.api.configuration.v2025.DspApiConfigurationV2025Extension

--- a/data-protocols/dsp/dsp-2025/dsp-negotiation-2025/dsp-negotiation-http-api-2025/src/main/java/org/eclipse/edc/virtual/protocol/dsp/negotiation/http/api/v2025/DspNegotiationApi2025Extension.java
+++ b/data-protocols/dsp/dsp-2025/dsp-negotiation-2025/dsp-negotiation-http-api-2025/src/main/java/org/eclipse/edc/virtual/protocol/dsp/negotiation/http/api/v2025/DspNegotiationApi2025Extension.java
@@ -64,7 +64,7 @@ public class DspNegotiationApi2025Extension implements ServiceExtension {
     @Inject
     private DspRequestHandler dspRequestHandler;
     @Inject
-    private DataspaceProfileContextRegistry versionRegistry;
+    private DataspaceProfileContextRegistry contextRegistry;
 
     @Inject
     private JsonLd jsonLd;

--- a/data-protocols/dsp/dsp-2025/dsp-negotiation-2025/dsp-negotiation-http-api-2025/src/main/java/org/eclipse/edc/virtual/protocol/dsp/negotiation/http/api/v2025/controller/DspNegotiationApiController20251.java
+++ b/data-protocols/dsp/dsp-2025/dsp-negotiation-2025/dsp-negotiation-http-api-2025/src/main/java/org/eclipse/edc/virtual/protocol/dsp/negotiation/http/api/v2025/controller/DspNegotiationApiController20251.java
@@ -63,7 +63,7 @@ import static org.eclipse.edc.protocol.dsp.spi.type.DspNegotiationPropertyAndTyp
  */
 @Consumes({MediaType.APPLICATION_JSON})
 @Produces({MediaType.APPLICATION_JSON})
-@Path(V_2025_1_PATH + "/{participantContextId}" + BASE_PATH)
+@Path("/{participantContextId}" + V_2025_1_PATH + BASE_PATH)
 public class DspNegotiationApiController20251 {
 
     private final ContractNegotiationProtocolService protocolService;

--- a/data-protocols/dsp/dsp-2025/dsp-negotiation-2025/dsp-negotiation-http-api-2025/src/test/java/org/eclipse/edc/virtual/protocol/dsp/negotiation/http/api/v2025/controller/DspNegotiationApiControllerV20251Test.java
+++ b/data-protocols/dsp/dsp-2025/dsp-negotiation-2025/dsp-negotiation-http-api-2025/src/test/java/org/eclipse/edc/virtual/protocol/dsp/negotiation/http/api/v2025/controller/DspNegotiationApiControllerV20251Test.java
@@ -44,7 +44,7 @@ class DspNegotiationApiControllerV20251Test extends DspNegotiationApiControllerT
 
     @Override
     protected String basePath() {
-        return V_2025_1_PATH + "/%s".formatted(participantContext.getParticipantContextId()) + BASE_PATH;
+        return "/%s".formatted(participantContext.getParticipantContextId()) + V_2025_1_PATH + BASE_PATH;
     }
 
     @Override

--- a/data-protocols/dsp/dsp-2025/dsp-transfer-process-2025/dsp-transfer-process-http-api-2025/src/main/java/org/eclipse/edc/virtual/protocol/dsp/transferprocess/http/api/v2025/controller/DspTransferProcessApiController20251.java
+++ b/data-protocols/dsp/dsp-2025/dsp-transfer-process-2025/dsp-transfer-process-http-api-2025/src/main/java/org/eclipse/edc/virtual/protocol/dsp/transferprocess/http/api/v2025/controller/DspTransferProcessApiController20251.java
@@ -59,7 +59,7 @@ import static org.eclipse.edc.protocol.dsp.transferprocess.http.api.TransferProc
  */
 @Consumes({MediaType.APPLICATION_JSON})
 @Produces({MediaType.APPLICATION_JSON})
-@Path(V_2025_1_PATH + "/{participantContextId}" + BASE_PATH)
+@Path("/{participantContextId}" + V_2025_1_PATH + BASE_PATH)
 public class DspTransferProcessApiController20251 {
 
     private final TransferProcessProtocolService protocolService;

--- a/data-protocols/dsp/dsp-2025/dsp-transfer-process-2025/dsp-transfer-process-http-api-2025/src/test/java/org/eclipse/edc/virtual/protocol/dsp/negotiation/http/api/v2025/controller/DspTransferProcessApiControllerV20251Test.java
+++ b/data-protocols/dsp/dsp-2025/dsp-transfer-process-2025/dsp-transfer-process-http-api-2025/src/test/java/org/eclipse/edc/virtual/protocol/dsp/negotiation/http/api/v2025/controller/DspTransferProcessApiControllerV20251Test.java
@@ -43,7 +43,7 @@ class DspTransferProcessApiControllerV20251Test extends DspTransferProcessApiCon
 
     @Override
     protected String basePath() {
-        return V_2025_1_PATH + "/%s".formatted(participantContext.getParticipantContextId()) + BASE_PATH;
+        return "/%s".formatted(participantContext.getParticipantContextId()) + V_2025_1_PATH + BASE_PATH;
     }
 
     @Override

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -40,7 +40,6 @@ edc-core-jersey = { module = "org.eclipse.edc:jersey-core", version.ref = "edc" 
 edc-core-jetty = { module = "org.eclipse.edc:jetty-core", version.ref = "edc" }
 edc-core-dsp-http = { module = "org.eclipse.edc:dsp-http-core", version.ref = "edc" }
 edc-core-dsp-http-configuration = { module = "org.eclipse.edc:dsp-http-api-base-configuration", version.ref = "edc" }
-edc-core-dsp-http-configuration-v2025 = { module = "org.eclipse.edc:dsp-http-api-configuration-2025", version.ref = "edc" }
 edc-core-dsp-http-dispatcher-v2025 = { module = "org.eclipse.edc:dsp-http-dispatcher-2025", version.ref = "edc" }
 edc-core-dsp-http-catalog-dispatcher = { module = "org.eclipse.edc:dsp-catalog-http-dispatcher", version.ref = "edc" }
 edc-core-dsp-http-negotiation-dispatcher = { module = "org.eclipse.edc:dsp-negotiation-http-dispatcher", version.ref = "edc" }
@@ -57,6 +56,8 @@ edc-core-dataplane-signaling-transfer = { module = "org.eclipse.edc:transfer-dat
 # EDC Lib modules
 edc-lib-store = { module = "org.eclipse.edc:store-lib", version.ref = "edc" }
 edc-lib-query = { module = "org.eclipse.edc:query-lib", version.ref = "edc" }
+edc-lib-transform = { module = "org.eclipse.edc:transform-lib", version.ref = "edc" }
+edc-lib-controlplane-transform = { module = "org.eclipse.edc:control-plane-transform", version.ref = "edc" }
 edc-lib-jersey-providers = { module = "org.eclipse.edc:jersey-providers-lib", version.ref = "edc" }
 edc-lib-dsp-catalog-validation = { module = "org.eclipse.edc:dsp-catalog-validation-lib", version.ref = "edc" }
 edc-lib-dsp-catalog-http = { module = "org.eclipse.edc:dsp-catalog-http-api-lib", version.ref = "edc" }

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -36,6 +36,7 @@ include(":core:transfer-process-manager")
 // data-protocols
 include(":data-protocols:dsp")
 include(":data-protocols:dsp:dsp-2025")
+include(":data-protocols:dsp:dsp-2025:dsp-http-api-configuration-2025")
 include(":data-protocols:dsp:dsp-2025:dsp-catalog-2025")
 include(":data-protocols:dsp:dsp-2025:dsp-catalog-2025:dsp-catalog-http-api-2025")
 include(":data-protocols:dsp:dsp-2025:dsp-negotiation-2025")

--- a/system-tests/dsp-tck-tests/build.gradle.kts
+++ b/system-tests/dsp-tck-tests/build.gradle.kts
@@ -27,8 +27,7 @@ dependencies {
     testImplementation(libs.testcontainers.vault)
     testImplementation(libs.testcontainers.postgres)
     runtimeOnly(libs.parsson)
-
-
+    
     testCompileOnly(project(":system-tests:runtimes:tck:tck-controlplane-memory"))
     testCompileOnly(project(":system-tests:runtimes:tck:tck-controlplane-postgres"))
 }

--- a/system-tests/dsp-tck-tests/src/test/resources/docker.tck.properties
+++ b/system-tests/dsp-tck-tests/src/test/resources/docker.tck.properties
@@ -14,7 +14,7 @@
 dataspacetck.debug=true
 dataspacetck.dsp.local.connector=false
 dataspacetck.dsp.connector.agent.id=participantContextId
-dataspacetck.dsp.connector.http.url=http://host.docker.internal:8282/api/dsp/2025-1/participantContextId
+dataspacetck.dsp.connector.http.url=http://host.docker.internal:8282/api/dsp/participantContextId/2025-1
 dataspacetck.dsp.connector.http.base.url=http://host.docker.internal:8282/api/dsp
 dataspacetck.dsp.connector.http.headers.authorization={\"region\": \"any\", \"audience\": \"any\", \"clientId\":\"TCK_PARTICIPANT\"}
 dataspacetck.dsp.connector.negotiation.initiate.url=http://host.docker.internal:8687/tck/negotiations/requests

--- a/system-tests/runtimes/tck/tck-controlplane-memory/build.gradle.kts
+++ b/system-tests/runtimes/tck/tck-controlplane-memory/build.gradle.kts
@@ -17,8 +17,8 @@ plugins {
 }
 
 dependencies {
-    runtimeOnly(project(":system-tests:extensions:v-tck-extension"));
-    runtimeOnly(project(":system-tests:runtimes:controlplane-memory")) {
+    implementation(project(":system-tests:extensions:v-tck-extension"));
+    implementation(project(":system-tests:runtimes:controlplane-memory")) {
         exclude("org.eclipse.edc", "identity-trust-service")
         exclude("org.eclipse.edc", "identity-trust-core")
         exclude("org.eclipse.edc", "identity-trust-sts-remote-client")

--- a/system-tests/runtimes/tck/tck-controlplane-postgres/build.gradle.kts
+++ b/system-tests/runtimes/tck/tck-controlplane-postgres/build.gradle.kts
@@ -18,19 +18,19 @@ plugins {
 
 dependencies {
 
-    runtimeOnly(project(":system-tests:extensions:v-tck-extension"));
-    runtimeOnly(project(":system-tests:runtimes:controlplane-postgres")) {
+    implementation(project(":system-tests:extensions:v-tck-extension"));
+    implementation(project(":system-tests:runtimes:controlplane-postgres")) {
         exclude("org.eclipse.edc", "identity-trust-service")
         exclude("org.eclipse.edc", "identity-trust-core")
         exclude("org.eclipse.edc", "identity-trust-sts-remote-client")
         exclude("org.eclipse.edc", "identity-trust-issuers-configuration")
         exclude("org.eclipse.edc", "vault-hashicorp")
     }
-    runtimeOnly(project(":extensions:postgres-cdc"))
-    runtimeOnly(project(":extensions:negotiation-cdc-publisher-nats"))
-    runtimeOnly(project(":extensions:negotiation-subscriber-nats"))
-    runtimeOnly(project(":extensions:transfer-process-cdc-publisher-nats"))
-    runtimeOnly(project(":extensions:transfer-process-subscriber-nats"))
+    implementation(project(":extensions:postgres-cdc"))
+    implementation(project(":extensions:negotiation-cdc-publisher-nats"))
+    implementation(project(":extensions:negotiation-subscriber-nats"))
+    implementation(project(":extensions:transfer-process-cdc-publisher-nats"))
+    implementation(project(":extensions:transfer-process-subscriber-nats"))
     runtimeOnly(libs.edc.tck.extension)
     runtimeOnly(libs.edc.core.participantcontext.single)
     runtimeOnly(libs.edc.bom.dataplane) {


### PR DESCRIPTION
## What this PR changes/adds

To support  webhook based on participant context, for DSP 2025 impl we created a new module 

`dsp-http-api-configuration-2025` which replaces the upstream one that register in the `DataspaceProfileContextRegistry` a `DataspaceProfileContext` which contains a template for the participant context id

`<dsp_base_path/%s/2025-1` that we replace in the impl of `ParticipantWebhookResolver` when fetching a webhook for

a participantContextId + a protocol/profile

## Why it does that

_Briefly state why the change was necessary._

## Further notes

This could change in the future by replacing the custom `ParticipantWebhookResolver`  if we support the participant context in `DataspaceProfileContextRegistry`


## Who will sponsor this feature?

_Please @-mention the committer that will sponsor your feature_.


## Linked Issue(s)

Closes #9 

_Please be sure to take a look at the [contributing guidelines](https://github.com/eclipse-edc/.github/blob/main/CONTRIBUTING.md#submit-a-pull-request) and our [etiquette for pull requests](https://github.com/eclipse-edc/.github/blob/main/contributing/pr_etiquette.md)._
