### PR TITLE
fix: transition to TERMINATING on DPS error

### DIFF
--- a/core/transfer-process-manager/src/main/java/org/eclipse/edc/virtualized/controlplane/transfer/process/TransferProcessStateMachineServiceImpl.java
+++ b/core/transfer-process-manager/src/main/java/org/eclipse/edc/virtualized/controlplane/transfer/process/TransferProcessStateMachineServiceImpl.java
@@ -162,7 +162,7 @@ public class TransferProcessStateMachineServiceImpl implements TransferProcessSt
         var policy = policyArchive.findPolicyForContract(contractId);
 
         if (policy == null) {
-            transitionToTerminated(process, "Policy not found for contract: " + contractId);
+            transitionToTerminating(process, "Policy not found for contract: " + contractId);
             return StatusResult.failure(FATAL_ERROR, "Policy not found for contract: " + contractId);
         }
 
@@ -191,7 +191,7 @@ public class TransferProcessStateMachineServiceImpl implements TransferProcessSt
         var result = dataFlowManager.start(process, policy);
 
         if (result.failed()) {
-            transitionToTerminated(process, result.getFailureDetail());
+            transitionToTerminating(process, result.getFailureDetail());
             return StatusResult.failure(FATAL_ERROR, result.getFailureDetail());
         }
         var dataFlowResponse = result.getContent();
@@ -243,7 +243,7 @@ public class TransferProcessStateMachineServiceImpl implements TransferProcessSt
         if (process.getType() == PROVIDER) {
             var result = dataFlowManager.suspend(process);
             if (result.failed()) {
-                transitionToTerminated(process, "Failed to suspend transfer process: " + result.getFailureDetail());
+                transitionToTerminating(process, "Failed to suspend transfer process: " + result.getFailureDetail());
                 return StatusResult.failure(FATAL_ERROR, result.getFailureDetail());
             }
         }


### PR DESCRIPTION
## What this PR changes/adds

Transition to `TERMINATING` instead of `TERMINATED` if the dataflow manager fails to forward the transition to the dataplane, or if the policy is null (during initialization).

## Why it does that

proper state transitions are needed to guarantee that DSP messages are sent out correctly

## Further notes

_List other areas of code that have changed but are not necessarily linked to the main feature. This could be method
signature changes, package declarations, bugs that were encountered and were fixed inline, etc._

## Who will sponsor this feature?

_Please @-mention the committer that will sponsor your feature_.

## Linked Issue(s)

Closes # <-- _insert Issue number if one exists_

_Please be sure to take a look at the [contributing guidelines](https://github.com/eclipse-edc/.github/blob/main/CONTRIBUTING.md#submit-a-pull-request) and our [etiquette for pull requests](https://github.com/eclipse-edc/.github/blob/main/contributing/pr_etiquette.md)._
