### PR TITLE
feat: enable snapshot publishing

### DIFF
--- a/.github/workflows/trigger_snapshot.yml
+++ b/.github/workflows/trigger_snapshot.yml
@@ -1,0 +1,32 @@
+#
+#  Copyright (c) 2025 Metaform Systems, Inc.
+#
+#  This program and the accompanying materials are made available under the
+#  terms of the Apache License, Version 2.0 which is available at
+#  https://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+#  WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+#  License for the specific language governing permissions and limitations
+#  under the License.
+#
+#  SPDX-License-Identifier: Apache-2.0
+
+name: "Publish Snapshot Build"
+
+on:
+  push:
+    branches:
+      - main
+  workflow_dispatch:
+
+jobs:
+  Publish-Snapshot:
+    # This workflow will abort if the required secrets don't exist
+    uses: eclipse-edc/.github/.github/workflows/publish-snapshot.yml@main
+    secrets: inherit
+
+  Publish-Dependencies:
+    uses: eclipse-edc/.github/.github/workflows/publish-dependencies.yml@main
+    secrets: inherit

--- a/system-tests/dsp-tck-tests/build.gradle.kts
+++ b/system-tests/dsp-tck-tests/build.gradle.kts
@@ -34,3 +34,6 @@ dependencies {
     testCompileOnly(project(":system-tests:runtimes:tck:tck-controlplane-postgres"))
 }
 
+edcBuild {
+    publish.set(false)
+}

--- a/system-tests/runtime-tests/build.gradle.kts
+++ b/system-tests/runtime-tests/build.gradle.kts
@@ -39,5 +39,9 @@ dependencies {
     testImplementation(libs.bouncyCastle.bcpkixJdk18on)
 }
 
+edcBuild {
+    publish.set(false)
+}
+
 
 

--- a/system-tests/runtimes/controlplane-base/build.gradle.kts
+++ b/system-tests/runtimes/controlplane-base/build.gradle.kts
@@ -38,5 +38,8 @@ dependencies {
     runtimeOnly(libs.edc.core.dataplane.signaling.transfer)
 }
 
+edcBuild {
+    publish.set(false)
+}
 
 

--- a/system-tests/system-test-fixtures/build.gradle.kts
+++ b/system-tests/system-test-fixtures/build.gradle.kts
@@ -20,3 +20,7 @@ dependencies {
     implementation(libs.testcontainers.junit)
     implementation(libs.testcontainers.postgres)
 }
+
+edcBuild {
+    publish.set(false)
+}


### PR DESCRIPTION
## What this PR changes/adds

enable snapshot publishing with upstream EDC reusable workflow:

Added also publish false to some internal modules used for testing only

## Why it does that

_Briefly state why the change was necessary._

## Further notes

_List other areas of code that have changed but are not necessarily linked to the main feature. This could be method
signature changes, package declarations, bugs that were encountered and were fixed inline, etc._


## Who will sponsor this feature?

_Please @-mention the committer that will sponsor your feature_.


## Linked Issue(s)

Closes #22 

_Please be sure to take a look at the [contributing guidelines](https://github.com/eclipse-edc/.github/blob/main/CONTRIBUTING.md#submit-a-pull-request) and our [etiquette for pull requests](https://github.com/eclipse-edc/.github/blob/main/contributing/pr_etiquette.md)._
