### PR TITLE
feat: contract negotiation APIs

### DIFF
--- a/extensions/control-plane/api/management-api/build.gradle.kts
+++ b/extensions/control-plane/api/management-api/build.gradle.kts
@@ -22,5 +22,6 @@ dependencies {
     api(project(":extensions:control-plane:api:management-api:asset-api"))
     api(project(":extensions:control-plane:api:management-api:contract-definition-api"))
     api(project(":extensions:control-plane:api:management-api:policy-definition-api"))
+    api(project(":extensions:control-plane:api:management-api:contract-negotiation-api"))
     api(project(":extensions:control-plane:api:management-api:management-api-configuration"))
 }

--- a/extensions/control-plane/api/management-api/contract-negotiation-api/build.gradle.kts
+++ b/extensions/control-plane/api/management-api/contract-negotiation-api/build.gradle.kts
@@ -1,0 +1,47 @@
+/*
+ *  Copyright (c) 2025 Metaform Systems, Inc.
+ *
+ *  This program and the accompanying materials are made available under the
+ *  terms of the Apache License, Version 2.0 which is available at
+ *  https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Contributors:
+ *       Metaform Systems, Inc. - initial API and implementation
+ *
+ */
+plugins {
+    `java-library`
+    id(libs.plugins.swagger.get().pluginId)
+}
+
+dependencies {
+    api(project(":spi:v-auth-spi"))
+    implementation(libs.edc.spi.core)
+    implementation(libs.edc.spi.controlplane)
+    implementation(libs.edc.spi.asset)
+    implementation(libs.edc.spi.validator)
+    implementation(libs.edc.spi.web)
+    implementation(libs.edc.spi.transform)
+    implementation(libs.edc.lib.controlplane.transform)
+    implementation(libs.edc.lib.transform)
+    implementation(libs.jakarta.annotation)
+
+    implementation(libs.edc.lib.api)
+    implementation(libs.edc.lib.jersey.providers)
+    implementation(libs.edc.lib.mgmtapi)
+    implementation(libs.edc.lib.validator)
+
+    testImplementation(testFixtures(libs.edc.core.jersey))
+    testImplementation(libs.restAssured)
+    testImplementation(libs.awaitility)
+}
+
+edcBuild {
+    swagger {
+        apiGroup.set("management-api")
+    }
+}
+
+

--- a/extensions/control-plane/api/management-api/contract-negotiation-api/src/main/java/org/eclipse/edc/virtual/connector/controlplane/api/management/contractnegotiation/ContractNegotiationApiExtension.java
+++ b/extensions/control-plane/api/management-api/contract-negotiation-api/src/main/java/org/eclipse/edc/virtual/connector/controlplane/api/management/contractnegotiation/ContractNegotiationApiExtension.java
@@ -1,0 +1,115 @@
+/*
+ *  Copyright (c) 2025 Metaform Systems, Inc.
+ *
+ *  This program and the accompanying materials are made available under the
+ *  terms of the Apache License, Version 2.0 which is available at
+ *  https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Contributors:
+ *       Metaform Systems, Inc. - initial API and implementation
+ *
+ */
+
+package org.eclipse.edc.virtual.connector.controlplane.api.management.contractnegotiation;
+
+import jakarta.json.Json;
+import org.eclipse.edc.api.auth.spi.AuthorizationService;
+import org.eclipse.edc.api.management.schema.ManagementApiJsonSchema;
+import org.eclipse.edc.connector.controlplane.contract.spi.types.negotiation.ContractNegotiation;
+import org.eclipse.edc.connector.controlplane.services.spi.contractnegotiation.ContractNegotiationService;
+import org.eclipse.edc.connector.controlplane.transform.edc.contractnegotiation.from.JsonObjectFromContractNegotiationTransformer;
+import org.eclipse.edc.connector.controlplane.transform.edc.contractnegotiation.from.JsonObjectFromNegotiationStateTransformer;
+import org.eclipse.edc.connector.controlplane.transform.edc.contractnegotiation.to.JsonObjectToContractOfferTransformer;
+import org.eclipse.edc.connector.controlplane.transform.edc.contractnegotiation.to.JsonObjectToContractRequestTransformer;
+import org.eclipse.edc.connector.controlplane.transform.edc.contractnegotiation.to.JsonObjectToTerminateNegotiationCommandTransformer;
+import org.eclipse.edc.jsonld.spi.JsonLd;
+import org.eclipse.edc.participantcontext.spi.service.ParticipantContextService;
+import org.eclipse.edc.participantcontext.spi.types.ParticipantResource;
+import org.eclipse.edc.runtime.metamodel.annotation.Extension;
+import org.eclipse.edc.runtime.metamodel.annotation.Inject;
+import org.eclipse.edc.spi.query.Criterion;
+import org.eclipse.edc.spi.query.QuerySpec;
+import org.eclipse.edc.spi.system.ServiceExtension;
+import org.eclipse.edc.spi.system.ServiceExtensionContext;
+import org.eclipse.edc.spi.types.TypeManager;
+import org.eclipse.edc.transform.spi.TypeTransformerRegistry;
+import org.eclipse.edc.validator.spi.JsonObjectValidatorRegistry;
+import org.eclipse.edc.virtual.connector.controlplane.api.management.contractnegotiation.transform.JsonObjectFromContractAgreementTransformer;
+import org.eclipse.edc.virtual.connector.controlplane.api.management.contractnegotiation.v4.ContractNegotiationApiV4Controller;
+import org.eclipse.edc.web.jersey.providers.jsonld.JerseyJsonLdInterceptor;
+import org.eclipse.edc.web.spi.WebService;
+import org.eclipse.edc.web.spi.configuration.ApiContext;
+
+import java.util.Map;
+
+import static org.eclipse.edc.api.management.ManagementApi.MANAGEMENT_SCOPE_V4;
+import static org.eclipse.edc.participantcontext.spi.types.ParticipantResource.filterByParticipantContextId;
+import static org.eclipse.edc.spi.constants.CoreConstants.JSON_LD;
+
+@Extension(value = ContractNegotiationApiExtension.NAME)
+public class ContractNegotiationApiExtension implements ServiceExtension {
+
+    public static final String NAME = "Management API: Contract Negotiation";
+
+    @Inject
+    private WebService webService;
+
+    @Inject
+    private TypeTransformerRegistry transformerRegistry;
+
+    @Inject
+    private ContractNegotiationService service;
+
+    @Inject
+    private JsonObjectValidatorRegistry validatorRegistry;
+
+    @Inject
+    private JsonLd jsonLd;
+
+    @Inject
+    private TypeManager typeManager;
+
+    @Inject
+    private AuthorizationService authorizationService;
+
+    @Inject
+    private ParticipantContextService participantContextService;
+
+    @Override
+    public String name() {
+        return NAME;
+    }
+
+    @Override
+    public void initialize(ServiceExtensionContext context) {
+        var factory = Json.createBuilderFactory(Map.of());
+        var monitor = context.getMonitor();
+
+        var managementApiTransformerRegistry = transformerRegistry.forContext("management-api");
+
+        managementApiTransformerRegistry.register(new JsonObjectToContractRequestTransformer());
+        managementApiTransformerRegistry.register(new JsonObjectToContractOfferTransformer());
+        managementApiTransformerRegistry.register(new JsonObjectToTerminateNegotiationCommandTransformer());
+        managementApiTransformerRegistry.register(new JsonObjectFromContractNegotiationTransformer(factory));
+        managementApiTransformerRegistry.register(new JsonObjectFromNegotiationStateTransformer(factory));
+        managementApiTransformerRegistry.register(new JsonObjectFromContractAgreementTransformer(factory));
+
+        authorizationService.addLookupFunction(ContractNegotiation.class, this::findContractNegotiation);
+
+        webService.registerResource(ApiContext.MANAGEMENT, new ContractNegotiationApiV4Controller(service, participantContextService, authorizationService, managementApiTransformerRegistry, monitor));
+        webService.registerDynamicResource(ApiContext.MANAGEMENT, ContractNegotiationApiV4Controller.class, new JerseyJsonLdInterceptor(jsonLd, typeManager, JSON_LD, MANAGEMENT_SCOPE_V4, validatorRegistry, ManagementApiJsonSchema.V4.version()));
+    }
+
+    private ParticipantResource findContractNegotiation(String ownerId, String assetId) {
+        return service
+                .search(QuerySpec.Builder.newInstance()
+                        .filter(filterByParticipantContextId(ownerId))
+                        .filter(new Criterion("id", "=", assetId))
+                        .build()
+                )
+                .map(it -> it.stream().findFirst().orElse(null))
+                .orElse(f -> null);
+    }
+}

--- a/extensions/control-plane/api/management-api/contract-negotiation-api/src/main/java/org/eclipse/edc/virtual/connector/controlplane/api/management/contractnegotiation/transform/JsonObjectFromContractAgreementTransformer.java
+++ b/extensions/control-plane/api/management-api/contract-negotiation-api/src/main/java/org/eclipse/edc/virtual/connector/controlplane/api/management/contractnegotiation/transform/JsonObjectFromContractAgreementTransformer.java
@@ -1,0 +1,56 @@
+/*
+ *  Copyright (c) 2023 Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
+ *
+ *  This program and the accompanying materials are made available under the
+ *  terms of the Apache License, Version 2.0 which is available at
+ *  https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Contributors:
+ *       Bayerische Motoren Werke Aktiengesellschaft (BMW AG) - initial API and implementation
+ *
+ */
+
+package org.eclipse.edc.virtual.connector.controlplane.api.management.contractnegotiation.transform;
+
+import jakarta.json.JsonBuilderFactory;
+import jakarta.json.JsonObject;
+import org.eclipse.edc.connector.controlplane.contract.spi.types.agreement.ContractAgreement;
+import org.eclipse.edc.jsonld.spi.transformer.AbstractJsonLdTransformer;
+import org.eclipse.edc.transform.spi.TransformerContext;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+
+import static org.eclipse.edc.connector.controlplane.contract.spi.types.agreement.ContractAgreement.CONTRACT_AGREEMENT_ASSET_ID;
+import static org.eclipse.edc.connector.controlplane.contract.spi.types.agreement.ContractAgreement.CONTRACT_AGREEMENT_CONSUMER_ID;
+import static org.eclipse.edc.connector.controlplane.contract.spi.types.agreement.ContractAgreement.CONTRACT_AGREEMENT_ID;
+import static org.eclipse.edc.connector.controlplane.contract.spi.types.agreement.ContractAgreement.CONTRACT_AGREEMENT_POLICY;
+import static org.eclipse.edc.connector.controlplane.contract.spi.types.agreement.ContractAgreement.CONTRACT_AGREEMENT_PROVIDER_ID;
+import static org.eclipse.edc.connector.controlplane.contract.spi.types.agreement.ContractAgreement.CONTRACT_AGREEMENT_SIGNING_DATE;
+import static org.eclipse.edc.connector.controlplane.contract.spi.types.agreement.ContractAgreement.CONTRACT_AGREEMENT_TYPE;
+import static org.eclipse.edc.jsonld.spi.JsonLdKeywords.ID;
+import static org.eclipse.edc.jsonld.spi.JsonLdKeywords.TYPE;
+
+public class JsonObjectFromContractAgreementTransformer extends AbstractJsonLdTransformer<ContractAgreement, JsonObject> {
+    private final JsonBuilderFactory jsonFactory;
+
+    public JsonObjectFromContractAgreementTransformer(JsonBuilderFactory jsonFactory) {
+        super(ContractAgreement.class, JsonObject.class);
+        this.jsonFactory = jsonFactory;
+    }
+
+    @Override
+    public @Nullable JsonObject transform(@NotNull ContractAgreement agreement, @NotNull TransformerContext context) {
+        return jsonFactory.createObjectBuilder()
+                .add(TYPE, CONTRACT_AGREEMENT_TYPE)
+                .add(ID, agreement.getId())
+                .add(CONTRACT_AGREEMENT_ASSET_ID, agreement.getAssetId())
+                .add(CONTRACT_AGREEMENT_ID, agreement.getAgreementId())
+                .add(CONTRACT_AGREEMENT_POLICY, context.transform(agreement.getPolicy(), JsonObject.class))
+                .add(CONTRACT_AGREEMENT_SIGNING_DATE, agreement.getContractSigningDate())
+                .add(CONTRACT_AGREEMENT_CONSUMER_ID, agreement.getConsumerId())
+                .add(CONTRACT_AGREEMENT_PROVIDER_ID, agreement.getProviderId())
+                .build();
+    }
+}

--- a/extensions/control-plane/api/management-api/contract-negotiation-api/src/main/java/org/eclipse/edc/virtual/connector/controlplane/api/management/contractnegotiation/v4/ContractNegotiationApiV4.java
+++ b/extensions/control-plane/api/management-api/contract-negotiation-api/src/main/java/org/eclipse/edc/virtual/connector/controlplane/api/management/contractnegotiation/v4/ContractNegotiationApiV4.java
@@ -1,0 +1,125 @@
+/*
+ *  Copyright (c) 2025 Metaform Systems, Inc.
+ *
+ *  This program and the accompanying materials are made available under the
+ *  terms of the Apache License, Version 2.0 which is available at
+ *  https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Contributors:
+ *       Metaform Systems, Inc. - initial API and implementation
+ *
+ */
+
+package org.eclipse.edc.virtual.connector.controlplane.api.management.contractnegotiation.v4;
+
+import io.swagger.v3.oas.annotations.OpenAPIDefinition;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.info.Info;
+import io.swagger.v3.oas.annotations.links.Link;
+import io.swagger.v3.oas.annotations.links.LinkParameter;
+import io.swagger.v3.oas.annotations.media.ArraySchema;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.parameters.RequestBody;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.json.JsonArray;
+import jakarta.json.JsonObject;
+import jakarta.ws.rs.core.SecurityContext;
+import org.eclipse.edc.api.management.schema.ManagementApiJsonSchema;
+
+@OpenAPIDefinition(info = @Info(version = "v4alpha"))
+@Tag(name = "Contract Negotiation v4alpha")
+public interface ContractNegotiationApiV4 {
+
+    @Operation(description = "Returns all contract negotiations according to a query",
+            requestBody = @RequestBody(content = @Content(schema = @Schema(ref = ManagementApiJsonSchema.V4.QUERY_SPEC))),
+            responses = {
+                    @ApiResponse(responseCode = "200", description = "The contract negotiations that match the query",
+                            content = @Content(array = @ArraySchema(schema = @Schema(ref = ManagementApiJsonSchema.V4.CONTRACT_NEGOTIATION)))),
+                    @ApiResponse(responseCode = "400", description = "Request was malformed",
+                            content = @Content(array = @ArraySchema(schema = @Schema(ref = ManagementApiJsonSchema.V4.API_ERROR))))}
+    )
+    JsonArray queryNegotiationsV4(String participantContextId, JsonObject querySpecJson, SecurityContext securityContext);
+
+    @Operation(description = "Gets a contract negotiation with the given ID",
+            responses = {
+                    @ApiResponse(responseCode = "200", description = "The contract negotiation",
+                            content = @Content(schema = @Schema(ref = ManagementApiJsonSchema.V4.CONTRACT_NEGOTIATION))),
+                    @ApiResponse(responseCode = "400", description = "Request was malformed, e.g. id was null",
+                            content = @Content(array = @ArraySchema(schema = @Schema(ref = ManagementApiJsonSchema.V4.API_ERROR)))),
+                    @ApiResponse(responseCode = "404", description = "An contract negotiation with the given ID does not exist",
+                            content = @Content(array = @ArraySchema(schema = @Schema(ref = ManagementApiJsonSchema.V4.API_ERROR))))
+            }
+    )
+    JsonObject getNegotiationV4(String participantContextId, String id, SecurityContext securityContext);
+
+    @Operation(description = "Gets the state of a contract negotiation with the given ID",
+            responses = {
+                    @ApiResponse(responseCode = "200", description = "The contract negotiation's state",
+                            content = @Content(schema = @Schema(ref = ManagementApiJsonSchema.V4.CONTRACT_NEGOTIATION_STATE))),
+                    @ApiResponse(responseCode = "400", description = "Request was malformed, e.g. id was null",
+                            content = @Content(array = @ArraySchema(schema = @Schema(ref = ManagementApiJsonSchema.V4.API_ERROR)))),
+                    @ApiResponse(responseCode = "404", description = "An contract negotiation with the given ID does not exist",
+                            content = @Content(array = @ArraySchema(schema = @Schema(ref = ManagementApiJsonSchema.V4.API_ERROR))))
+            }
+    )
+    JsonObject getNegotiationStateV4(String participantContextId, String id, SecurityContext securityContext);
+
+    @Operation(description = "Gets a contract agreement for a contract negotiation with the given ID",
+            responses = {
+                    @ApiResponse(responseCode = "200", description = "The contract agreement that is attached to the negotiation, or null",
+                            content = @Content(schema = @Schema(ref = ManagementApiJsonSchema.V4.CONTRACT_AGREEMENT))),
+                    @ApiResponse(responseCode = "400", description = "Request was malformed, e.g. id was null",
+                            content = @Content(array = @ArraySchema(schema = @Schema(ref = ManagementApiJsonSchema.V4.API_ERROR)))),
+                    @ApiResponse(responseCode = "404", description = "An contract negotiation with the given ID does not exist",
+                            content = @Content(array = @ArraySchema(schema = @Schema(ref = ManagementApiJsonSchema.V4.API_ERROR))))
+            }
+    )
+    JsonObject getAgreementForNegotiationV4(String participantContextId, String negotiationId, SecurityContext securityContext);
+
+    @Operation(description = "Initiates a contract negotiation for a given offer and with the given counter part. Please note that successfully invoking this endpoint " +
+            "only means that the negotiation was initiated. Clients must poll the /{id}/state endpoint to track the state",
+            requestBody = @RequestBody(content = @Content(schema = @Schema(ref = ManagementApiJsonSchema.V4.CONTRACT_REQUEST))),
+            responses = {
+                    @ApiResponse(responseCode = "200", description = "The negotiation was successfully initiated. Returns the contract negotiation ID and created timestamp",
+                            content = @Content(schema = @Schema(ref = ManagementApiJsonSchema.V4.ID_RESPONSE)),
+                            links = @Link(name = "poll-state", operationId = "getNegotiationStateV3", parameters = {
+                                    @LinkParameter(name = "id", expression = "$response.body#/id")
+                            })
+                    ),
+                    @ApiResponse(responseCode = "400", description = "Request body was malformed",
+                            content = @Content(array = @ArraySchema(schema = @Schema(ref = ManagementApiJsonSchema.V4.API_ERROR)))),
+            })
+    JsonObject initiateContractNegotiationV4(String participantContextId, JsonObject requestDto, SecurityContext securityContext);
+
+    @Operation(description = "Terminates the contract negotiation.",
+            requestBody = @RequestBody(content = @Content(schema = @Schema(ref = ManagementApiJsonSchema.V4.TERMINATE_NEGOTIATION))),
+            responses = {
+                    @ApiResponse(responseCode = "200", description = "ContractNegotiation is terminating",
+                            links = @Link(name = "poll-state", operationId = "getNegotiationStateV3")),
+                    @ApiResponse(responseCode = "400", description = "Request was malformed",
+                            content = @Content(array = @ArraySchema(schema = @Schema(ref = ManagementApiJsonSchema.V4.API_ERROR)))),
+                    @ApiResponse(responseCode = "404", description = "A contract negotiation with the given ID does not exist",
+                            content = @Content(array = @ArraySchema(schema = @Schema(ref = ManagementApiJsonSchema.V4.API_ERROR))))
+            }
+    )
+    void terminateNegotiationV4(String participantContextId, String id, JsonObject terminateNegotiation, SecurityContext securityContext);
+
+    @Operation(description = "Deletes the contract negotiation with the given ID. Only terminated negotiations without agreement will be deleted",
+            responses = {
+                    @ApiResponse(responseCode = "204", description = "ContractNegotiation is deleted",
+                            links = @Link(name = "poll-state", operationId = "getNegotiationStateV3")),
+                    @ApiResponse(responseCode = "400", description = "Request was malformed, e.g. id was null",
+                            content = @Content(array = @ArraySchema(schema = @Schema(ref = ManagementApiJsonSchema.V4.API_ERROR)))),
+                    @ApiResponse(responseCode = "404", description = "A contract negotiation with the given ID does not exist",
+                            content = @Content(array = @ArraySchema(schema = @Schema(ref = ManagementApiJsonSchema.V4.API_ERROR)))),
+                    @ApiResponse(responseCode = "409", description = "The given contract negotiation cannot be deleted due to a wrong state or has existing contract agreement",
+                            content = @Content(array = @ArraySchema(schema = @Schema(ref = ManagementApiJsonSchema.V4.API_ERROR))))
+            }
+    )
+    void deleteNegotiationV4(String participantContextId, String id, SecurityContext securityContext);
+
+}

--- a/extensions/control-plane/api/management-api/contract-negotiation-api/src/main/java/org/eclipse/edc/virtual/connector/controlplane/api/management/contractnegotiation/v4/ContractNegotiationApiV4Controller.java
+++ b/extensions/control-plane/api/management-api/contract-negotiation-api/src/main/java/org/eclipse/edc/virtual/connector/controlplane/api/management/contractnegotiation/v4/ContractNegotiationApiV4Controller.java
@@ -1,0 +1,232 @@
+/*
+ *  Copyright (c) 2025 Metaform Systems, Inc.
+ *
+ *  This program and the accompanying materials are made available under the
+ *  terms of the Apache License, Version 2.0 which is available at
+ *  https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Contributors:
+ *       Metaform Systems, Inc. - initial API and implementation
+ *
+ */
+
+package org.eclipse.edc.virtual.connector.controlplane.api.management.contractnegotiation.v4;
+
+import jakarta.annotation.security.RolesAllowed;
+import jakarta.json.JsonArray;
+import jakarta.json.JsonObject;
+import jakarta.ws.rs.Consumes;
+import jakarta.ws.rs.DELETE;
+import jakarta.ws.rs.GET;
+import jakarta.ws.rs.POST;
+import jakarta.ws.rs.Path;
+import jakarta.ws.rs.PathParam;
+import jakarta.ws.rs.Produces;
+import jakarta.ws.rs.core.Context;
+import jakarta.ws.rs.core.SecurityContext;
+import org.eclipse.edc.api.auth.spi.AuthorizationService;
+import org.eclipse.edc.api.auth.spi.ParticipantPrincipal;
+import org.eclipse.edc.api.auth.spi.RequiredScope;
+import org.eclipse.edc.api.model.IdResponse;
+import org.eclipse.edc.connector.controlplane.contract.spi.types.command.TerminateNegotiationCommand;
+import org.eclipse.edc.connector.controlplane.contract.spi.types.negotiation.ContractNegotiation;
+import org.eclipse.edc.connector.controlplane.contract.spi.types.negotiation.ContractRequest;
+import org.eclipse.edc.connector.controlplane.contract.spi.types.negotiation.NegotiationState;
+import org.eclipse.edc.connector.controlplane.services.spi.contractnegotiation.ContractNegotiationService;
+import org.eclipse.edc.participantcontext.spi.service.ParticipantContextService;
+import org.eclipse.edc.participantcontext.spi.types.ParticipantContext;
+import org.eclipse.edc.spi.EdcException;
+import org.eclipse.edc.spi.monitor.Monitor;
+import org.eclipse.edc.spi.query.QuerySpec;
+import org.eclipse.edc.spi.result.Result;
+import org.eclipse.edc.transform.spi.TypeTransformerRegistry;
+import org.eclipse.edc.web.spi.exception.InvalidRequestException;
+import org.eclipse.edc.web.spi.exception.ObjectNotFoundException;
+import org.eclipse.edc.web.spi.validation.SchemaType;
+
+import java.util.Optional;
+
+import static jakarta.json.stream.JsonCollectors.toJsonArray;
+import static jakarta.ws.rs.core.MediaType.APPLICATION_JSON;
+import static org.eclipse.edc.connector.controlplane.contract.spi.types.command.TerminateNegotiationCommand.TERMINATE_NEGOTIATION_TYPE_TERM;
+import static org.eclipse.edc.connector.controlplane.contract.spi.types.negotiation.ContractRequest.CONTRACT_REQUEST_TYPE_TERM;
+import static org.eclipse.edc.participantcontext.spi.types.ParticipantResource.filterByParticipantContextId;
+import static org.eclipse.edc.spi.query.QuerySpec.EDC_QUERY_SPEC_TYPE_TERM;
+import static org.eclipse.edc.web.spi.exception.ServiceResultHandler.exceptionMapper;
+
+@Consumes(APPLICATION_JSON)
+@Produces(APPLICATION_JSON)
+@Path("/v4alpha/participants/{participantContextId}/contractnegotiations")
+public class ContractNegotiationApiV4Controller implements ContractNegotiationApiV4 {
+    private final ContractNegotiationService service;
+    private final ParticipantContextService participantContextService;
+    private final AuthorizationService authorizationService;
+    private final TypeTransformerRegistry transformerRegistry;
+    private final Monitor monitor;
+
+    public ContractNegotiationApiV4Controller(ContractNegotiationService service, ParticipantContextService participantContextService, AuthorizationService authorizationService, TypeTransformerRegistry transformerRegistry, Monitor monitor) {
+        this.service = service;
+        this.participantContextService = participantContextService;
+        this.authorizationService = authorizationService;
+        this.transformerRegistry = transformerRegistry;
+        this.monitor = monitor;
+    }
+
+    @POST
+    @Path("/request")
+    @RolesAllowed({ParticipantPrincipal.ROLE_ADMIN, ParticipantPrincipal.ROLE_PARTICIPANT})
+    @RequiredScope("management-api:read")
+    @Override
+    public JsonArray queryNegotiationsV4(@PathParam("participantContextId") String participantContextId,
+                                         @SchemaType(EDC_QUERY_SPEC_TYPE_TERM) JsonObject querySpecJson,
+                                         @Context SecurityContext securityContext) {
+
+        authorizationService.authorize(securityContext, participantContextId, participantContextId, ParticipantContext.class)
+                .orElseThrow(exceptionMapper(ParticipantContext.class, participantContextId));
+
+        QuerySpec querySpec;
+        if (querySpecJson == null) {
+            querySpec = QuerySpec.Builder.newInstance().build();
+        } else {
+            querySpec = transformerRegistry.transform(querySpecJson, QuerySpec.class)
+                    .orElseThrow(InvalidRequestException::new);
+        }
+
+        var query = querySpec.toBuilder()
+                .filter(filterByParticipantContextId(participantContextId))
+                .build();
+
+        return service.search(query).orElseThrow(exceptionMapper(ContractNegotiation.class, null)).stream()
+                .map(it -> transformerRegistry.transform(it, JsonObject.class))
+                .peek(this::logIfError)
+                .filter(Result::succeeded)
+                .map(Result::getContent)
+                .collect(toJsonArray());
+    }
+
+    @GET
+    @Path("/{id}")
+    @RolesAllowed({ParticipantPrincipal.ROLE_ADMIN, ParticipantPrincipal.ROLE_PARTICIPANT})
+    @RequiredScope("management-api:read")
+    @Override
+    public JsonObject getNegotiationV4(@PathParam("participantContextId") String participantContextId,
+                                       @PathParam("id") String id,
+                                       @Context SecurityContext securityContext) {
+
+        authorizationService.authorize(securityContext, participantContextId, id, ContractNegotiation.class)
+                .orElseThrow(exceptionMapper(ContractNegotiation.class, id));
+
+        return Optional.of(id)
+                .map(service::findbyId)
+                .map(it -> transformerRegistry.transform(it, JsonObject.class))
+                .map(Result::getContent)
+                .orElseThrow(() -> new ObjectNotFoundException(ContractNegotiation.class, id));
+    }
+
+    @GET
+    @Path("/{id}/state")
+    @RolesAllowed({ParticipantPrincipal.ROLE_ADMIN, ParticipantPrincipal.ROLE_PARTICIPANT})
+    @RequiredScope("management-api:read")
+    @Override
+    public JsonObject getNegotiationStateV4(@PathParam("participantContextId") String participantContextId,
+                                            @PathParam("id") String id,
+                                            @Context SecurityContext securityContext) {
+
+        authorizationService.authorize(securityContext, participantContextId, id, ContractNegotiation.class)
+                .orElseThrow(exceptionMapper(ContractNegotiation.class, id));
+
+        return Optional.of(id)
+                .map(service::getState)
+                .map(NegotiationState::new)
+                .map(state -> transformerRegistry.transform(state, JsonObject.class))
+                .orElseThrow(() -> new ObjectNotFoundException(ContractNegotiation.class, id))
+                .orElseThrow(failure -> new EdcException(failure.getFailureDetail()));
+    }
+
+    @GET
+    @Path("/{id}/agreement")
+    @RolesAllowed({ParticipantPrincipal.ROLE_ADMIN, ParticipantPrincipal.ROLE_PARTICIPANT})
+    @RequiredScope("management-api:read")
+    @Override
+    public JsonObject getAgreementForNegotiationV4(@PathParam("participantContextId") String participantContextId,
+                                                   @PathParam("id") String negotiationId,
+                                                   @Context SecurityContext securityContext) {
+        authorizationService.authorize(securityContext, participantContextId, negotiationId, ContractNegotiation.class)
+                .orElseThrow(exceptionMapper(ContractNegotiation.class, negotiationId));
+
+        return Optional.of(negotiationId)
+                .map(service::getForNegotiation)
+                .map(it -> transformerRegistry.transform(it, JsonObject.class)
+                        .orElseThrow(failure -> new EdcException(failure.getFailureDetail())))
+                .orElseThrow(() -> new ObjectNotFoundException(ContractNegotiation.class, negotiationId));
+    }
+
+    @POST
+    @RolesAllowed({ParticipantPrincipal.ROLE_ADMIN, ParticipantPrincipal.ROLE_PARTICIPANT})
+    @RequiredScope("management-api:write")
+    @Override
+    public JsonObject initiateContractNegotiationV4(@PathParam("participantContextId") String participantContextId,
+                                                    @SchemaType(CONTRACT_REQUEST_TYPE_TERM) JsonObject requestObject,
+                                                    @Context SecurityContext securityContext) {
+
+
+        authorizationService.authorize(securityContext, participantContextId, participantContextId, ParticipantContext.class)
+                .orElseThrow(exceptionMapper(ParticipantContext.class, participantContextId));
+
+        var contractRequest = transformerRegistry.transform(requestObject, ContractRequest.class)
+                .orElseThrow(InvalidRequestException::new);
+
+        var participantContext = participantContextService.getParticipantContext(participantContextId)
+                .orElseThrow(exceptionMapper(ParticipantContext.class, participantContextId));
+
+        var contractNegotiation = service.initiateNegotiation(participantContext, contractRequest);
+
+        var responseDto = IdResponse.Builder.newInstance()
+                .id(contractNegotiation.getId())
+                .createdAt(contractNegotiation.getCreatedAt())
+                .build();
+
+        return transformerRegistry.transform(responseDto, JsonObject.class)
+                .orElseThrow(f -> new EdcException("Error creating response body: " + f.getFailureDetail()));
+    }
+
+    @POST
+    @Path("/{id}/terminate")
+    @RolesAllowed({ParticipantPrincipal.ROLE_ADMIN, ParticipantPrincipal.ROLE_PARTICIPANT})
+    @RequiredScope("management-api:write")
+    @Override
+    public void terminateNegotiationV4(@PathParam("participantContextId") String participantContextId,
+                                       @PathParam("id") String id,
+                                       @SchemaType(TERMINATE_NEGOTIATION_TYPE_TERM) JsonObject terminateNegotiation,
+                                       @Context SecurityContext securityContext) {
+
+        authorizationService.authorize(securityContext, participantContextId, id, ContractNegotiation.class)
+                .orElseThrow(exceptionMapper(ContractNegotiation.class, id));
+
+        var command = transformerRegistry.transform(terminateNegotiation, TerminateNegotiationCommand.class)
+                .orElseThrow(InvalidRequestException::new);
+
+        service.terminate(command).orElseThrow(exceptionMapper(ContractNegotiation.class, id));
+    }
+
+    @DELETE
+    @Path("/{id}")
+    @RolesAllowed({ParticipantPrincipal.ROLE_ADMIN, ParticipantPrincipal.ROLE_PARTICIPANT})
+    @RequiredScope("management-api:write")
+    @Override
+    public void deleteNegotiationV4(@PathParam("participantContextId") String participantContextId,
+                                    @PathParam("id") String id,
+                                    @Context SecurityContext securityContext) {
+
+        authorizationService.authorize(securityContext, participantContextId, id, ContractNegotiation.class)
+                .orElseThrow(exceptionMapper(ContractNegotiation.class, id));
+
+        service.delete(id).orElseThrow(exceptionMapper(ContractNegotiation.class, id));
+    }
+
+    private void logIfError(Result<?> result) {
+        result.onFailure(f -> monitor.warning(f.getFailureDetail()));
+    }
+}

--- a/extensions/control-plane/api/management-api/contract-negotiation-api/src/main/resources/META-INF/services/org.eclipse.edc.spi.system.ServiceExtension
+++ b/extensions/control-plane/api/management-api/contract-negotiation-api/src/main/resources/META-INF/services/org.eclipse.edc.spi.system.ServiceExtension
@@ -1,0 +1,15 @@
+#
+#  Copyright (c) 2025 Metaform Systems, Inc.
+#
+#  This program and the accompanying materials are made available under the
+#  terms of the Apache License, Version 2.0 which is available at
+#  https://www.apache.org/licenses/LICENSE-2.0
+#
+#  SPDX-License-Identifier: Apache-2.0
+#
+#  Contributors:
+#       Metaform Systems, Inc. - initial API and implementation
+#
+#
+
+org.eclipse.edc.virtual.connector.controlplane.api.management.contractnegotiation.ContractNegotiationApiExtension

--- a/extensions/control-plane/api/management-api/contract-negotiation-api/src/test/java/org/eclipse/edc/virtual/connector/controlplane/api/management/contractnegotiation/ContractNegotiationApiControllerTestBase.java
+++ b/extensions/control-plane/api/management-api/contract-negotiation-api/src/test/java/org/eclipse/edc/virtual/connector/controlplane/api/management/contractnegotiation/ContractNegotiationApiControllerTestBase.java
@@ -1,0 +1,506 @@
+/*
+ *  Copyright (c) 2025 Metaform Systems, Inc.
+ *
+ *  This program and the accompanying materials are made available under the
+ *  terms of the Apache License, Version 2.0 which is available at
+ *  https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Contributors:
+ *       Metaform Systems, Inc. - initial API and implementation
+ *
+ */
+
+package org.eclipse.edc.virtual.connector.controlplane.api.management.contractnegotiation;
+
+import io.restassured.specification.RequestSpecification;
+import jakarta.json.Json;
+import jakarta.json.JsonObject;
+import org.eclipse.edc.api.auth.spi.AuthorizationService;
+import org.eclipse.edc.api.model.IdResponse;
+import org.eclipse.edc.connector.controlplane.contract.spi.types.agreement.ContractAgreement;
+import org.eclipse.edc.connector.controlplane.contract.spi.types.command.TerminateNegotiationCommand;
+import org.eclipse.edc.connector.controlplane.contract.spi.types.negotiation.ContractNegotiation;
+import org.eclipse.edc.connector.controlplane.contract.spi.types.negotiation.ContractNegotiationStates;
+import org.eclipse.edc.connector.controlplane.contract.spi.types.negotiation.ContractRequest;
+import org.eclipse.edc.connector.controlplane.contract.spi.types.negotiation.NegotiationState;
+import org.eclipse.edc.connector.controlplane.contract.spi.types.offer.ContractOffer;
+import org.eclipse.edc.connector.controlplane.services.spi.contractnegotiation.ContractNegotiationService;
+import org.eclipse.edc.participantcontext.spi.service.ParticipantContextService;
+import org.eclipse.edc.participantcontext.spi.types.ParticipantContext;
+import org.eclipse.edc.policy.model.Policy;
+import org.eclipse.edc.spi.query.QuerySpec;
+import org.eclipse.edc.spi.result.Result;
+import org.eclipse.edc.spi.result.ServiceResult;
+import org.eclipse.edc.spi.types.domain.callback.CallbackAddress;
+import org.eclipse.edc.transform.spi.TypeTransformerRegistry;
+import org.eclipse.edc.web.jersey.testfixtures.RestControllerTestBase;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+
+import static io.restassured.RestAssured.given;
+import static io.restassured.http.ContentType.JSON;
+import static jakarta.json.Json.createObjectBuilder;
+import static java.lang.String.format;
+import static java.util.UUID.randomUUID;
+import static org.eclipse.edc.api.model.IdResponse.ID_RESPONSE_TYPE;
+import static org.eclipse.edc.connector.controlplane.contract.spi.types.negotiation.NegotiationState.NEGOTIATION_STATE_TYPE;
+import static org.eclipse.edc.jsonld.spi.JsonLdKeywords.ID;
+import static org.eclipse.edc.jsonld.spi.JsonLdKeywords.TYPE;
+import static org.eclipse.edc.jsonld.spi.JsonLdKeywords.VOCAB;
+import static org.eclipse.edc.spi.constants.CoreConstants.EDC_NAMESPACE;
+import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.notNullValue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.contains;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
+import static org.mockito.Mockito.verifyNoMoreInteractions;
+import static org.mockito.Mockito.when;
+
+public abstract class ContractNegotiationApiControllerTestBase extends RestControllerTestBase {
+    protected final ContractNegotiationService service = mock();
+    protected final TypeTransformerRegistry transformerRegistry = mock();
+    protected final AuthorizationService authorizationService = mock();
+    protected final ParticipantContextService participantContextService = mock();
+    private final String participantContextId = "test-participant-context-id";
+
+    @BeforeEach
+    void setup() {
+        when(authorizationService.authorize(any(), any(), any(), any())).thenReturn(ServiceResult.success());
+    }
+
+    private RequestSpecification baseRequest(String participantContextId) {
+        return given()
+                .baseUri("http://localhost:" + port + "/" + versionPath() + "/participants/" + participantContextId)
+                .when();
+    }
+
+    protected abstract String versionPath();
+
+    private ContractNegotiation createContractNegotiation(String negotiationId) {
+        return createContractNegotiationBuilder(negotiationId)
+                .build();
+    }
+
+    private ContractAgreement createContractAgreement(String negotiationId) {
+        return ContractAgreement.Builder.newInstance()
+                .id(negotiationId)
+                .consumerId("test-consumer")
+                .providerId("test-provider")
+                .assetId(randomUUID().toString())
+                .policy(Policy.Builder.newInstance().build())
+                .build();
+    }
+
+    private ContractNegotiation.Builder createContractNegotiationBuilder(String negotiationId) {
+        return ContractNegotiation.Builder.newInstance()
+                .id(negotiationId)
+                .counterPartyId(randomUUID().toString())
+                .counterPartyAddress("address")
+                .callbackAddresses(List.of(CallbackAddress.Builder.newInstance()
+                        .uri("local://test")
+                        .build()))
+                .protocol("protocol");
+    }
+
+    @Nested
+    class Delete {
+
+        @Test
+        void delete_shouldCallService() {
+            when(service.delete(any())).thenReturn(ServiceResult.success());
+
+            baseRequest(participantContextId)
+                    .contentType(JSON)
+                    .delete("/contractnegotiations/cn1")
+                    .then()
+                    .statusCode(204);
+
+            verify(service).delete("cn1");
+        }
+
+        @Test
+        void delete_shouldFailDueToWrongState() {
+            when(service.delete(any())).thenReturn(ServiceResult.conflict(format("Cannot delete negotiation in state: %s".formatted(ContractNegotiationStates.AGREED.name()))));
+
+            baseRequest(participantContextId)
+                    .contentType(JSON)
+                    .delete("/contractnegotiations/cn1")
+                    .then()
+                    .statusCode(409);
+
+            verify(service).delete("cn1");
+        }
+
+        @Test
+        void delete_shouldFailDueToNegotiationNotFound() {
+            when(service.delete(any())).thenReturn(ServiceResult.notFound("ContractNegotiation negotiationId not found"));
+
+            baseRequest(participantContextId)
+                    .contentType(JSON)
+                    .delete("/contractnegotiations/cn1")
+                    .then()
+                    .statusCode(404);
+
+            verify(service).delete("cn1");
+        }
+    }
+
+    @Nested
+    class Terminate {
+
+        @Test
+        void terminate_shouldCallService() {
+            var command = new TerminateNegotiationCommand("id", "reason");
+            when(transformerRegistry.transform(any(JsonObject.class), eq(TerminateNegotiationCommand.class))).thenReturn(Result.success(command));
+            when(service.terminate(any())).thenReturn(ServiceResult.success());
+
+            baseRequest(participantContextId)
+                    .body(Json.createObjectBuilder().add(ID, "id").build())
+                    .contentType(JSON)
+                    .post("/contractnegotiations/cn1/terminate")
+                    .then()
+                    .statusCode(204);
+
+            verify(service).terminate(command);
+        }
+
+        @Test
+        void terminate_shouldReturnBadRequest_whenTransformerFails() {
+            when(transformerRegistry.transform(any(JsonObject.class), eq(TerminateNegotiationCommand.class))).thenReturn(Result.failure("error"));
+
+            baseRequest(participantContextId)
+                    .body(Json.createObjectBuilder().add(ID, "id").build())
+                    .contentType(JSON)
+                    .post("/contractnegotiations/cn1/terminate")
+                    .then()
+                    .statusCode(400);
+
+            verifyNoInteractions(service);
+        }
+
+        @Test
+        void terminate_shouldReturnError_whenServiceFails() {
+            var command = new TerminateNegotiationCommand("id", "reason");
+            when(transformerRegistry.transform(any(JsonObject.class), eq(TerminateNegotiationCommand.class))).thenReturn(Result.success(command));
+            when(service.terminate(any())).thenReturn(ServiceResult.conflict("conflict"));
+
+            baseRequest(participantContextId)
+                    .body(Json.createObjectBuilder().add(ID, "id").build())
+                    .contentType(JSON)
+                    .post("/contractnegotiations/cn1/terminate")
+                    .then()
+                    .statusCode(409);
+        }
+
+    }
+
+    @Nested
+    class Initiate {
+
+        @Test
+        void initiate() {
+            var contractNegotiation = createContractNegotiation("cn1");
+            var responseBody = createObjectBuilder().add(TYPE, ID_RESPONSE_TYPE).add(ID, contractNegotiation.getId()).build();
+
+            when(transformerRegistry.transform(any(JsonObject.class), eq(ContractRequest.class))).thenReturn(Result.success(
+                    ContractRequest.Builder.newInstance()
+                            .protocol("test-protocol")
+                            .counterPartyAddress("test-cb")
+                            .contractOffer(ContractOffer.Builder.newInstance()
+                                    .id("test-offer-id")
+                                    .assetId(randomUUID().toString())
+                                    .policy(Policy.Builder.newInstance().build())
+                                    .build())
+                            .build()));
+
+            when(participantContextService.getParticipantContext(any())).thenReturn(ServiceResult.success(ParticipantContext.Builder.newInstance().participantContextId(participantContextId).build()));
+            when(transformerRegistry.transform(any(), eq(JsonObject.class))).thenReturn(Result.success(responseBody));
+            when(service.initiateNegotiation(any(ParticipantContext.class), any(ContractRequest.class))).thenReturn(contractNegotiation);
+
+            when(transformerRegistry.transform(any(IdResponse.class), eq(JsonObject.class))).thenReturn(Result.success(responseBody));
+
+            baseRequest(participantContextId)
+                    .contentType(JSON)
+                    .body(createObjectBuilder().build())
+                    .post("/contractnegotiations")
+                    .then()
+                    .statusCode(200)
+                    .body(ID, is(contractNegotiation.getId()));
+
+            verify(service).initiateNegotiation(any(), any());
+            verify(transformerRegistry).transform(any(JsonObject.class), eq(ContractRequest.class));
+            verify(transformerRegistry).transform(any(IdResponse.class), eq(JsonObject.class));
+            verifyNoMoreInteractions(transformerRegistry, service);
+        }
+
+        @Test
+        void initiate_invalidRequest() {
+            when(transformerRegistry.transform(any(JsonObject.class), any())).thenReturn(Result.failure("test-failure"));
+
+            baseRequest(participantContextId)
+                    .contentType(JSON)
+                    .body(createObjectBuilder().build())
+                    .post("/contractnegotiations")
+                    .then()
+                    .statusCode(400);
+            verifyNoMoreInteractions(service);
+        }
+    }
+
+    @Nested
+    class FindAgreement {
+
+        @Test
+        void getAgreement() {
+            when(service.getForNegotiation(eq("cn1"))).thenReturn(createContractAgreement("cn1"));
+            when(transformerRegistry.transform(any(ContractAgreement.class), eq(JsonObject.class)))
+                    .thenReturn(Result.success(createObjectBuilder().build()));
+
+            baseRequest(participantContextId)
+                    .get("/contractnegotiations/cn1/agreement")
+                    .then()
+                    .statusCode(200)
+                    .contentType(JSON)
+                    .body(notNullValue());
+
+            verify(service).getForNegotiation(eq("cn1"));
+            verify(transformerRegistry).transform(any(ContractAgreement.class), eq(JsonObject.class));
+            verifyNoMoreInteractions(transformerRegistry, service);
+        }
+
+        @Test
+        void getAgreement_transformationFails() {
+            when(service.getForNegotiation(eq("cn1"))).thenReturn(createContractAgreement("cn1"));
+            when(transformerRegistry.transform(any(ContractAgreement.class), eq(JsonObject.class)))
+                    .thenReturn(Result.failure("test-failure"));
+
+            baseRequest(participantContextId)
+                    .get("/contractnegotiations/cn1/agreement")
+                    .then()
+                    .statusCode(500);
+
+            verify(service).getForNegotiation(eq("cn1"));
+            verify(transformerRegistry).transform(any(ContractAgreement.class), eq(JsonObject.class));
+            verifyNoMoreInteractions(transformerRegistry, service);
+        }
+
+        @Test
+        void getAgreement_whenNoneFound() {
+            when(service.getForNegotiation(eq("cn1"))).thenReturn(null);
+
+            baseRequest(participantContextId)
+                    .get("/contractnegotiations/cn1/agreement")
+                    .then()
+                    .statusCode(404)
+                    .contentType(JSON)
+                    .body(notNullValue());
+
+            verify(service).getForNegotiation(eq("cn1"));
+            verifyNoMoreInteractions(transformerRegistry, service);
+        }
+
+    }
+
+    @Nested
+    class FindById {
+
+        @Test
+        void getById() {
+            when(service.findbyId(anyString())).thenReturn(createContractNegotiation("cn1"));
+            when(transformerRegistry.transform(any(ContractNegotiation.class), eq(JsonObject.class)))
+                    .thenReturn(Result.success(createObjectBuilder().build()));
+
+            baseRequest(participantContextId)
+                    .get("/contractnegotiations/cn1")
+                    .then()
+                    .statusCode(200)
+                    .contentType(JSON)
+                    .body(notNullValue());
+
+            verify(service).findbyId(anyString());
+            verify(transformerRegistry).transform(any(ContractNegotiation.class), eq(JsonObject.class));
+        }
+
+        @Test
+        void getById_notFound() {
+            when(service.findbyId(anyString())).thenReturn(null);
+
+            baseRequest(participantContextId)
+                    .get("/contractnegotiations/cn1")
+                    .then()
+                    .statusCode(404)
+                    .contentType(JSON)
+                    .body(notNullValue());
+
+            verify(service).findbyId(anyString());
+            verifyNoInteractions(transformerRegistry);
+        }
+
+        @Test
+        void getById_transformationFails() {
+            when(service.findbyId(eq("cn1"))).thenReturn(createContractNegotiation("cn1"));
+            when(transformerRegistry.transform(any(ContractNegotiation.class), eq(JsonObject.class)))
+                    .thenReturn(Result.failure("test-failure"));
+
+            baseRequest(participantContextId)
+                    .get("/contractnegotiations/cn1")
+                    .then()
+                    .statusCode(404)
+                    .contentType(JSON)
+                    .body(notNullValue());
+
+            verify(service).findbyId(anyString());
+            verify(transformerRegistry).transform(any(ContractNegotiation.class), eq(JsonObject.class));
+        }
+
+        @Test
+        void getById_onlyState() {
+            var compacted = createObjectBuilder()
+                    .add(VOCAB, EDC_NAMESPACE)
+                    .add(TYPE, NEGOTIATION_STATE_TYPE)
+                    .add("state", "REQUESTED")
+                    .build();
+
+            when(service.getState(eq("cn1"))).thenReturn("REQUESTED");
+            when(transformerRegistry.transform(any(NegotiationState.class), eq(JsonObject.class)))
+                    .thenReturn(Result.success(compacted));
+
+            baseRequest(participantContextId)
+                    .get("/contractnegotiations/cn1/state")
+                    .then()
+                    .statusCode(200)
+                    .contentType(JSON)
+                    .body("state", is("REQUESTED"));
+            verify(service).getState(eq("cn1"));
+            verify(transformerRegistry).transform(any(NegotiationState.class), eq(JsonObject.class));
+            verifyNoMoreInteractions(service, transformerRegistry);
+        }
+    }
+
+    @Nested
+    class Query {
+
+        @Test
+        void query() {
+            when(service.search(any(QuerySpec.class))).thenReturn(ServiceResult.success(List.of(
+                    createContractNegotiation("cn1"),
+                    createContractNegotiation("cn2")
+            )));
+            var responseBody = createObjectBuilder().add(ID, "cn").build();
+
+            when(transformerRegistry.transform(any(ContractNegotiation.class), eq(JsonObject.class)))
+                    .thenReturn(Result.success(responseBody));
+
+            baseRequest(participantContextId)
+                    .contentType(JSON)
+                    .post("/contractnegotiations/request")
+                    .then()
+                    .statusCode(200)
+                    .contentType(JSON)
+                    .body("size()", is(2));
+
+            verify(service).search(any(QuerySpec.class));
+            verify(transformerRegistry, times(2)).transform(any(ContractNegotiation.class), eq(JsonObject.class));
+        }
+
+
+        @Test
+        void query_queryTransformationFails() {
+            when(service.search(any(QuerySpec.class))).thenReturn(ServiceResult.success(List.of(
+                    createContractNegotiation("cn1"),
+                    createContractNegotiation("cn2")
+            )));
+            when(transformerRegistry.transform(any(JsonObject.class), eq(QuerySpec.class))).thenReturn(Result.failure("test-failure"));
+
+            var requestBody = createObjectBuilder().build();
+            baseRequest(participantContextId)
+                    .contentType(JSON)
+                    .body(requestBody)
+                    .post("/contractnegotiations/request")
+                    .then()
+                    .statusCode(400);
+
+            verify(transformerRegistry).transform(any(JsonObject.class), eq(QuerySpec.class));
+            verifyNoInteractions(service);
+            verifyNoMoreInteractions(transformerRegistry);
+        }
+
+        @Test
+        void query_dtoTransformationFails() {
+            when(service.search(any(QuerySpec.class))).thenReturn(ServiceResult.success(List.of(
+                    createContractNegotiation("cn1"),
+                    createContractNegotiation("cn2")
+            )));
+            when(transformerRegistry.transform(any(ContractNegotiation.class), any()))
+                    .thenReturn(Result.failure("test-failure"));
+
+            baseRequest(participantContextId)
+                    .contentType(JSON)
+                    .post("/contractnegotiations/request")
+                    .then()
+                    .statusCode(200)
+                    .contentType(JSON)
+                    .body("size()", is(0));
+
+            verify(service).search(any(QuerySpec.class));
+        }
+
+        @Test
+        void query_singleFailure_shouldLogError() {
+            when(service.search(any(QuerySpec.class))).thenReturn(ServiceResult.success(List.of(
+                    createContractNegotiation("cn1"),
+                    createContractNegotiation("cn2")
+            )));
+            when(transformerRegistry.transform(any(ContractNegotiation.class), eq(JsonObject.class)))
+                    .thenReturn(Result.success(createObjectBuilder().build()))
+                    .thenReturn(Result.failure("test-failure"));
+
+            baseRequest(participantContextId)
+                    .contentType(JSON)
+                    .post("/contractnegotiations/request")
+                    .then()
+                    .statusCode(200)
+                    .contentType(JSON)
+                    .body("size()", is(1));
+
+            verify(service).search(any(QuerySpec.class));
+            verify(transformerRegistry, times(2)).transform(any(ContractNegotiation.class), eq(JsonObject.class));
+            verify(monitor).warning(contains("test-failure"));
+        }
+
+        @Test
+        void query_jsonObjectTransformationFails() {
+            when(service.search(any(QuerySpec.class))).thenReturn(ServiceResult.success(List.of(
+                    createContractNegotiation("cn1"),
+                    createContractNegotiation("cn2")
+            )));
+            when(transformerRegistry.transform(any(JsonObject.class), eq(QuerySpec.class))).thenReturn(Result.success(QuerySpec.none()));
+            when(transformerRegistry.transform(any(ContractNegotiation.class), eq(JsonObject.class)))
+                    .thenReturn(Result.failure("test-failure"));
+
+            var requestBody = createObjectBuilder().build();
+            baseRequest(participantContextId)
+                    .contentType(JSON)
+                    .body(requestBody)
+                    .post("/contractnegotiations/request")
+                    .then()
+                    .statusCode(200)
+                    .contentType(JSON)
+                    .body("size()", is(0));
+
+            verify(service).search(any(QuerySpec.class));
+            verify(transformerRegistry).transform(any(JsonObject.class), eq(QuerySpec.class));
+            verify(transformerRegistry, times(2)).transform(any(ContractNegotiation.class), eq(JsonObject.class));
+        }
+    }
+}

--- a/extensions/control-plane/api/management-api/contract-negotiation-api/src/test/java/org/eclipse/edc/virtual/connector/controlplane/api/management/contractnegotiation/ContractNegotiationApiExtensionTest.java
+++ b/extensions/control-plane/api/management-api/contract-negotiation-api/src/test/java/org/eclipse/edc/virtual/connector/controlplane/api/management/contractnegotiation/ContractNegotiationApiExtensionTest.java
@@ -1,0 +1,55 @@
+/*
+ *  Copyright (c) 2025 Metaform Systems, Inc.
+ *
+ *  This program and the accompanying materials are made available under the
+ *  terms of the Apache License, Version 2.0 which is available at
+ *  https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Contributors:
+ *       Metaform Systems, Inc. - initial API and implementation
+ *
+ */
+
+package org.eclipse.edc.virtual.connector.controlplane.api.management.contractnegotiation;
+
+import org.eclipse.edc.junit.extensions.DependencyInjectionExtension;
+import org.eclipse.edc.spi.system.ServiceExtensionContext;
+import org.eclipse.edc.transform.spi.TypeTransformerRegistry;
+import org.eclipse.edc.validator.spi.JsonObjectValidatorRegistry;
+import org.eclipse.edc.virtual.connector.controlplane.api.management.contractnegotiation.v4.ContractNegotiationApiV4Controller;
+import org.eclipse.edc.web.spi.WebService;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.isA;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(DependencyInjectionExtension.class)
+class ContractNegotiationApiExtensionTest {
+
+    private final JsonObjectValidatorRegistry validatorRegistry = mock(JsonObjectValidatorRegistry.class);
+    private final WebService webService = mock();
+    private final TypeTransformerRegistry typeTransformerRegistry = mock();
+
+    @BeforeEach
+    void setUp(ServiceExtensionContext context) {
+        when(typeTransformerRegistry.forContext(any())).thenReturn(mock());
+        context.registerService(TypeTransformerRegistry.class, typeTransformerRegistry);
+        context.registerService(JsonObjectValidatorRegistry.class, validatorRegistry);
+        context.registerService(WebService.class, webService);
+    }
+
+    @Test
+    void initiate_shouldRegisterControllers(ServiceExtensionContext context, ContractNegotiationApiExtension extension) {
+        extension.initialize(context);
+
+        verify(webService).registerResource(any(), isA(ContractNegotiationApiV4Controller.class));
+    }
+
+}

--- a/extensions/control-plane/api/management-api/contract-negotiation-api/src/test/java/org/eclipse/edc/virtual/connector/controlplane/api/management/contractnegotiation/v4/ContractNegotiationApiV4ControllerTest.java
+++ b/extensions/control-plane/api/management-api/contract-negotiation-api/src/test/java/org/eclipse/edc/virtual/connector/controlplane/api/management/contractnegotiation/v4/ContractNegotiationApiV4ControllerTest.java
@@ -1,0 +1,32 @@
+/*
+ *  Copyright (c) 2025 Metaform Systems, Inc.
+ *
+ *  This program and the accompanying materials are made available under the
+ *  terms of the Apache License, Version 2.0 which is available at
+ *  https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Contributors:
+ *       Metaform Systems, Inc. - initial API and implementation
+ *
+ */
+
+package org.eclipse.edc.virtual.connector.controlplane.api.management.contractnegotiation.v4;
+
+import org.eclipse.edc.junit.annotations.ApiTest;
+import org.eclipse.edc.virtual.connector.controlplane.api.management.contractnegotiation.ContractNegotiationApiControllerTestBase;
+
+@ApiTest
+class ContractNegotiationApiV4ControllerTest extends ContractNegotiationApiControllerTestBase {
+
+    @Override
+    protected Object controller() {
+        return new ContractNegotiationApiV4Controller(service, participantContextService, authorizationService, transformerRegistry, monitor);
+    }
+
+    @Override
+    protected String versionPath() {
+        return "v4alpha";
+    }
+}

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -64,6 +64,7 @@ include(":extensions:common:api:api-authorization")
 include(":extensions:control-plane:api:management-api:asset-api")
 include(":extensions:control-plane:api:management-api:contract-definition-api")
 include(":extensions:control-plane:api:management-api:policy-definition-api")
+include(":extensions:control-plane:api:management-api:contract-negotiation-api")
 include(":extensions:control-plane:api:management-api:management-api-configuration")
 
 // lib

--- a/system-tests/management-api/management-api-tests/src/test/java/org/eclipse/edc/test/e2e/managementapi/v4/ContractNegotiationApiV4EndToEndTest.java
+++ b/system-tests/management-api/management-api-tests/src/test/java/org/eclipse/edc/test/e2e/managementapi/v4/ContractNegotiationApiV4EndToEndTest.java
@@ -1,0 +1,829 @@
+/*
+ *  Copyright (c) 2025 Metaform Systems, Inc.
+ *
+ *  This program and the accompanying materials are made available under the
+ *  terms of the Apache License, Version 2.0 which is available at
+ *  https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Contributors:
+ *       Metaform Systems, Inc. - initial API and implementation
+ *
+ */
+
+package org.eclipse.edc.test.e2e.managementapi.v4;
+
+import com.github.tomakehurst.wiremock.junit5.WireMockExtension;
+import com.nimbusds.jose.JOSEException;
+import com.nimbusds.jose.jwk.Curve;
+import com.nimbusds.jose.jwk.ECKey;
+import com.nimbusds.jose.jwk.gen.ECKeyGenerator;
+import jakarta.json.Json;
+import jakarta.json.JsonArrayBuilder;
+import jakarta.json.JsonObject;
+import org.eclipse.edc.connector.controlplane.contract.spi.negotiation.store.ContractNegotiationStore;
+import org.eclipse.edc.connector.controlplane.contract.spi.types.agreement.ContractAgreement;
+import org.eclipse.edc.connector.controlplane.contract.spi.types.negotiation.ContractNegotiation;
+import org.eclipse.edc.connector.controlplane.contract.spi.types.negotiation.ContractNegotiationStates;
+import org.eclipse.edc.connector.controlplane.contract.spi.types.offer.ContractOffer;
+import org.eclipse.edc.junit.annotations.EndToEndTest;
+import org.eclipse.edc.junit.annotations.PostgresqlIntegrationTest;
+import org.eclipse.edc.junit.extensions.ComponentRuntimeExtension;
+import org.eclipse.edc.junit.extensions.RuntimeExtension;
+import org.eclipse.edc.participantcontext.spi.service.ParticipantContextService;
+import org.eclipse.edc.participantcontext.spi.types.ParticipantContext;
+import org.eclipse.edc.policy.model.Policy;
+import org.eclipse.edc.policy.model.PolicyType;
+import org.eclipse.edc.spi.query.QuerySpec;
+import org.eclipse.edc.spi.system.configuration.Config;
+import org.eclipse.edc.spi.system.configuration.ConfigFactory;
+import org.eclipse.edc.spi.types.domain.callback.CallbackAddress;
+import org.eclipse.edc.sql.testfixtures.PostgresqlEndToEndExtension;
+import org.eclipse.edc.test.e2e.managementapi.ManagementEndToEndTestContext;
+import org.eclipse.edc.test.e2e.managementapi.Runtimes;
+import org.eclipse.edc.virtualized.nats.testfixtures.NatsEndToEndExtension;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Order;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.BeforeAllCallback;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.UUID;
+
+import static com.github.tomakehurst.wiremock.client.WireMock.aResponse;
+import static com.github.tomakehurst.wiremock.client.WireMock.any;
+import static com.github.tomakehurst.wiremock.client.WireMock.urlPathEqualTo;
+import static com.github.tomakehurst.wiremock.core.WireMockConfiguration.wireMockConfig;
+import static io.restassured.http.ContentType.JSON;
+import static jakarta.json.Json.createArrayBuilder;
+import static jakarta.json.Json.createObjectBuilder;
+import static java.util.UUID.randomUUID;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.eclipse.edc.connector.controlplane.contract.spi.types.negotiation.ContractNegotiationStates.AGREED;
+import static org.eclipse.edc.connector.controlplane.contract.spi.types.negotiation.ContractNegotiationStates.REQUESTED;
+import static org.eclipse.edc.connector.controlplane.contract.spi.types.negotiation.ContractNegotiationStates.TERMINATED;
+import static org.eclipse.edc.jsonld.spi.JsonLdKeywords.CONTEXT;
+import static org.eclipse.edc.jsonld.spi.JsonLdKeywords.ID;
+import static org.eclipse.edc.jsonld.spi.JsonLdKeywords.TYPE;
+import static org.eclipse.edc.spi.constants.CoreConstants.EDC_CONNECTOR_MANAGEMENT_CONTEXT_V2;
+import static org.eclipse.edc.test.e2e.managementapi.v4.TestFunction.PARTICIPANT_CONTEXT_ID;
+import static org.eclipse.edc.test.e2e.managementapi.v4.TestFunction.createParticipant;
+import static org.eclipse.edc.test.e2e.managementapi.v4.TestFunction.jsonLdContext;
+import static org.eclipse.edc.virtualized.test.system.fixtures.DockerImages.createPgContainer;
+import static org.hamcrest.Matchers.contains;
+import static org.hamcrest.Matchers.containsString;
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.matchesRegex;
+
+public class ContractNegotiationApiV4EndToEndTest {
+
+    abstract static class Tests {
+
+        @Order(0)
+        @RegisterExtension
+        static WireMockExtension mockJwksServer = WireMockExtension.newInstance()
+                .options(wireMockConfig().dynamicPort())
+                .build();
+
+        private String participantTokenJwt;
+        private ECKey oauthServerSigningKey;
+
+
+        @BeforeEach
+        void setup(ManagementEndToEndTestContext context, ParticipantContextService participantContextService) throws JOSEException {
+            createParticipant(participantContextService, PARTICIPANT_CONTEXT_ID);
+
+            // stub JWKS endpoint at /jwks/ returning 200 OK with a simple JWKS
+            oauthServerSigningKey = new ECKeyGenerator(Curve.P_256).keyID(UUID.randomUUID().toString()).generate();
+            participantTokenJwt = context.createToken(PARTICIPANT_CONTEXT_ID, oauthServerSigningKey);
+
+            // create JWKS with the participant's key
+            var jwks = createObjectBuilder()
+                    .add("keys", createArrayBuilder().add(createObjectBuilder(oauthServerSigningKey.toPublicJWK().toJSONObject())))
+                    .build()
+                    .toString();
+
+            // use wiremock to host a JWKS endpoint
+            mockJwksServer.stubFor(any(urlPathEqualTo("/.well-known/jwks"))
+                    .willReturn(aResponse()
+                            .withStatus(200)
+                            .withHeader("Content-Type", "application/json")
+                            .withBody(jwks)));
+        }
+
+        @AfterEach
+        void teardown(ParticipantContextService participantContextService, ContractNegotiationStore store) {
+            participantContextService.deleteParticipantContext(PARTICIPANT_CONTEXT_ID)
+                    .orElseThrow(f -> new AssertionError(f.getFailureDetail()));
+
+            store.queryNegotiations(QuerySpec.max()).forEach(cn -> store.deleteById(cn.getId()));
+        }
+
+        @Test
+        void initiate(ManagementEndToEndTestContext context, ContractNegotiationStore store) {
+
+            var requestJson = contractRequestJson();
+
+            var id = context.baseRequest(participantTokenJwt)
+                    .contentType(JSON)
+                    .body(requestJson.toString())
+                    .post("/v4alpha/participants/" + PARTICIPANT_CONTEXT_ID + "/contractnegotiations")
+                    .then()
+                    .log().ifValidationFails()
+                    .statusCode(200)
+                    .contentType(JSON)
+                    .extract().jsonPath().getString(ID);
+
+            assertThat(store.findById(id)).isNotNull();
+        }
+
+        private JsonObject contractRequestJson() {
+            return createObjectBuilder()
+                    .add(CONTEXT, createArrayBuilder().add(EDC_CONNECTOR_MANAGEMENT_CONTEXT_V2))
+                    .add(TYPE, "ContractRequest")
+                    .add("counterPartyAddress", "test-address")
+                    .add("protocol", "test-protocol")
+                    .add("providerId", "test-provider-id")
+                    .add("callbackAddresses", createCallbackAddress())
+                    .add("policy", createPolicy())
+                    .build();
+        }
+
+        @Test
+        void initiate_whenValidationFails(ManagementEndToEndTestContext context, ContractNegotiationStore store) {
+
+            var requestJson = createObjectBuilder()
+                    .add(CONTEXT, createArrayBuilder().add(EDC_CONNECTOR_MANAGEMENT_CONTEXT_V2))
+                    .add(TYPE, "ContractRequest")
+                    .add("counterPartyAddress", "test-address")
+                    .build();
+
+            context.baseRequest(participantTokenJwt)
+                    .contentType(JSON)
+                    .body(requestJson.toString())
+                    .post("/v4alpha/participants/" + PARTICIPANT_CONTEXT_ID + "/contractnegotiations")
+                    .then()
+                    .log().ifValidationFails()
+                    .statusCode(400);
+        }
+
+        @Test
+        void initiate_tokenBearerWrong(ManagementEndToEndTestContext context, ParticipantContextService service) {
+            var requestJson = contractRequestJson();
+
+            var otherParticipantId = UUID.randomUUID().toString();
+
+            service.createParticipantContext(ParticipantContext.Builder.newInstance().participantContextId(otherParticipantId).build())
+                    .orElseThrow(f -> new AssertionError("ParticipantContext " + otherParticipantId + " not created."));
+
+            var token = context.createToken(otherParticipantId, oauthServerSigningKey);
+
+            context.baseRequest(token)
+                    .contentType(JSON)
+                    .body(requestJson.toString())
+                    .post("/v4alpha/participants/" + PARTICIPANT_CONTEXT_ID + "/contractnegotiations")
+                    .then()
+                    .log().ifValidationFails()
+                    .statusCode(403)
+                    .body(containsString("User '%s' is not authorized to access this resource.".formatted(otherParticipantId)));
+        }
+
+        @Test
+        void initiate_tokenLacksWriteScope(ManagementEndToEndTestContext context, ParticipantContextService service) {
+            var requestJson = contractRequestJson();
+
+            var otherParticipantId = UUID.randomUUID().toString();
+
+            service.createParticipantContext(ParticipantContext.Builder.newInstance().participantContextId(otherParticipantId).build())
+                    .orElseThrow(f -> new AssertionError("ParticipantContext " + otherParticipantId + " not created."));
+
+            var token = context.createToken(PARTICIPANT_CONTEXT_ID, oauthServerSigningKey, Map.of("scope", "management-api:read"));
+
+            context.baseRequest(token)
+                    .contentType(JSON)
+                    .body(requestJson.toString())
+                    .post("/v4alpha/participants/" + PARTICIPANT_CONTEXT_ID + "/contractnegotiations")
+                    .then()
+                    .log().ifValidationFails()
+                    .statusCode(403)
+                    .body(matchesRegex("(?s).*Required scope.*missing.*"));
+        }
+
+        @Test
+        void initiate_tokenBearerIsAdmin(ManagementEndToEndTestContext context, ContractNegotiationStore store) {
+
+            var requestJson = contractRequestJson();
+
+            var token = context.createAdminToken(oauthServerSigningKey);
+
+            var id = context.baseRequest(token)
+                    .contentType(JSON)
+                    .body(requestJson.toString())
+                    .post("/v4alpha/participants/" + PARTICIPANT_CONTEXT_ID + "/contractnegotiations")
+                    .then()
+                    .log().ifValidationFails()
+                    .statusCode(200)
+                    .contentType(JSON)
+                    .extract().jsonPath().getString(ID);
+
+            assertThat(store.findById(id)).isNotNull();
+        }
+
+        @Test
+        void getById(ManagementEndToEndTestContext context, ContractNegotiationStore store) {
+            store.save(createContractNegotiationBuilder("cn1").contractAgreement(createContractAgreement("cn1")).build());
+
+            context.baseRequest(participantTokenJwt)
+                    .contentType(JSON)
+                    .get("/v4alpha/participants/" + PARTICIPANT_CONTEXT_ID + "/contractnegotiations/cn1")
+                    .then()
+                    .statusCode(200)
+                    .contentType(JSON)
+                    .body(CONTEXT, contains(EDC_CONNECTOR_MANAGEMENT_CONTEXT_V2))
+                    .body(TYPE, equalTo("ContractNegotiation"))
+                    .body(ID, is("cn1"))
+                    .body("protocol", equalTo("dataspace-protocol-http"));
+        }
+
+        @Test
+        void getById_tokenBearerDoesNotOwnResource(ManagementEndToEndTestContext context, ContractNegotiationStore store, ParticipantContextService srv) {
+            store.save(createContractNegotiationBuilder("cn1").contractAgreement(createContractAgreement("cn1")).build());
+
+            var otherParticipantId = UUID.randomUUID().toString();
+            createParticipant(srv, otherParticipantId);
+
+            var token = context.createToken(otherParticipantId, oauthServerSigningKey);
+
+            context.baseRequest(token)
+                    .contentType(JSON)
+                    .get("/v4alpha/participants/" + PARTICIPANT_CONTEXT_ID + "/contractnegotiations/cn1")
+                    .then()
+                    .statusCode(403);
+        }
+
+        @Test
+        void getById_tokenLacksRequiredScope(ManagementEndToEndTestContext context, ContractNegotiationStore store) {
+            store.save(createContractNegotiationBuilder("cn1").contractAgreement(createContractAgreement("cn1")).build());
+
+            var token = context.createToken(PARTICIPANT_CONTEXT_ID, oauthServerSigningKey, Map.of("scope", "management-api:missing"));
+
+            context.baseRequest(token)
+                    .contentType(JSON)
+                    .get("/v4alpha/participants/" + PARTICIPANT_CONTEXT_ID + "/contractnegotiations/cn1")
+                    .then()
+                    .statusCode(403);
+        }
+
+        @Test
+        void getState(ManagementEndToEndTestContext context, ContractNegotiationStore store) {
+            var state = ContractNegotiationStates.FINALIZED.code(); // all other states could be modified by the state machine
+            store.save(createContractNegotiationBuilder("cn1").state(state).build());
+
+            context.baseRequest(participantTokenJwt)
+                    .contentType(JSON)
+                    .get("/v4alpha/participants/" + PARTICIPANT_CONTEXT_ID + "/contractnegotiations/cn1/state")
+                    .then()
+                    .statusCode(200)
+                    .contentType(JSON)
+                    .body("state", is("FINALIZED"));
+        }
+
+        @Test
+        void getState_tokenBearerDoesNotOwnResource(ManagementEndToEndTestContext context, ContractNegotiationStore store, ParticipantContextService srv) {
+            var state = ContractNegotiationStates.FINALIZED.code();
+            store.save(createContractNegotiationBuilder("cn1").state(state).build());
+
+            var otherParticipantId = UUID.randomUUID().toString();
+            createParticipant(srv, otherParticipantId);
+
+            var token = context.createToken(otherParticipantId, oauthServerSigningKey);
+
+            context.baseRequest(token)
+                    .contentType(JSON)
+                    .get("/v4alpha/participants/" + PARTICIPANT_CONTEXT_ID + "/contractnegotiations/cn1/state")
+                    .then()
+                    .statusCode(403);
+
+        }
+
+        @Test
+        void getState_tokenLacksRequiredScope(ManagementEndToEndTestContext context, ContractNegotiationStore store) {
+            var state = ContractNegotiationStates.FINALIZED.code();
+            store.save(createContractNegotiationBuilder("cn1").state(state).build());
+
+            var token = context.createToken(PARTICIPANT_CONTEXT_ID, oauthServerSigningKey, Map.of("scope", "management-api:missing"));
+
+            context.baseRequest(token)
+                    .contentType(JSON)
+                    .get("/v4alpha/participants/" + PARTICIPANT_CONTEXT_ID + "/contractnegotiations/cn1/state")
+                    .then()
+                    .statusCode(403);
+
+        }
+
+        @Test
+        void getAgreement(ManagementEndToEndTestContext context, ContractNegotiationStore store) {
+            var agreement = createContractAgreement("cn1");
+            store.save(createContractNegotiationBuilder("cn1").contractAgreement(agreement).build());
+
+            context.baseRequest(participantTokenJwt)
+                    .contentType(JSON)
+                    .get("/v4alpha/participants/" + PARTICIPANT_CONTEXT_ID + "/contractnegotiations/cn1/agreement")
+                    .then()
+                    .statusCode(200)
+                    .contentType(JSON)
+                    .body(CONTEXT, contains(EDC_CONNECTOR_MANAGEMENT_CONTEXT_V2))
+                    .body(TYPE, equalTo("ContractAgreement"))
+                    .body(ID, is("cn1"))
+                    .body("assetId", equalTo(agreement.getAssetId()))
+                    .body("policy.'@type'", equalTo("Agreement"));
+
+        }
+
+        @Test
+        void getAgreement_tokenBearerDoesNotOwnResource(ManagementEndToEndTestContext context,
+                                                        ContractNegotiationStore store, ParticipantContextService srv) {
+            var agreement = createContractAgreement("cn1");
+            store.save(createContractNegotiationBuilder("cn1").contractAgreement(agreement).build());
+
+            var otherParticipantId = UUID.randomUUID().toString();
+            createParticipant(srv, otherParticipantId);
+
+            var token = context.createToken(otherParticipantId, oauthServerSigningKey);
+
+            context.baseRequest(token)
+                    .contentType(JSON)
+                    .get("/v4alpha/participants/" + PARTICIPANT_CONTEXT_ID + "/contractnegotiations/cn1/agreement")
+                    .then()
+                    .statusCode(403);
+
+        }
+
+        @Test
+        void getAgreement_tokenLacksRequiredScope(ManagementEndToEndTestContext context,
+                                                  ContractNegotiationStore store) {
+            var agreement = createContractAgreement("cn1");
+            store.save(createContractNegotiationBuilder("cn1").contractAgreement(agreement).build());
+
+            var token = context.createToken(PARTICIPANT_CONTEXT_ID, oauthServerSigningKey, Map.of("scope", "management-api:missing"));
+
+            context.baseRequest(token)
+                    .contentType(JSON)
+                    .get("/v4alpha/participants/" + PARTICIPANT_CONTEXT_ID + "/contractnegotiations/cn1/agreement")
+                    .then()
+                    .statusCode(403);
+
+        }
+
+        @Test
+        void query(ManagementEndToEndTestContext context, ContractNegotiationStore store) {
+            var id1 = UUID.randomUUID().toString();
+            var id2 = UUID.randomUUID().toString();
+            store.save(createContractNegotiationBuilder(id1).counterPartyAddress(context.providerProtocolUrl()).build());
+            store.save(createContractNegotiationBuilder(id2).counterPartyAddress(context.providerProtocolUrl()).build());
+
+            var query = createObjectBuilder()
+                    .add(CONTEXT, jsonLdContext())
+                    .add(TYPE, "QuerySpec")
+                    .add("filterExpression", createArrayBuilder()
+                            .add(createObjectBuilder()
+                                    .add(TYPE, "Criterion")
+                                    .add("operandLeft", "id")
+                                    .add("operator", "in")
+                                    .add("operandRight", createArrayBuilder().add(id1).add(id2))
+                            )
+                            .add(createObjectBuilder()
+                                    .add(TYPE, "Criterion")
+                                    .add("operandLeft", "pending")
+                                    .add("operator", "=")
+                                    .add("operandRight", false)
+                            )
+                    )
+                    .build();
+
+            var jsonPath = context.baseRequest(participantTokenJwt)
+                    .contentType(JSON)
+                    .body(query.toString())
+                    .post("/v4alpha/participants/" + PARTICIPANT_CONTEXT_ID + "/contractnegotiations/request")
+                    .then()
+                    .log().ifValidationFails()
+                    .statusCode(200)
+                    .contentType(JSON)
+                    .body("size()", is(2))
+                    .extract().jsonPath();
+
+            assertThat(jsonPath.getString("[0].counterPartyAddress")).isEqualTo(context.providerProtocolUrl());
+            assertThat(jsonPath.getString("[0].@id")).isIn(id1, id2);
+            assertThat(jsonPath.getString("[1].@id")).isIn(id1, id2);
+            assertThat(jsonPath.getString("[0].protocol")).isEqualTo("dataspace-protocol-http");
+            assertThat(jsonPath.getString("[1].protocol")).isEqualTo("dataspace-protocol-http");
+            assertThat(jsonPath.getString("[0].@type")).isEqualTo("ContractNegotiation");
+            assertThat(jsonPath.getString("[1].@type")).isEqualTo("ContractNegotiation");
+            assertThat(jsonPath.getList("[0].@context")).contains(EDC_CONNECTOR_MANAGEMENT_CONTEXT_V2);
+            assertThat(jsonPath.getList("[1].@context")).contains(EDC_CONNECTOR_MANAGEMENT_CONTEXT_V2);
+
+        }
+
+        @Test
+        void query_tokenBearerIsAdmin_shouldReturnAll(ManagementEndToEndTestContext context, ContractNegotiationStore store) {
+
+            var id1 = UUID.randomUUID().toString();
+            var id2 = UUID.randomUUID().toString();
+            store.save(createContractNegotiationBuilder(id1).counterPartyAddress(context.providerProtocolUrl()).build());
+            store.save(createContractNegotiationBuilder(id2).counterPartyAddress(context.providerProtocolUrl()).build());
+
+            var query = createObjectBuilder()
+                    .add(CONTEXT, jsonLdContext())
+                    .add(TYPE, "QuerySpec")
+                    .add("filterExpression", createArrayBuilder()
+                            .add(createObjectBuilder()
+                                    .add(TYPE, "Criterion")
+                                    .add("operandLeft", "id")
+                                    .add("operator", "in")
+                                    .add("operandRight", createArrayBuilder().add(id1).add(id2))
+                            )
+                            .add(createObjectBuilder()
+                                    .add(TYPE, "Criterion")
+                                    .add("operandLeft", "pending")
+                                    .add("operator", "=")
+                                    .add("operandRight", false)
+                            )
+                    )
+                    .build();
+
+            var token = context.createAdminToken(oauthServerSigningKey);
+
+            context.baseRequest(token)
+                    .contentType(JSON)
+                    .body(query.toString())
+                    .post("/v4alpha/participants/" + PARTICIPANT_CONTEXT_ID + "/contractnegotiations/request")
+                    .then()
+                    .log().ifValidationFails()
+                    .statusCode(200)
+                    .contentType(JSON)
+                    .body("size()", is(2));
+
+        }
+
+        @Test
+        void query_shouldLimitToResourceOwner(ManagementEndToEndTestContext context, ContractNegotiationStore store) {
+            var otherParticipantId = UUID.randomUUID().toString();
+
+            var id1 = UUID.randomUUID().toString();
+            var id2 = UUID.randomUUID().toString();
+            store.save(createContractNegotiationBuilder(id1).counterPartyAddress(context.providerProtocolUrl()).build());
+            store.save(createContractNegotiationBuilder(id2).participantContextId(otherParticipantId).counterPartyAddress(context.providerProtocolUrl()).build());
+
+            var query = createObjectBuilder()
+                    .add(CONTEXT, jsonLdContext())
+                    .add(TYPE, "QuerySpec")
+                    .add("filterExpression", createArrayBuilder()
+                            .add(createObjectBuilder()
+                                    .add(TYPE, "Criterion")
+                                    .add("operandLeft", "id")
+                                    .add("operator", "in")
+                                    .add("operandRight", createArrayBuilder().add(id1).add(id2))
+                            )
+                            .add(createObjectBuilder()
+                                    .add(TYPE, "Criterion")
+                                    .add("operandLeft", "pending")
+                                    .add("operator", "=")
+                                    .add("operandRight", false)
+                            )
+                    )
+                    .build();
+
+            var token = context.createAdminToken(oauthServerSigningKey);
+
+            context.baseRequest(token)
+                    .contentType(JSON)
+                    .body(query.toString())
+                    .post("/v4alpha/participants/" + PARTICIPANT_CONTEXT_ID + "/contractnegotiations/request")
+                    .then()
+                    .log().ifValidationFails()
+                    .statusCode(200)
+                    .contentType(JSON)
+                    .body("size()", is(1))
+                    .body("[0].@id", is(id1));
+
+        }
+
+        @Test
+        void query_tokenBearerNotEqualResourceOwner(ManagementEndToEndTestContext context, ContractNegotiationStore store, ParticipantContextService srv) {
+            var otherParticipantId = UUID.randomUUID().toString();
+            srv.createParticipantContext(ParticipantContext.Builder.newInstance().participantContextId(otherParticipantId).build())
+                    .orElseThrow(f -> new AssertionError("ParticipantContext " + otherParticipantId + " not created."));
+            var id = UUID.randomUUID().toString();
+            store.save(createContractNegotiationBuilder(id).counterPartyAddress(context.providerProtocolUrl()).build());
+
+            var query = createObjectBuilder()
+                    .add(CONTEXT, jsonLdContext())
+                    .add(TYPE, "QuerySpec")
+                    .add("filterExpression", createArrayBuilder()
+                            .add(createObjectBuilder()
+                                    .add(TYPE, "Criterion")
+                                    .add("operandLeft", "id")
+                                    .add("operator", "in")
+                                    .add("operandRight", createArrayBuilder().add(id))
+                            )
+                            .add(createObjectBuilder()
+                                    .add(TYPE, "Criterion")
+                                    .add("operandLeft", "pending")
+                                    .add("operator", "=")
+                                    .add("operandRight", false)
+                            )
+                    )
+                    .build();
+
+            var token = context.createToken(otherParticipantId, oauthServerSigningKey);
+
+            context.baseRequest(token)
+                    .contentType(JSON)
+                    .body(query.toString())
+                    .post("/v4alpha/participants/" + PARTICIPANT_CONTEXT_ID + "/contractnegotiations/request")
+                    .then()
+                    .log().ifValidationFails()
+                    .statusCode(403)
+                    .body(containsString("User '%s' is not authorized to access this resource.".formatted(otherParticipantId)));
+
+        }
+
+        @Test
+        void terminate(ManagementEndToEndTestContext context, ContractNegotiationStore store) {
+            store.save(createContractNegotiationBuilder("cn1").build());
+            var requestBody = createObjectBuilder()
+                    .add(CONTEXT, createArrayBuilder().add(EDC_CONNECTOR_MANAGEMENT_CONTEXT_V2))
+                    .add(ID, "cn1")
+                    .add(TYPE, "TerminateNegotiation")
+                    .add("reason", "any good reason")
+                    .build();
+
+            context.baseRequest(participantTokenJwt)
+                    .body(requestBody.toString())
+                    .contentType(JSON)
+                    .post("/v4alpha/participants/" + PARTICIPANT_CONTEXT_ID + "/contractnegotiations/cn1/terminate")
+                    .then()
+                    .log().ifError()
+                    .statusCode(204);
+        }
+
+        @Test
+        void terminate_tokenBearerDoesNotOwnResource(ManagementEndToEndTestContext context,
+                                                     ContractNegotiationStore store,
+                                                     ParticipantContextService srv) {
+            store.save(createContractNegotiationBuilder("cn1").build());
+            var requestBody = createObjectBuilder()
+                    .add(CONTEXT, createArrayBuilder().add(EDC_CONNECTOR_MANAGEMENT_CONTEXT_V2))
+                    .add(ID, "cn1")
+                    .add(TYPE, "TerminateNegotiation")
+                    .add("reason", "any good reason")
+                    .build();
+
+            var otherParticipantId = UUID.randomUUID().toString();
+            createParticipant(srv, otherParticipantId);
+
+            var token = context.createToken(otherParticipantId, oauthServerSigningKey);
+
+            context.baseRequest(token)
+                    .body(requestBody.toString())
+                    .contentType(JSON)
+                    .post("/v4alpha/participants/" + PARTICIPANT_CONTEXT_ID + "/contractnegotiations/cn1/terminate")
+                    .then()
+                    .log().ifError()
+                    .statusCode(403);
+        }
+
+        @Test
+        void terminate_tokenLacksRequiredScope(ManagementEndToEndTestContext context,
+                                               ContractNegotiationStore store) {
+            store.save(createContractNegotiationBuilder("cn1").build());
+            var requestBody = createObjectBuilder()
+                    .add(CONTEXT, createArrayBuilder().add(EDC_CONNECTOR_MANAGEMENT_CONTEXT_V2))
+                    .add(ID, "cn1")
+                    .add(TYPE, "TerminateNegotiation")
+                    .add("reason", "any good reason")
+                    .build();
+
+
+            var token = context.createToken(PARTICIPANT_CONTEXT_ID, oauthServerSigningKey, Map.of("scope", "management-api:missing"));
+
+            context.baseRequest(token)
+                    .body(requestBody.toString())
+                    .contentType(JSON)
+                    .post("/v4alpha/participants/" + PARTICIPANT_CONTEXT_ID + "/contractnegotiations/cn1/terminate")
+                    .then()
+                    .log().ifError()
+                    .statusCode(403);
+        }
+
+        @Test
+        void delete(ManagementEndToEndTestContext context, ContractNegotiationStore store) {
+            store.save(createContractNegotiationBuilder("cn1")
+                    .state(TERMINATED.code()).build());
+
+            context.baseRequest(participantTokenJwt)
+                    .contentType(JSON)
+                    .delete("/v4alpha/participants/" + PARTICIPANT_CONTEXT_ID + "/contractnegotiations/cn1")
+                    .then()
+                    .statusCode(204);
+
+            assertThat(store.findById("cn1")).isNull();
+        }
+
+        @Test
+        void delete_shouldFailDueToWrongState(ManagementEndToEndTestContext context, ContractNegotiationStore store) {
+            store.save(createContractNegotiationBuilder("cn1")
+                    .state(AGREED.code()).build());
+
+            context.baseRequest(participantTokenJwt)
+                    .contentType(JSON)
+                    .delete("/v4alpha/participants/" + PARTICIPANT_CONTEXT_ID + "/contractnegotiations/cn1")
+                    .then()
+                    .statusCode(409);
+
+            assertThat(store.findById("cn1")).isNotNull();
+        }
+
+        @Test
+        void delete_tokenBearerDoesNotOwnResource(ManagementEndToEndTestContext context,
+                                                  ContractNegotiationStore store,
+                                                  ParticipantContextService srv) {
+            store.save(createContractNegotiationBuilder("cn1").build());
+
+            var otherParticipantId = UUID.randomUUID().toString();
+            createParticipant(srv, otherParticipantId);
+
+            var token = context.createToken(otherParticipantId, oauthServerSigningKey);
+
+            context.baseRequest(token)
+                    .contentType(JSON)
+                    .delete("/v4alpha/participants/" + PARTICIPANT_CONTEXT_ID + "/contractnegotiations/cn1")
+                    .then()
+                    .statusCode(403);
+        }
+
+        @Test
+        void delete_tokenLacksRequiredScope(ManagementEndToEndTestContext context,
+                                            ContractNegotiationStore store) {
+            store.save(createContractNegotiationBuilder("cn1").build());
+
+            var token = context.createToken(PARTICIPANT_CONTEXT_ID, oauthServerSigningKey, Map.of("scope", "management-api:missing"));
+
+            context.baseRequest(token)
+                    .contentType(JSON)
+                    .delete("/v4alpha/participants/" + PARTICIPANT_CONTEXT_ID + "/contractnegotiations/cn1")
+                    .then()
+                    .statusCode(403);
+        }
+
+        private ContractNegotiation.Builder createContractNegotiationBuilder(String negotiationId) {
+            return ContractNegotiation.Builder.newInstance()
+                    .id(negotiationId)
+                    .correlationId(negotiationId)
+                    .counterPartyId(randomUUID().toString())
+                    .counterPartyAddress("http://counter-party/address")
+                    .callbackAddresses(List.of(CallbackAddress.Builder.newInstance()
+                            .uri("local://test")
+                            .events(Set.of("test-event1", "test-event2"))
+                            .build()))
+                    .protocol("dataspace-protocol-http")
+                    .state(REQUESTED.code())
+                    .participantContextId(PARTICIPANT_CONTEXT_ID)
+                    .contractOffer(contractOfferBuilder().build());
+        }
+
+        private ContractOffer.Builder contractOfferBuilder() {
+            return ContractOffer.Builder.newInstance()
+                    .id("test-offer-id")
+                    .assetId(randomUUID().toString())
+                    .policy(Policy.Builder.newInstance().build());
+        }
+
+        private ContractAgreement createContractAgreement(String negotiationId) {
+            return ContractAgreement.Builder.newInstance()
+                    .id(negotiationId)
+                    .assetId(randomUUID().toString())
+                    .consumerId(randomUUID() + "-consumer")
+                    .providerId(randomUUID() + "-provider")
+                    .policy(Policy.Builder.newInstance().type(PolicyType.CONTRACT).build())
+                    .participantContextId(PARTICIPANT_CONTEXT_ID)
+                    .build();
+        }
+
+        private JsonArrayBuilder createCallbackAddress() {
+            var builder = Json.createArrayBuilder();
+            return builder.add(createObjectBuilder()
+                    .add(TYPE, "CallbackAddress")
+                    .add("transactional", false)
+                    .add("uri", "http://test.local/")
+                    .add("events", Json.createArrayBuilder().build()));
+        }
+
+        private JsonObject createPolicy() {
+            var permissionJson = createObjectBuilder().add(TYPE, "permission")
+                    .add("action", "use")
+                    .build();
+            var prohibitionJson = createObjectBuilder().add(TYPE, "prohibition")
+                    .add("action", "use")
+                    .build();
+            var dutyJson = createObjectBuilder().add(TYPE, "duty")
+                    .add("action", "use")
+                    .build();
+
+            return createObjectBuilder()
+                    .add(CONTEXT, "http://www.w3.org/ns/odrl.jsonld")
+                    .add(TYPE, "Offer")
+                    .add(ID, "offer-id")
+                    .add("permission", createArrayBuilder().add(permissionJson))
+                    .add("prohibition", createArrayBuilder().add(prohibitionJson))
+                    .add("obligation", createArrayBuilder().add(dutyJson))
+                    .add("assigner", "provider-id")
+                    .add("target", "asset-id")
+                    .build();
+        }
+
+    }
+
+    @Nested
+    @EndToEndTest
+    class InMemory extends Tests {
+
+        @RegisterExtension
+        static RuntimeExtension runtime = ComponentRuntimeExtension.Builder.newInstance()
+                .name(Runtimes.ControlPlane.NAME)
+                .modules(Runtimes.ControlPlane.MODULES)
+                .endpoints(Runtimes.ControlPlane.ENDPOINTS.build())
+                .configurationProvider(Runtimes.ControlPlane::config)
+                .paramProvider(ManagementEndToEndTestContext.class, ManagementEndToEndTestContext::forContext)
+                .configurationProvider(() -> ConfigFactory.fromMap(Map.of("edc.iam.oauth2.jwks.url", "http://localhost:" + mockJwksServer.getPort() + "/.well-known/jwks")))
+                .build();
+    }
+
+    @Nested
+    @PostgresqlIntegrationTest
+    class Postgres extends Tests {
+
+        @RegisterExtension
+        @Order(0)
+        static final PostgresqlEndToEndExtension POSTGRES_EXTENSION = new PostgresqlEndToEndExtension(createPgContainer());
+
+        @Order(0)
+        @RegisterExtension
+        static final NatsEndToEndExtension NATS_EXTENSION = new NatsEndToEndExtension();
+
+        @Order(1)
+        @RegisterExtension
+        static final BeforeAllCallback SETUP = context -> {
+            POSTGRES_EXTENSION.createDatabase(Runtimes.ControlPlane.NAME.toLowerCase());
+            NATS_EXTENSION.createStream("state_machine", "negotiations.>", "transfers.>");
+            NATS_EXTENSION.createConsumer("state_machine", "cn-subscriber", "negotiations.>");
+            NATS_EXTENSION.createConsumer("state_machine", "tp-subscriber", "transfers.>");
+        };
+
+        @Order(3)
+        @RegisterExtension
+        static final BeforeAllCallback SEED = context -> {
+            POSTGRES_EXTENSION.execute(Runtimes.ControlPlane.NAME.toLowerCase(), "ALTER TABLE edc_contract_negotiation REPLICA IDENTITY FULL;");
+            POSTGRES_EXTENSION.execute(Runtimes.ControlPlane.NAME.toLowerCase(), "ALTER TABLE edc_transfer_process REPLICA IDENTITY FULL;");
+        };
+
+        @Order(2)
+        @RegisterExtension
+        static RuntimeExtension runtime = ComponentRuntimeExtension.Builder.newInstance()
+                .name(Runtimes.ControlPlane.NAME)
+                .modules(Runtimes.ControlPlane.MODULES)
+                .modules(Runtimes.ControlPlane.PG_MODULES)
+                .endpoints(Runtimes.ControlPlane.ENDPOINTS.build())
+                .configurationProvider(Runtimes.ControlPlane::config)
+                .configurationProvider(() -> POSTGRES_EXTENSION.configFor(Runtimes.ControlPlane.NAME.toLowerCase()))
+                .configurationProvider(Postgres::runtimeConfiguration)
+                .configurationProvider(() -> ConfigFactory.fromMap(Map.of("edc.iam.oauth2.jwks.url", "http://localhost:" + mockJwksServer.getPort() + "/.well-known/jwks")))
+                .paramProvider(ManagementEndToEndTestContext.class, ManagementEndToEndTestContext::forContext)
+                .build();
+
+        private static Config runtimeConfiguration() {
+            return ConfigFactory.fromMap(new HashMap<>() {
+                {
+                    put("edc.postgres.cdc.url", POSTGRES_EXTENSION.getJdbcUrl(Runtimes.ControlPlane.NAME.toLowerCase()));
+                    put("edc.postgres.cdc.user", POSTGRES_EXTENSION.getUsername());
+                    put("edc.postgres.cdc.password", POSTGRES_EXTENSION.getPassword());
+                    put("edc.postgres.cdc.slot", "edc_cdc_slot_" + Runtimes.ControlPlane.NAME.toLowerCase());
+                    put("edc.nats.cn.subscriber.url", NATS_EXTENSION.getNatsUrl());
+                    put("edc.nats.cn.publisher.url", NATS_EXTENSION.getNatsUrl());
+                    put("edc.nats.tp.subscriber.url", NATS_EXTENSION.getNatsUrl());
+                    put("edc.nats.tp.publisher.url", NATS_EXTENSION.getNatsUrl());
+                }
+            });
+        }
+
+    }
+
+}

--- a/system-tests/management-api/management-api-tests/src/test/java/org/eclipse/edc/test/e2e/managementapi/v4/TestFunction.java
+++ b/system-tests/management-api/management-api-tests/src/test/java/org/eclipse/edc/test/e2e/managementapi/v4/TestFunction.java
@@ -1,0 +1,44 @@
+/*
+ *  Copyright (c) 2025 Metaform Systems, Inc.
+ *
+ *  This program and the accompanying materials are made available under the
+ *  terms of the Apache License, Version 2.0 which is available at
+ *  https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Contributors:
+ *       Metaform Systems, Inc. - initial API and implementation
+ *
+ */
+
+package org.eclipse.edc.test.e2e.managementapi.v4;
+
+import jakarta.json.JsonArray;
+import org.eclipse.edc.participantcontext.spi.service.ParticipantContextService;
+import org.eclipse.edc.participantcontext.spi.types.ParticipantContext;
+import org.eclipse.edc.participantcontext.spi.types.ParticipantContextState;
+
+import static jakarta.json.Json.createArrayBuilder;
+import static org.eclipse.edc.spi.constants.CoreConstants.EDC_CONNECTOR_MANAGEMENT_CONTEXT_V2;
+
+public class TestFunction {
+
+    public static final String PARTICIPANT_CONTEXT_ID = "test-participant";
+
+    public static void createParticipant(ParticipantContextService participantContextService, String participantContextId) {
+        var pc = ParticipantContext.Builder.newInstance()
+                .participantContextId(participantContextId)
+                .state(ParticipantContextState.ACTIVATED)
+                .build();
+
+        participantContextService.createParticipantContext(pc)
+                .orElseThrow(f -> new AssertionError(f.getFailureDetail()));
+    }
+
+    public static JsonArray jsonLdContext() {
+        return createArrayBuilder()
+                .add(EDC_CONNECTOR_MANAGEMENT_CONTEXT_V2)
+                .build();
+    }
+}


### PR DESCRIPTION
## What this PR changes/adds

contract negotiation APIs

## Why it does that

_Briefly state why the change was necessary._

## Further notes

Added for the moment a copy of `JsonObjectFromContractAgreementTransformer`. It will be removed once we expose that on upstream EDC core

## Who will sponsor this feature?

_Please @-mention the committer that will sponsor your feature_.


## Linked Issue(s)

Closes #49 

_Please be sure to take a look at the [contributing guidelines](https://github.com/eclipse-edc/.github/blob/main/CONTRIBUTING.md#submit-a-pull-request) and our [etiquette for pull requests](https://github.com/eclipse-edc/.github/blob/main/contributing/pr_etiquette.md)._
