### PR TITLE
feat: cel expression api

### DIFF
--- a/extensions/cel/cel-extension/src/main/java/org/eclipse/edc/virtualized/policy/cel/engine/CelExpressionEngineImpl.java
+++ b/extensions/cel/cel-extension/src/main/java/org/eclipse/edc/virtualized/policy/cel/engine/CelExpressionEngineImpl.java
@@ -79,7 +79,7 @@ public class CelExpressionEngineImpl implements CelExpressionEngine {
     public Set<String> evaluationScopes(String leftOperand) {
         return fetch(leftOperand)
                 .stream()
-                .flatMap(expr -> expr.scopes().stream())
+                .flatMap(expr -> expr.getScopes().stream())
                 .collect(Collectors.toSet());
     }
 
@@ -136,7 +136,7 @@ public class CelExpressionEngineImpl implements CelExpressionEngine {
 
     private Result<List<CelAbstractSyntaxTree>> fetchAndCompile(String leftOperand) {
         return fetch(leftOperand).stream()
-                .map(expr -> compile(expr.expression()))
+                .map(expr -> compile(expr.getExpression()))
                 .collect(Result.collector());
     }
 

--- a/extensions/cel/cel-extension/src/main/java/org/eclipse/edc/virtualized/policy/cel/service/CelPolicyExpressionServiceImpl.java
+++ b/extensions/cel/cel-extension/src/main/java/org/eclipse/edc/virtualized/policy/cel/service/CelPolicyExpressionServiceImpl.java
@@ -14,6 +14,7 @@
 
 package org.eclipse.edc.virtualized.policy.cel.service;
 
+import org.eclipse.edc.spi.query.Criterion;
 import org.eclipse.edc.spi.query.QuerySpec;
 import org.eclipse.edc.spi.result.ServiceResult;
 import org.eclipse.edc.transaction.spi.TransactionContext;
@@ -38,7 +39,7 @@ public class CelPolicyExpressionServiceImpl implements CelPolicyExpressionServic
     @Override
     public ServiceResult<Void> create(CelExpression expression) {
         return tx.execute(() -> {
-            var validationResult = engine.validate(expression.expression());
+            var validationResult = engine.validate(expression.getExpression());
             if (validationResult.failed()) {
                 return validationResult;
             }
@@ -52,9 +53,22 @@ public class CelPolicyExpressionServiceImpl implements CelPolicyExpressionServic
     }
 
     @Override
+    public ServiceResult<CelExpression> findById(String id) {
+        return tx.execute(() -> {
+            var query = QuerySpec.Builder.newInstance().filter(Criterion.criterion("id", "=", id)).build();
+            var results = store.query(query);
+            if (results.isEmpty()) {
+                return ServiceResult.notFound("CelExpression with id " + id + " not found");
+            } else {
+                return ServiceResult.success(results.get(0));
+            }
+        });
+    }
+
+    @Override
     public ServiceResult<Void> update(CelExpression expression) {
         return tx.execute(() -> {
-            var validationResult = engine.validate(expression.expression());
+            var validationResult = engine.validate(expression.getExpression());
             if (validationResult.failed()) {
                 return validationResult;
             }

--- a/extensions/cel/cel-extension/src/main/java/org/eclipse/edc/virtualized/policy/cel/store/InMemoryCelExpressionStore.java
+++ b/extensions/cel/cel-extension/src/main/java/org/eclipse/edc/virtualized/policy/cel/store/InMemoryCelExpressionStore.java
@@ -37,16 +37,16 @@ public class InMemoryCelExpressionStore implements CelExpressionStore {
 
     @Override
     public StoreResult<Void> create(CelExpression expression) {
-        return expressions.putIfAbsent(expression.id(), expression) == null
+        return expressions.putIfAbsent(expression.getId(), expression) == null
                 ? StoreResult.success()
-                : StoreResult.alreadyExists(alreadyExistsErrorMessage(expression.id()));
+                : StoreResult.alreadyExists(alreadyExistsErrorMessage(expression.getId()));
     }
 
     @Override
     public StoreResult<Void> update(CelExpression expression) {
-        return expressions.replace(expression.id(), expression) != null
+        return expressions.replace(expression.getId(), expression) != null
                 ? StoreResult.success()
-                : StoreResult.notFound(notFoundErrorMessage(expression.id()));
+                : StoreResult.notFound(notFoundErrorMessage(expression.getId()));
     }
 
     @Override

--- a/extensions/cel/cel-extension/src/test/java/org/eclipse/edc/virtualized/policy/cel/engine/CelExpressionEngineImplTest.java
+++ b/extensions/cel/cel-extension/src/test/java/org/eclipse/edc/virtualized/policy/cel/engine/CelExpressionEngineImplTest.java
@@ -229,7 +229,11 @@ public class CelExpressionEngineImplTest {
     }
 
     private CelExpression expression(String expr) {
-        return new CelExpression("id", "test", expr, "desc");
+        return CelExpression.Builder.newInstance().id("id")
+                .leftOperand("test")
+                .expression(expr)
+                .description("description")
+                .build();
     }
 
     private @NotNull Map<String, Object> credential() {

--- a/extensions/cel/cel-extension/src/test/java/org/eclipse/edc/virtualized/policy/cel/service/CelPolicyExpressionServiceImplTest.java
+++ b/extensions/cel/cel-extension/src/test/java/org/eclipse/edc/virtualized/policy/cel/service/CelPolicyExpressionServiceImplTest.java
@@ -134,6 +134,10 @@ public class CelPolicyExpressionServiceImplTest {
     }
 
     private CelExpression celExpression(String id) {
-        return new CelExpression(id, "leftOperand", "expression", "description");
+        return CelExpression.Builder.newInstance().id(id)
+                .leftOperand("leftOperand")
+                .expression("expression")
+                .description("description")
+                .build();
     }
 }

--- a/extensions/cel/cel-spi/src/main/java/org/eclipse/edc/virtualized/policy/cel/model/CelExpression.java
+++ b/extensions/cel/cel-spi/src/main/java/org/eclipse/edc/virtualized/policy/cel/model/CelExpression.java
@@ -14,25 +14,122 @@
 
 package org.eclipse.edc.virtualized.policy.cel.model;
 
-import java.time.Clock;
+import org.eclipse.edc.spi.entity.Entity;
+
+import java.util.HashSet;
+import java.util.Objects;
 import java.util.Set;
+
+import static org.eclipse.edc.spi.constants.CoreConstants.EDC_NAMESPACE;
 
 /**
  * Represents a CEL (Common Expression Language) expression used in policy definitions.
  *
- * @param id          the unique identifier of the CEL expression
- * @param leftOperand the left operand of the expression
- * @param expression  the CEL expression string
- * @param description a description of the expression
- * @param createdAt   the timestamp when the expression was created
- * @param updatedAt   the timestamp when the expression was last updated
  */
-public record CelExpression(String id, Set<String> scopes, String leftOperand, String expression,
-                            String description, Long createdAt, Long updatedAt) {
+public class CelExpression extends Entity {
+
+    public static final String CEL_EXPRESSION_TYPE_TERM = "CelExpression";
+    public static final String CEL_EXPRESSION_TYPE_IRI = EDC_NAMESPACE + CEL_EXPRESSION_TYPE_TERM;
+    public static final String CEL_EXPRESSION_SCOPES_TERM = "scopes";
+    public static final String CEL_EXPRESSION_SCOPES_IRI = EDC_NAMESPACE + CEL_EXPRESSION_SCOPES_TERM;
+    public static final String CEL_EXPRESSION_LEFT_OPERAND_TERM = "leftOperand";
+    public static final String CEL_EXPRESSION_LEFT_OPERAND_IRI = EDC_NAMESPACE + CEL_EXPRESSION_LEFT_OPERAND_TERM;
+    public static final String CEL_EXPRESSION_EXPRESSION_TERM = "expression";
+    public static final String CEL_EXPRESSION_EXPRESSION_IRI = EDC_NAMESPACE + CEL_EXPRESSION_EXPRESSION_TERM;
+    public static final String CEL_EXPRESSION_DESCRIPTION_TERM = "description";
+    public static final String CEL_EXPRESSION_DESCRIPTION_IRI = EDC_NAMESPACE + CEL_EXPRESSION_DESCRIPTION_TERM;
+    public static final String MATCH_ALL_SCOPE = "*.";
+
+    private Set<String> scopes = new HashSet<>();
+    private String leftOperand;
+    private String expression;
+    private String description;
+    private long updatedAt;
 
 
-    public CelExpression(String id, String leftOperand, String expression, String description) {
-        this(id, Set.of("*."), leftOperand, expression, description, Clock.systemUTC().millis(), Clock.systemUTC().millis());
+    private CelExpression() {
     }
 
+    public Set<String> getScopes() {
+        return scopes;
+    }
+
+    public String getDescription() {
+        return description;
+    }
+
+    public String getExpression() {
+        return expression;
+    }
+
+    public String getLeftOperand() {
+        return leftOperand;
+    }
+
+    public long getUpdatedAt() {
+        return updatedAt;
+    }
+
+    public static class Builder extends Entity.Builder<CelExpression, Builder> {
+
+        private Builder() {
+            super(new CelExpression());
+        }
+
+        public static Builder newInstance() {
+            return new Builder();
+        }
+
+        public Builder id(String id) {
+            entity.id = id;
+            return this;
+        }
+
+        @Override
+        public Builder self() {
+            return this;
+        }
+
+        public Builder scopes(Set<String> scopes) {
+            entity.scopes = scopes;
+            return this;
+        }
+
+        public Builder leftOperand(String leftOperand) {
+            entity.leftOperand = leftOperand;
+            return this;
+        }
+
+        public Builder expression(String expression) {
+            entity.expression = expression;
+            return this;
+        }
+
+        public Builder description(String description) {
+            entity.description = description;
+            return this;
+        }
+
+        public Builder updatedAt(Long updatedAt) {
+            entity.updatedAt = updatedAt;
+            return this;
+        }
+
+        public CelExpression build() {
+            Objects.requireNonNull(entity.leftOperand, "CelExpression leftOperand cannot be null");
+            Objects.requireNonNull(entity.expression, "CelExpression expression cannot be null");
+            Objects.requireNonNull(entity.description, "CelExpression description cannot be null");
+
+            if (entity.getUpdatedAt() == 0L) {
+                entity.updatedAt = entity.getCreatedAt();
+            }
+
+            if (entity.scopes.isEmpty()) {
+                entity.scopes.add(MATCH_ALL_SCOPE);
+            }
+
+            return super.build();
+        }
+
+    }
 }

--- a/extensions/cel/cel-spi/src/main/java/org/eclipse/edc/virtualized/policy/cel/service/CelPolicyExpressionService.java
+++ b/extensions/cel/cel-spi/src/main/java/org/eclipse/edc/virtualized/policy/cel/service/CelPolicyExpressionService.java
@@ -35,6 +35,14 @@ public interface CelPolicyExpressionService {
     ServiceResult<Void> create(CelExpression expression);
 
     /**
+     * Finds a CEL expression by its ID.
+     *
+     * @param id the ID of the expression to find
+     * @return a service result containing the found expression or an error
+     */
+    ServiceResult<CelExpression> findById(String id);
+
+    /**
      * Updates an existing CEL expression.
      *
      * @param expression the expression to update

--- a/extensions/cel/cel-spi/src/testFixtures/java/org/eclipse/edc/virtualized/policy/cel/CelExpressionStoreTestBase.java
+++ b/extensions/cel/cel-spi/src/testFixtures/java/org/eclipse/edc/virtualized/policy/cel/CelExpressionStoreTestBase.java
@@ -135,7 +135,7 @@ public abstract class CelExpressionStoreTestBase {
         var expr = celExpression("expr-to-delete");
         getStore().create(expr);
 
-        var deleteRes = getStore().delete(expr.id());
+        var deleteRes = getStore().delete(expr.getId());
         assertThat(deleteRes).isSucceeded();
     }
 
@@ -150,6 +150,10 @@ public abstract class CelExpressionStoreTestBase {
     }
 
     private CelExpression celExpression(String id, String leftOperand) {
-        return new CelExpression(id, leftOperand, "expression", "description");
+        return CelExpression.Builder.newInstance().id(id)
+                .leftOperand(leftOperand)
+                .expression("expression")
+                .description("description")
+                .build();
     }
 }

--- a/extensions/common/api/lib/v-management-api-lib/build.gradle.kts
+++ b/extensions/common/api/lib/v-management-api-lib/build.gradle.kts
@@ -1,0 +1,30 @@
+/*
+ *  Copyright (c) 2025 Metaform Systems, Inc.
+ *
+ *  This program and the accompanying materials are made available under the
+ *  terms of the Apache License, Version 2.0 which is available at
+ *  https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Contributors:
+ *       Metaform Systems, Inc. - initial API and implementation
+ *
+ */
+
+plugins {
+    `java-library`
+}
+
+dependencies {
+    api(libs.edc.spi.jsonld)
+    api(libs.edc.spi.web)
+    api(libs.edc.spi.contract)
+    api(libs.edc.lib.mgmtapi)
+
+    testImplementation(libs.edc.junit)
+    testImplementation(libs.edc.lib.jsonld)
+    testImplementation(libs.edc.lib.transform)
+}
+
+

--- a/extensions/common/api/lib/v-management-api-lib/src/main/java/org/eclipse/virtualized/api/management/VirtualManagementApi.java
+++ b/extensions/common/api/lib/v-management-api-lib/src/main/java/org/eclipse/virtualized/api/management/VirtualManagementApi.java
@@ -14,17 +14,8 @@
 
 package org.eclipse.virtualized.api.management;
 
-public interface ManagementApi {
+public interface VirtualManagementApi {
 
-    // Transformer scope for management API
-    String MANAGEMENT_API_CONTEXT = "management-api";
-
-    String MANAGEMENT_API_V_4_ALPHA = "v4alpha";
-
-    // JSON-LD scope for management API
-    String MANAGEMENT_SCOPE = "MANAGEMENT_API";
-
-    // JSON-LD scope for management API version 4 alpha
-    String MANAGEMENT_SCOPE_V4 = MANAGEMENT_SCOPE + ":" + MANAGEMENT_API_V_4_ALPHA;
+    String EDC_V_CONNECTOR_MANAGEMENT_CONTEXT_V2 = "https://w3id.org/edc/virtual-connector/management/v2";
 
 }

--- a/extensions/common/api/lib/v-management-api-lib/src/main/java/org/eclipse/virtualized/api/management/schema/VirtualManagementApiJsonSchema.java
+++ b/extensions/common/api/lib/v-management-api-lib/src/main/java/org/eclipse/virtualized/api/management/schema/VirtualManagementApiJsonSchema.java
@@ -12,18 +12,14 @@
  *
  */
 
-plugins {
-    `java-library`
+package org.eclipse.virtualized.api.management.schema;
+
+public interface VirtualManagementApiJsonSchema {
+
+    String VIRTUAL_EDC_MGMT_V4_SCHEMA_PREFIX = "https://w3id.org/edc/virtual-connector/management/schema/v4";
+
+    interface V4 {
+
+        String CEL_EXPRESSION = VIRTUAL_EDC_MGMT_V4_SCHEMA_PREFIX + "/cel-expression-schema.json";
+    }
 }
-
-dependencies {
-    api(libs.edc.spi.jsonld)
-    api(libs.edc.spi.web)
-    api(libs.edc.spi.contract)
-
-    testImplementation(libs.edc.junit)
-    testImplementation(libs.edc.lib.jsonld)
-    testImplementation(libs.edc.lib.transform)
-}
-
-

--- a/extensions/control-plane/api/management-api/build.gradle.kts
+++ b/extensions/control-plane/api/management-api/build.gradle.kts
@@ -27,5 +27,7 @@ dependencies {
     api(project(":extensions:control-plane:api:management-api:transfer-process-api"))
     api(project(":extensions:control-plane:api:management-api:participant-context-api"))
     api(project(":extensions:control-plane:api:management-api:participant-context-config-api"))
+    api(project(":extensions:control-plane:api:management-api:cel-api"))
     api(project(":extensions:control-plane:api:management-api:management-api-configuration"))
+    api(project(":extensions:control-plane:api:management-api:v-management-api-schema-validator"))
 }

--- a/extensions/control-plane/api/management-api/cel-api/build.gradle.kts
+++ b/extensions/control-plane/api/management-api/cel-api/build.gradle.kts
@@ -1,0 +1,55 @@
+/*
+ *  Copyright (c) 2025 Metaform Systems, Inc.
+ *
+ *  This program and the accompanying materials are made available under the
+ *  terms of the Apache License, Version 2.0 which is available at
+ *  https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Contributors:
+ *       Metaform Systems, Inc. - initial API and implementation
+ *
+ */
+
+
+
+plugins {
+    `java-library`
+    id(libs.plugins.swagger.get().pluginId)
+
+}
+
+dependencies {
+
+    api(project(":spi:v-auth-spi"))
+    api(project(":extensions:cel:cel-spi"))
+    api(project(":extensions:common:api:lib:v-management-api-lib"))
+    implementation(libs.edc.spi.core)
+    implementation(libs.edc.spi.contract)
+    implementation(libs.edc.spi.controlplane)
+    implementation(libs.edc.spi.participantcontext.config)
+    implementation(libs.edc.spi.asset)
+    implementation(libs.edc.spi.validator)
+    implementation(libs.edc.spi.web)
+    implementation(libs.edc.spi.transform)
+    implementation(libs.edc.lib.controlplane.transform)
+    implementation(libs.jakarta.annotation)
+
+    implementation(libs.edc.lib.api)
+    implementation(libs.edc.lib.jersey.providers)
+    implementation(libs.edc.lib.mgmtapi)
+    implementation(libs.edc.lib.validator)
+
+    testImplementation(testFixtures(libs.edc.core.jersey))
+    testImplementation(libs.restAssured)
+    testImplementation(libs.awaitility)
+}
+
+edcBuild {
+    swagger {
+        apiGroup.set("management-api")
+    }
+}
+
+

--- a/extensions/control-plane/api/management-api/cel-api/src/main/java/org/eclipse/edc/virtualized/connector/controlplane/api/management/cel/CelExpressionManagementApiExtension.java
+++ b/extensions/control-plane/api/management-api/cel-api/src/main/java/org/eclipse/edc/virtualized/connector/controlplane/api/management/cel/CelExpressionManagementApiExtension.java
@@ -1,0 +1,77 @@
+/*
+ *  Copyright (c) 2025 Metaform Systems, Inc.
+ *
+ *  This program and the accompanying materials are made available under the
+ *  terms of the Apache License, Version 2.0 which is available at
+ *  https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Contributors:
+ *       Metaform Systems, Inc. - initial API and implementation
+ *
+ */
+
+package org.eclipse.edc.virtualized.connector.controlplane.api.management.cel;
+
+import jakarta.json.Json;
+import org.eclipse.edc.api.management.schema.ManagementApiJsonSchema;
+import org.eclipse.edc.jsonld.spi.JsonLd;
+import org.eclipse.edc.runtime.metamodel.annotation.Extension;
+import org.eclipse.edc.runtime.metamodel.annotation.Inject;
+import org.eclipse.edc.spi.system.ServiceExtension;
+import org.eclipse.edc.spi.system.ServiceExtensionContext;
+import org.eclipse.edc.spi.types.TypeManager;
+import org.eclipse.edc.transform.spi.TypeTransformerRegistry;
+import org.eclipse.edc.validator.spi.JsonObjectValidatorRegistry;
+import org.eclipse.edc.virtualized.connector.controlplane.api.management.cel.transform.JsonObjectFromCelExpressionTransformer;
+import org.eclipse.edc.virtualized.connector.controlplane.api.management.cel.transform.JsonObjectToCelExpressionTransformer;
+import org.eclipse.edc.virtualized.connector.controlplane.api.management.cel.v4.CelExpressionApiV4Controller;
+import org.eclipse.edc.virtualized.policy.cel.service.CelPolicyExpressionService;
+import org.eclipse.edc.web.jersey.providers.jsonld.JerseyJsonLdInterceptor;
+import org.eclipse.edc.web.spi.WebService;
+import org.eclipse.edc.web.spi.configuration.ApiContext;
+
+import java.util.Map;
+
+import static org.eclipse.edc.api.management.ManagementApi.MANAGEMENT_SCOPE_V4;
+import static org.eclipse.edc.spi.constants.CoreConstants.JSON_LD;
+import static org.eclipse.edc.virtualized.connector.controlplane.api.management.cel.CelExpressionManagementApiExtension.NAME;
+
+@Extension(value = NAME)
+public class CelExpressionManagementApiExtension implements ServiceExtension {
+
+    public static final String NAME = "CEL management API Extension";
+
+    @Inject
+    private WebService webService;
+
+    @Inject
+    private TypeTransformerRegistry transformerRegistry;
+
+    @Inject
+    private JsonObjectValidatorRegistry validatorRegistry;
+
+    @Inject
+    private JsonLd jsonLd;
+
+    @Inject
+    private TypeManager typeManager;
+
+    @Inject
+    private CelPolicyExpressionService service;
+
+    @Override
+    public void initialize(ServiceExtensionContext context) {
+        var factory = Json.createBuilderFactory(Map.of());
+
+        var managementApiTransformerRegistry = transformerRegistry.forContext("management-api");
+
+        managementApiTransformerRegistry.register(new JsonObjectFromCelExpressionTransformer(factory));
+        managementApiTransformerRegistry.register(new JsonObjectToCelExpressionTransformer());
+
+        webService.registerResource(ApiContext.MANAGEMENT, new CelExpressionApiV4Controller(service, managementApiTransformerRegistry));
+        webService.registerDynamicResource(ApiContext.MANAGEMENT, CelExpressionApiV4Controller.class, new JerseyJsonLdInterceptor(jsonLd, typeManager, JSON_LD, MANAGEMENT_SCOPE_V4, validatorRegistry, ManagementApiJsonSchema.V4.version()));
+
+    }
+}

--- a/extensions/control-plane/api/management-api/cel-api/src/main/java/org/eclipse/edc/virtualized/connector/controlplane/api/management/cel/transform/JsonObjectFromCelExpressionTransformer.java
+++ b/extensions/control-plane/api/management-api/cel-api/src/main/java/org/eclipse/edc/virtualized/connector/controlplane/api/management/cel/transform/JsonObjectFromCelExpressionTransformer.java
@@ -1,0 +1,53 @@
+/*
+ *  Copyright (c) 2025 Metaform Systems, Inc.
+ *
+ *  This program and the accompanying materials are made available under the
+ *  terms of the Apache License, Version 2.0 which is available at
+ *  https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Contributors:
+ *       Metaform Systems, Inc. - initial API and implementation
+ *
+ */
+
+package org.eclipse.edc.virtualized.connector.controlplane.api.management.cel.transform;
+
+import jakarta.json.Json;
+import jakarta.json.JsonBuilderFactory;
+import jakarta.json.JsonObject;
+import org.eclipse.edc.jsonld.spi.transformer.AbstractJsonLdTransformer;
+import org.eclipse.edc.transform.spi.TransformerContext;
+import org.eclipse.edc.virtualized.policy.cel.model.CelExpression;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+
+import static org.eclipse.edc.jsonld.spi.JsonLdKeywords.ID;
+import static org.eclipse.edc.jsonld.spi.JsonLdKeywords.TYPE;
+import static org.eclipse.edc.virtualized.policy.cel.model.CelExpression.CEL_EXPRESSION_DESCRIPTION_IRI;
+import static org.eclipse.edc.virtualized.policy.cel.model.CelExpression.CEL_EXPRESSION_EXPRESSION_IRI;
+import static org.eclipse.edc.virtualized.policy.cel.model.CelExpression.CEL_EXPRESSION_LEFT_OPERAND_IRI;
+import static org.eclipse.edc.virtualized.policy.cel.model.CelExpression.CEL_EXPRESSION_SCOPES_IRI;
+
+public class JsonObjectFromCelExpressionTransformer extends AbstractJsonLdTransformer<CelExpression, JsonObject> {
+
+    private final JsonBuilderFactory factory;
+
+    public JsonObjectFromCelExpressionTransformer(JsonBuilderFactory factory) {
+        super(CelExpression.class, JsonObject.class);
+        this.factory = factory;
+    }
+
+    @Override
+    public @Nullable JsonObject transform(@NotNull CelExpression celExpression, @NotNull TransformerContext context) {
+        return factory.createObjectBuilder()
+                .add(ID, celExpression.getId())
+                .add(TYPE, CelExpression.CEL_EXPRESSION_TYPE_IRI)
+                .add(CEL_EXPRESSION_LEFT_OPERAND_IRI, celExpression.getLeftOperand())
+                .add(CEL_EXPRESSION_EXPRESSION_IRI, celExpression.getExpression())
+                .add(CEL_EXPRESSION_DESCRIPTION_IRI, celExpression.getDescription())
+                .add(CEL_EXPRESSION_SCOPES_IRI, Json.createArrayBuilder(celExpression.getScopes()))
+                .build();
+    }
+}

--- a/extensions/control-plane/api/management-api/cel-api/src/main/java/org/eclipse/edc/virtualized/connector/controlplane/api/management/cel/transform/JsonObjectToCelExpressionTransformer.java
+++ b/extensions/control-plane/api/management-api/cel-api/src/main/java/org/eclipse/edc/virtualized/connector/controlplane/api/management/cel/transform/JsonObjectToCelExpressionTransformer.java
@@ -1,0 +1,64 @@
+/*
+ *  Copyright (c) 2025 Metaform Systems, Inc.
+ *
+ *  This program and the accompanying materials are made available under the
+ *  terms of the Apache License, Version 2.0 which is available at
+ *  https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Contributors:
+ *       Metaform Systems, Inc. - initial API and implementation
+ *
+ */
+
+package org.eclipse.edc.virtualized.connector.controlplane.api.management.cel.transform;
+
+import jakarta.json.JsonObject;
+import org.eclipse.edc.jsonld.spi.transformer.AbstractJsonLdTransformer;
+import org.eclipse.edc.transform.spi.TransformerContext;
+import org.eclipse.edc.virtualized.policy.cel.model.CelExpression;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+
+import java.util.HashSet;
+import java.util.UUID;
+
+import static java.util.Optional.ofNullable;
+import static org.eclipse.edc.virtualized.policy.cel.model.CelExpression.CEL_EXPRESSION_DESCRIPTION_IRI;
+import static org.eclipse.edc.virtualized.policy.cel.model.CelExpression.CEL_EXPRESSION_EXPRESSION_IRI;
+import static org.eclipse.edc.virtualized.policy.cel.model.CelExpression.CEL_EXPRESSION_LEFT_OPERAND_IRI;
+import static org.eclipse.edc.virtualized.policy.cel.model.CelExpression.CEL_EXPRESSION_SCOPES_IRI;
+
+public class JsonObjectToCelExpressionTransformer extends AbstractJsonLdTransformer<JsonObject, CelExpression> {
+
+    public JsonObjectToCelExpressionTransformer() {
+        super(JsonObject.class, CelExpression.class);
+    }
+
+    @Override
+    public @Nullable CelExpression transform(@NotNull JsonObject object, @NotNull TransformerContext context) {
+
+        var id = nodeId(object);
+
+        if (id == null) {
+            id = UUID.randomUUID().toString();
+        }
+        var scopes = new HashSet<String>();
+
+        var operandLeft = transformString(object.get(CEL_EXPRESSION_LEFT_OPERAND_IRI), context);
+        var expression = transformString(object.get(CEL_EXPRESSION_EXPRESSION_IRI), context);
+        var description = transformString(object.get(CEL_EXPRESSION_DESCRIPTION_IRI), context);
+
+        ofNullable(object.getJsonArray(CEL_EXPRESSION_SCOPES_IRI))
+                .ifPresent(ja -> scopes.addAll(ja.stream().map(this::nodeValue).toList()));
+
+        return CelExpression.Builder.newInstance()
+                .id(id)
+                .scopes(scopes)
+                .leftOperand(operandLeft)
+                .expression(expression)
+                .description(description)
+                .build();
+    }
+}

--- a/extensions/control-plane/api/management-api/cel-api/src/main/java/org/eclipse/edc/virtualized/connector/controlplane/api/management/cel/v4/CelExpressionApiV4.java
+++ b/extensions/control-plane/api/management-api/cel-api/src/main/java/org/eclipse/edc/virtualized/connector/controlplane/api/management/cel/v4/CelExpressionApiV4.java
@@ -1,0 +1,101 @@
+/*
+ *  Copyright (c) 2025 Metaform Systems, Inc.
+ *
+ *  This program and the accompanying materials are made available under the
+ *  terms of the Apache License, Version 2.0 which is available at
+ *  https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Contributors:
+ *       Metaform Systems, Inc. - initial API and implementation
+ *
+ */
+
+package org.eclipse.edc.virtualized.connector.controlplane.api.management.cel.v4;
+
+import io.swagger.v3.oas.annotations.OpenAPIDefinition;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.info.Info;
+import io.swagger.v3.oas.annotations.media.ArraySchema;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.parameters.RequestBody;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.json.JsonArray;
+import jakarta.json.JsonObject;
+import jakarta.ws.rs.core.SecurityContext;
+import org.eclipse.virtualized.api.management.schema.VirtualManagementApiJsonSchema;
+
+@OpenAPIDefinition(info = @Info(title = "Cel Expressions Management API", version = "v4alpha"))
+@Tag(name = "Cel Expressions v4alpha")
+public interface CelExpressionApiV4 {
+
+    @Operation(description = "Set ParticipantContext config.",
+            requestBody = @RequestBody(content = @Content(schema = @Schema(ref = org.eclipse.edc.api.management.schema.ManagementApiJsonSchema.V4.PARTICIPANT_CONTEXT_CONFIG), mediaType = "application/json")),
+            responses = {
+                    @ApiResponse(responseCode = "200", description = "The Expression was created successfully"),
+                    @ApiResponse(responseCode = "400", description = "Request body was malformed, or the request could not be processed",
+                            content = @Content(array = @ArraySchema(schema = @Schema(ref = org.eclipse.edc.api.management.schema.ManagementApiJsonSchema.V4.API_ERROR)), mediaType = "application/json")),
+                    @ApiResponse(responseCode = "401", description = "The request could not be completed, because either the authentication was missing or was not valid.",
+                            content = @Content(array = @ArraySchema(schema = @Schema(ref = org.eclipse.edc.api.management.schema.ManagementApiJsonSchema.V4.API_ERROR)), mediaType = "application/json")),
+                    @ApiResponse(responseCode = "409", description = "Can't create the ParticipantContext, because a object with the same ID already exists",
+                            content = @Content(array = @ArraySchema(schema = @Schema(ref = org.eclipse.edc.api.management.schema.ManagementApiJsonSchema.V4.API_ERROR)), mediaType = "application/json"))
+            }
+    )
+    JsonObject createExpressionV4(JsonObject expression);
+
+    @Operation(description = "Gets an Expression by ID.",
+            responses = {
+                    @ApiResponse(responseCode = "200", description = "The Cel Expression.",
+                            content = @Content(schema = @Schema(ref = VirtualManagementApiJsonSchema.V4.CEL_EXPRESSION))),
+                    @ApiResponse(responseCode = "400", description = "Request body was malformed, or the request could not be processed",
+                            content = @Content(array = @ArraySchema(schema = @Schema(ref = org.eclipse.edc.api.management.schema.ManagementApiJsonSchema.V4.API_ERROR)), mediaType = "application/json")),
+                    @ApiResponse(responseCode = "401", description = "The request could not be completed, because either the authentication was missing or was not valid.",
+                            content = @Content(array = @ArraySchema(schema = @Schema(ref = org.eclipse.edc.api.management.schema.ManagementApiJsonSchema.V4.API_ERROR)), mediaType = "application/json")),
+                    @ApiResponse(responseCode = "404", description = "A ParticipantContext with the given ID does not exist.",
+                            content = @Content(array = @ArraySchema(schema = @Schema(ref = org.eclipse.edc.api.management.schema.ManagementApiJsonSchema.V4.API_ERROR)), mediaType = "application/json"))
+            }
+    )
+    JsonObject getExpressionV4(String id, SecurityContext securityContext);
+
+    @Operation(description = "Update an Expression.",
+            responses = {
+                    @ApiResponse(responseCode = "204", description = "The Cel Expression was updated successfully.",
+                            content = @Content(schema = @Schema(ref = VirtualManagementApiJsonSchema.V4.CEL_EXPRESSION))),
+                    @ApiResponse(responseCode = "400", description = "Request body was malformed, or the request could not be processed",
+                            content = @Content(array = @ArraySchema(schema = @Schema(ref = org.eclipse.edc.api.management.schema.ManagementApiJsonSchema.V4.API_ERROR)), mediaType = "application/json")),
+                    @ApiResponse(responseCode = "401", description = "The request could not be completed, because either the authentication was missing or was not valid.",
+                            content = @Content(array = @ArraySchema(schema = @Schema(ref = org.eclipse.edc.api.management.schema.ManagementApiJsonSchema.V4.API_ERROR)), mediaType = "application/json")),
+                    @ApiResponse(responseCode = "404", description = "A ParticipantContext with the given ID does not exist.",
+                            content = @Content(array = @ArraySchema(schema = @Schema(ref = org.eclipse.edc.api.management.schema.ManagementApiJsonSchema.V4.API_ERROR)), mediaType = "application/json"))
+            }
+    )
+    void updateExpressionV4(String id, JsonObject expression, SecurityContext securityContext);
+
+    @Operation(description = "Returns all cel expressions according to a query",
+            requestBody = @RequestBody(content = @Content(schema = @Schema(ref = org.eclipse.edc.api.management.schema.ManagementApiJsonSchema.V4.QUERY_SPEC))),
+            responses = {
+                    @ApiResponse(responseCode = "200", description = "The policy definitions matching the query",
+                            content = @Content(array = @ArraySchema(schema = @Schema(ref = VirtualManagementApiJsonSchema.V4.CEL_EXPRESSION)))),
+                    @ApiResponse(responseCode = "400", description = "Request was malformed",
+                            content = @Content(array = @ArraySchema(schema = @Schema(ref = org.eclipse.edc.api.management.schema.ManagementApiJsonSchema.V4.API_ERROR))))}
+    )
+    JsonArray queryExpressionV4(JsonObject querySpecJson);
+
+    @Operation(description = "Delete an Expression by ID.",
+            responses = {
+                    @ApiResponse(responseCode = "204", description = "The Cel Expression was deleted.",
+                            content = @Content(schema = @Schema(ref = VirtualManagementApiJsonSchema.V4.CEL_EXPRESSION))),
+                    @ApiResponse(responseCode = "400", description = "Request body was malformed, or the request could not be processed",
+                            content = @Content(array = @ArraySchema(schema = @Schema(ref = org.eclipse.edc.api.management.schema.ManagementApiJsonSchema.V4.API_ERROR)), mediaType = "application/json")),
+                    @ApiResponse(responseCode = "401", description = "The request could not be completed, because either the authentication was missing or was not valid.",
+                            content = @Content(array = @ArraySchema(schema = @Schema(ref = org.eclipse.edc.api.management.schema.ManagementApiJsonSchema.V4.API_ERROR)), mediaType = "application/json")),
+                    @ApiResponse(responseCode = "404", description = "A ParticipantContext with the given ID does not exist.",
+                            content = @Content(array = @ArraySchema(schema = @Schema(ref = org.eclipse.edc.api.management.schema.ManagementApiJsonSchema.V4.API_ERROR)), mediaType = "application/json"))
+            }
+    )
+    void deleteExpressionV4(String id, SecurityContext securityContext);
+
+}

--- a/extensions/control-plane/api/management-api/cel-api/src/main/java/org/eclipse/edc/virtualized/connector/controlplane/api/management/cel/v4/CelExpressionApiV4.java
+++ b/extensions/control-plane/api/management-api/cel-api/src/main/java/org/eclipse/edc/virtualized/connector/controlplane/api/management/cel/v4/CelExpressionApiV4.java
@@ -25,23 +25,23 @@ import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.json.JsonArray;
 import jakarta.json.JsonObject;
-import jakarta.ws.rs.core.SecurityContext;
+import org.eclipse.edc.api.management.schema.ManagementApiJsonSchema;
 import org.eclipse.virtualized.api.management.schema.VirtualManagementApiJsonSchema;
 
 @OpenAPIDefinition(info = @Info(title = "Cel Expressions Management API", version = "v4alpha"))
 @Tag(name = "Cel Expressions v4alpha")
 public interface CelExpressionApiV4 {
 
-    @Operation(description = "Set ParticipantContext config.",
-            requestBody = @RequestBody(content = @Content(schema = @Schema(ref = org.eclipse.edc.api.management.schema.ManagementApiJsonSchema.V4.PARTICIPANT_CONTEXT_CONFIG), mediaType = "application/json")),
+    @Operation(description = "Create a Cel Expression.",
+            requestBody = @RequestBody(content = @Content(schema = @Schema(ref = ManagementApiJsonSchema.V4.PARTICIPANT_CONTEXT_CONFIG), mediaType = "application/json")),
             responses = {
-                    @ApiResponse(responseCode = "200", description = "The Expression was created successfully"),
+                    @ApiResponse(responseCode = "200", description = "The Cel Expression was created successfully"),
                     @ApiResponse(responseCode = "400", description = "Request body was malformed, or the request could not be processed",
-                            content = @Content(array = @ArraySchema(schema = @Schema(ref = org.eclipse.edc.api.management.schema.ManagementApiJsonSchema.V4.API_ERROR)), mediaType = "application/json")),
+                            content = @Content(array = @ArraySchema(schema = @Schema(ref = ManagementApiJsonSchema.V4.API_ERROR)), mediaType = "application/json")),
                     @ApiResponse(responseCode = "401", description = "The request could not be completed, because either the authentication was missing or was not valid.",
-                            content = @Content(array = @ArraySchema(schema = @Schema(ref = org.eclipse.edc.api.management.schema.ManagementApiJsonSchema.V4.API_ERROR)), mediaType = "application/json")),
-                    @ApiResponse(responseCode = "409", description = "Can't create the ParticipantContext, because a object with the same ID already exists",
-                            content = @Content(array = @ArraySchema(schema = @Schema(ref = org.eclipse.edc.api.management.schema.ManagementApiJsonSchema.V4.API_ERROR)), mediaType = "application/json"))
+                            content = @Content(array = @ArraySchema(schema = @Schema(ref = ManagementApiJsonSchema.V4.API_ERROR)), mediaType = "application/json")),
+                    @ApiResponse(responseCode = "409", description = "Can't create the Cel expression, because a object with the same ID already exists",
+                            content = @Content(array = @ArraySchema(schema = @Schema(ref = ManagementApiJsonSchema.V4.API_ERROR)), mediaType = "application/json"))
             }
     )
     JsonObject createExpressionV4(JsonObject expression);
@@ -51,36 +51,36 @@ public interface CelExpressionApiV4 {
                     @ApiResponse(responseCode = "200", description = "The Cel Expression.",
                             content = @Content(schema = @Schema(ref = VirtualManagementApiJsonSchema.V4.CEL_EXPRESSION))),
                     @ApiResponse(responseCode = "400", description = "Request body was malformed, or the request could not be processed",
-                            content = @Content(array = @ArraySchema(schema = @Schema(ref = org.eclipse.edc.api.management.schema.ManagementApiJsonSchema.V4.API_ERROR)), mediaType = "application/json")),
+                            content = @Content(array = @ArraySchema(schema = @Schema(ref = ManagementApiJsonSchema.V4.API_ERROR)), mediaType = "application/json")),
                     @ApiResponse(responseCode = "401", description = "The request could not be completed, because either the authentication was missing or was not valid.",
-                            content = @Content(array = @ArraySchema(schema = @Schema(ref = org.eclipse.edc.api.management.schema.ManagementApiJsonSchema.V4.API_ERROR)), mediaType = "application/json")),
-                    @ApiResponse(responseCode = "404", description = "A ParticipantContext with the given ID does not exist.",
-                            content = @Content(array = @ArraySchema(schema = @Schema(ref = org.eclipse.edc.api.management.schema.ManagementApiJsonSchema.V4.API_ERROR)), mediaType = "application/json"))
+                            content = @Content(array = @ArraySchema(schema = @Schema(ref = ManagementApiJsonSchema.V4.API_ERROR)), mediaType = "application/json")),
+                    @ApiResponse(responseCode = "404", description = "A Cel Expression with the given ID does not exist.",
+                            content = @Content(array = @ArraySchema(schema = @Schema(ref = ManagementApiJsonSchema.V4.API_ERROR)), mediaType = "application/json"))
             }
     )
-    JsonObject getExpressionV4(String id, SecurityContext securityContext);
+    JsonObject getExpressionV4(String id);
 
     @Operation(description = "Update an Expression.",
             responses = {
                     @ApiResponse(responseCode = "204", description = "The Cel Expression was updated successfully.",
                             content = @Content(schema = @Schema(ref = VirtualManagementApiJsonSchema.V4.CEL_EXPRESSION))),
                     @ApiResponse(responseCode = "400", description = "Request body was malformed, or the request could not be processed",
-                            content = @Content(array = @ArraySchema(schema = @Schema(ref = org.eclipse.edc.api.management.schema.ManagementApiJsonSchema.V4.API_ERROR)), mediaType = "application/json")),
+                            content = @Content(array = @ArraySchema(schema = @Schema(ref = ManagementApiJsonSchema.V4.API_ERROR)), mediaType = "application/json")),
                     @ApiResponse(responseCode = "401", description = "The request could not be completed, because either the authentication was missing or was not valid.",
-                            content = @Content(array = @ArraySchema(schema = @Schema(ref = org.eclipse.edc.api.management.schema.ManagementApiJsonSchema.V4.API_ERROR)), mediaType = "application/json")),
-                    @ApiResponse(responseCode = "404", description = "A ParticipantContext with the given ID does not exist.",
-                            content = @Content(array = @ArraySchema(schema = @Schema(ref = org.eclipse.edc.api.management.schema.ManagementApiJsonSchema.V4.API_ERROR)), mediaType = "application/json"))
+                            content = @Content(array = @ArraySchema(schema = @Schema(ref = ManagementApiJsonSchema.V4.API_ERROR)), mediaType = "application/json")),
+                    @ApiResponse(responseCode = "404", description = "A Cel Expression with the given ID does not exist.",
+                            content = @Content(array = @ArraySchema(schema = @Schema(ref = ManagementApiJsonSchema.V4.API_ERROR)), mediaType = "application/json"))
             }
     )
-    void updateExpressionV4(String id, JsonObject expression, SecurityContext securityContext);
+    void updateExpressionV4(String id, JsonObject expression);
 
     @Operation(description = "Returns all cel expressions according to a query",
-            requestBody = @RequestBody(content = @Content(schema = @Schema(ref = org.eclipse.edc.api.management.schema.ManagementApiJsonSchema.V4.QUERY_SPEC))),
+            requestBody = @RequestBody(content = @Content(schema = @Schema(ref = ManagementApiJsonSchema.V4.QUERY_SPEC))),
             responses = {
-                    @ApiResponse(responseCode = "200", description = "The policy definitions matching the query",
+                    @ApiResponse(responseCode = "200", description = "The cel expressions matching the query",
                             content = @Content(array = @ArraySchema(schema = @Schema(ref = VirtualManagementApiJsonSchema.V4.CEL_EXPRESSION)))),
                     @ApiResponse(responseCode = "400", description = "Request was malformed",
-                            content = @Content(array = @ArraySchema(schema = @Schema(ref = org.eclipse.edc.api.management.schema.ManagementApiJsonSchema.V4.API_ERROR))))}
+                            content = @Content(array = @ArraySchema(schema = @Schema(ref = ManagementApiJsonSchema.V4.API_ERROR))))}
     )
     JsonArray queryExpressionV4(JsonObject querySpecJson);
 
@@ -89,13 +89,13 @@ public interface CelExpressionApiV4 {
                     @ApiResponse(responseCode = "204", description = "The Cel Expression was deleted.",
                             content = @Content(schema = @Schema(ref = VirtualManagementApiJsonSchema.V4.CEL_EXPRESSION))),
                     @ApiResponse(responseCode = "400", description = "Request body was malformed, or the request could not be processed",
-                            content = @Content(array = @ArraySchema(schema = @Schema(ref = org.eclipse.edc.api.management.schema.ManagementApiJsonSchema.V4.API_ERROR)), mediaType = "application/json")),
+                            content = @Content(array = @ArraySchema(schema = @Schema(ref = ManagementApiJsonSchema.V4.API_ERROR)), mediaType = "application/json")),
                     @ApiResponse(responseCode = "401", description = "The request could not be completed, because either the authentication was missing or was not valid.",
-                            content = @Content(array = @ArraySchema(schema = @Schema(ref = org.eclipse.edc.api.management.schema.ManagementApiJsonSchema.V4.API_ERROR)), mediaType = "application/json")),
-                    @ApiResponse(responseCode = "404", description = "A ParticipantContext with the given ID does not exist.",
-                            content = @Content(array = @ArraySchema(schema = @Schema(ref = org.eclipse.edc.api.management.schema.ManagementApiJsonSchema.V4.API_ERROR)), mediaType = "application/json"))
+                            content = @Content(array = @ArraySchema(schema = @Schema(ref = ManagementApiJsonSchema.V4.API_ERROR)), mediaType = "application/json")),
+                    @ApiResponse(responseCode = "404", description = "A Cel Expression with the given ID does not exist.",
+                            content = @Content(array = @ArraySchema(schema = @Schema(ref = ManagementApiJsonSchema.V4.API_ERROR)), mediaType = "application/json"))
             }
     )
-    void deleteExpressionV4(String id, SecurityContext securityContext);
+    void deleteExpressionV4(String id);
 
 }

--- a/extensions/control-plane/api/management-api/cel-api/src/main/java/org/eclipse/edc/virtualized/connector/controlplane/api/management/cel/v4/CelExpressionApiV4Controller.java
+++ b/extensions/control-plane/api/management-api/cel-api/src/main/java/org/eclipse/edc/virtualized/connector/controlplane/api/management/cel/v4/CelExpressionApiV4Controller.java
@@ -26,8 +26,6 @@ import jakarta.ws.rs.PUT;
 import jakarta.ws.rs.Path;
 import jakarta.ws.rs.PathParam;
 import jakarta.ws.rs.Produces;
-import jakarta.ws.rs.core.Context;
-import jakarta.ws.rs.core.SecurityContext;
 import org.eclipse.edc.api.auth.spi.ParticipantPrincipal;
 import org.eclipse.edc.api.auth.spi.RequiredScope;
 import org.eclipse.edc.api.model.IdResponse;
@@ -62,7 +60,7 @@ public class CelExpressionApiV4Controller implements CelExpressionApiV4 {
     }
 
     @POST
-    @RolesAllowed({ParticipantPrincipal.ROLE_ADMIN})
+    @RolesAllowed({ParticipantPrincipal.ROLE_ADMIN, ParticipantPrincipal.ROLE_PROVISIONER})
     @RequiredScope("management-api:write")
     @Override
     public JsonObject createExpressionV4(@SchemaType(CEL_EXPRESSION_TYPE_TERM) JsonObject expression) {
@@ -84,10 +82,10 @@ public class CelExpressionApiV4Controller implements CelExpressionApiV4 {
 
     @GET
     @Path("{id}")
-    @RolesAllowed({ParticipantPrincipal.ROLE_ADMIN})
+    @RolesAllowed({ParticipantPrincipal.ROLE_ADMIN, ParticipantPrincipal.ROLE_PROVISIONER})
     @RequiredScope("management-api:read")
     @Override
-    public JsonObject getExpressionV4(@PathParam("id") String id, @Context SecurityContext securityContext) {
+    public JsonObject getExpressionV4(@PathParam("id") String id) {
 
         var expr = service.findById(id)
                 .orElseThrow(exceptionMapper(ParticipantContext.class, id));
@@ -98,10 +96,10 @@ public class CelExpressionApiV4Controller implements CelExpressionApiV4 {
 
     @PUT
     @Path("{id}")
-    @RolesAllowed({ParticipantPrincipal.ROLE_ADMIN})
+    @RolesAllowed({ParticipantPrincipal.ROLE_ADMIN, ParticipantPrincipal.ROLE_PROVISIONER})
     @RequiredScope("management-api:write")
     @Override
-    public void updateExpressionV4(@PathParam("id") String id, @SchemaType(CEL_EXPRESSION_TYPE_TERM) JsonObject expression, @Context SecurityContext securityContext) {
+    public void updateExpressionV4(@PathParam("id") String id, @SchemaType(CEL_EXPRESSION_TYPE_TERM) JsonObject expression) {
 
         var expr = transformerRegistry.transform(expression, CelExpression.class)
                 .orElseThrow(InvalidRequestException::new);
@@ -114,7 +112,7 @@ public class CelExpressionApiV4Controller implements CelExpressionApiV4 {
 
     @POST
     @Path("request")
-    @RolesAllowed({ParticipantPrincipal.ROLE_ADMIN})
+    @RolesAllowed({ParticipantPrincipal.ROLE_ADMIN, ParticipantPrincipal.ROLE_PROVISIONER})
     @RequiredScope("management-api:read")
     @Override
     public JsonArray queryExpressionV4(@SchemaType(EDC_QUERY_SPEC_TYPE_TERM) JsonObject querySpecJson) {
@@ -135,10 +133,10 @@ public class CelExpressionApiV4Controller implements CelExpressionApiV4 {
 
     @DELETE
     @Path("{id}")
-    @RolesAllowed({ParticipantPrincipal.ROLE_ADMIN})
+    @RolesAllowed({ParticipantPrincipal.ROLE_ADMIN, ParticipantPrincipal.ROLE_PROVISIONER})
     @RequiredScope("management-api:write")
     @Override
-    public void deleteExpressionV4(@PathParam("id") String id, @Context SecurityContext securityContext) {
+    public void deleteExpressionV4(@PathParam("id") String id) {
         service.delete(id)
                 .orElseThrow(exceptionMapper(ParticipantContext.class, id));
     }

--- a/extensions/control-plane/api/management-api/cel-api/src/main/java/org/eclipse/edc/virtualized/connector/controlplane/api/management/cel/v4/CelExpressionApiV4Controller.java
+++ b/extensions/control-plane/api/management-api/cel-api/src/main/java/org/eclipse/edc/virtualized/connector/controlplane/api/management/cel/v4/CelExpressionApiV4Controller.java
@@ -1,0 +1,145 @@
+/*
+ *  Copyright (c) 2025 Metaform Systems, Inc.
+ *
+ *  This program and the accompanying materials are made available under the
+ *  terms of the Apache License, Version 2.0 which is available at
+ *  https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Contributors:
+ *       Metaform Systems, Inc. - initial API and implementation
+ *
+ */
+
+package org.eclipse.edc.virtualized.connector.controlplane.api.management.cel.v4;
+
+
+import jakarta.annotation.security.RolesAllowed;
+import jakarta.json.JsonArray;
+import jakarta.json.JsonObject;
+import jakarta.ws.rs.Consumes;
+import jakarta.ws.rs.DELETE;
+import jakarta.ws.rs.GET;
+import jakarta.ws.rs.POST;
+import jakarta.ws.rs.PUT;
+import jakarta.ws.rs.Path;
+import jakarta.ws.rs.PathParam;
+import jakarta.ws.rs.Produces;
+import jakarta.ws.rs.core.Context;
+import jakarta.ws.rs.core.SecurityContext;
+import org.eclipse.edc.api.auth.spi.ParticipantPrincipal;
+import org.eclipse.edc.api.auth.spi.RequiredScope;
+import org.eclipse.edc.api.model.IdResponse;
+import org.eclipse.edc.participantcontext.spi.types.ParticipantContext;
+import org.eclipse.edc.spi.EdcException;
+import org.eclipse.edc.spi.query.QuerySpec;
+import org.eclipse.edc.spi.result.Result;
+import org.eclipse.edc.transform.spi.TypeTransformerRegistry;
+import org.eclipse.edc.virtualized.policy.cel.model.CelExpression;
+import org.eclipse.edc.virtualized.policy.cel.service.CelPolicyExpressionService;
+import org.eclipse.edc.web.spi.exception.InvalidRequestException;
+import org.eclipse.edc.web.spi.validation.SchemaType;
+
+import static jakarta.json.stream.JsonCollectors.toJsonArray;
+import static jakarta.ws.rs.core.MediaType.APPLICATION_JSON;
+import static org.eclipse.edc.spi.query.QuerySpec.EDC_QUERY_SPEC_TYPE_TERM;
+import static org.eclipse.edc.virtualized.policy.cel.model.CelExpression.CEL_EXPRESSION_TYPE_TERM;
+import static org.eclipse.edc.web.spi.exception.ServiceResultHandler.exceptionMapper;
+
+@Consumes(APPLICATION_JSON)
+@Produces(APPLICATION_JSON)
+@Path("/v4alpha/celexpressions")
+public class CelExpressionApiV4Controller implements CelExpressionApiV4 {
+
+    private final CelPolicyExpressionService service;
+    private final TypeTransformerRegistry transformerRegistry;
+
+    public CelExpressionApiV4Controller(CelPolicyExpressionService service,
+                                        TypeTransformerRegistry transformerRegistry) {
+        this.service = service;
+        this.transformerRegistry = transformerRegistry;
+    }
+
+    @POST
+    @RolesAllowed({ParticipantPrincipal.ROLE_ADMIN})
+    @RequiredScope("management-api:write")
+    @Override
+    public JsonObject createExpressionV4(@SchemaType(CEL_EXPRESSION_TYPE_TERM) JsonObject expression) {
+
+        var expr = transformerRegistry.transform(expression, CelExpression.class)
+                .orElseThrow(InvalidRequestException::new);
+
+        service.create(expr)
+                .orElseThrow(exceptionMapper(CelExpression.class, expr.getId()));
+
+        var responseDto = IdResponse.Builder.newInstance()
+                .id(expr.getId())
+                .createdAt(expr.getCreatedAt())
+                .build();
+
+        return transformerRegistry.transform(responseDto, JsonObject.class)
+                .orElseThrow(f -> new EdcException("Error creating response body: " + f.getFailureDetail()));
+    }
+
+    @GET
+    @Path("{id}")
+    @RolesAllowed({ParticipantPrincipal.ROLE_ADMIN})
+    @RequiredScope("management-api:read")
+    @Override
+    public JsonObject getExpressionV4(@PathParam("id") String id, @Context SecurityContext securityContext) {
+
+        var expr = service.findById(id)
+                .orElseThrow(exceptionMapper(ParticipantContext.class, id));
+
+        return transformerRegistry.transform(expr, JsonObject.class)
+                .orElseThrow(f -> new EdcException("Error creating response body: " + f.getFailureDetail()));
+    }
+
+    @PUT
+    @Path("{id}")
+    @RolesAllowed({ParticipantPrincipal.ROLE_ADMIN})
+    @RequiredScope("management-api:write")
+    @Override
+    public void updateExpressionV4(@PathParam("id") String id, @SchemaType(CEL_EXPRESSION_TYPE_TERM) JsonObject expression, @Context SecurityContext securityContext) {
+
+        var expr = transformerRegistry.transform(expression, CelExpression.class)
+                .orElseThrow(InvalidRequestException::new);
+
+        service.update(expr)
+                .orElseThrow(exceptionMapper(CelExpression.class, id));
+
+
+    }
+
+    @POST
+    @Path("request")
+    @RolesAllowed({ParticipantPrincipal.ROLE_ADMIN})
+    @RequiredScope("management-api:read")
+    @Override
+    public JsonArray queryExpressionV4(@SchemaType(EDC_QUERY_SPEC_TYPE_TERM) JsonObject querySpecJson) {
+        QuerySpec querySpec;
+        if (querySpecJson == null) {
+            querySpec = QuerySpec.Builder.newInstance().build();
+        } else {
+            querySpec = transformerRegistry.transform(querySpecJson, QuerySpec.class)
+                    .orElseThrow(InvalidRequestException::new);
+        }
+
+        return service.query(querySpec).orElseThrow(exceptionMapper(CelExpression.class)).stream()
+                .map(expression -> transformerRegistry.transform(expression, JsonObject.class))
+                .filter(Result::succeeded)
+                .map(Result::getContent)
+                .collect(toJsonArray());
+    }
+
+    @DELETE
+    @Path("{id}")
+    @RolesAllowed({ParticipantPrincipal.ROLE_ADMIN})
+    @RequiredScope("management-api:write")
+    @Override
+    public void deleteExpressionV4(@PathParam("id") String id, @Context SecurityContext securityContext) {
+        service.delete(id)
+                .orElseThrow(exceptionMapper(ParticipantContext.class, id));
+    }
+}

--- a/extensions/control-plane/api/management-api/cel-api/src/main/resources/META-INF/services/org.eclipse.edc.spi.system.ServiceExtension
+++ b/extensions/control-plane/api/management-api/cel-api/src/main/resources/META-INF/services/org.eclipse.edc.spi.system.ServiceExtension
@@ -1,0 +1,15 @@
+#
+#  Copyright (c) 2025 Metaform Systems, Inc.
+#
+#  This program and the accompanying materials are made available under the
+#  terms of the Apache License, Version 2.0 which is available at
+#  https://www.apache.org/licenses/LICENSE-2.0
+#
+#  SPDX-License-Identifier: Apache-2.0
+#
+#  Contributors:
+#       Metaform Systems, Inc. - initial API and implementation
+#
+#
+
+org.eclipse.edc.virtualized.connector.controlplane.api.management.cel.CelExpressionManagementApiExtension

--- a/extensions/control-plane/api/management-api/cel-api/src/test/java/org/eclipse/edc/virtualized/connector/controlplane/api/management/cel/CelExpressionApiControllerTestBase.java
+++ b/extensions/control-plane/api/management-api/cel-api/src/test/java/org/eclipse/edc/virtualized/connector/controlplane/api/management/cel/CelExpressionApiControllerTestBase.java
@@ -1,0 +1,283 @@
+/*
+ *  Copyright (c) 2025 Metaform Systems, Inc.
+ *
+ *  This program and the accompanying materials are made available under the
+ *  terms of the Apache License, Version 2.0 which is available at
+ *  https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Contributors:
+ *       Metaform Systems, Inc. - initial API and implementation
+ *
+ */
+
+package org.eclipse.edc.virtualized.connector.controlplane.api.management.cel;
+
+import io.restassured.specification.RequestSpecification;
+import jakarta.json.Json;
+import jakarta.json.JsonObject;
+import org.eclipse.edc.api.model.IdResponse;
+import org.eclipse.edc.participantcontext.spi.config.model.ParticipantContextConfiguration;
+import org.eclipse.edc.spi.query.QuerySpec;
+import org.eclipse.edc.spi.result.Result;
+import org.eclipse.edc.spi.result.ServiceResult;
+import org.eclipse.edc.transform.spi.TypeTransformerRegistry;
+import org.eclipse.edc.virtualized.policy.cel.model.CelExpression;
+import org.eclipse.edc.virtualized.policy.cel.service.CelPolicyExpressionService;
+import org.eclipse.edc.web.jersey.testfixtures.RestControllerTestBase;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+import java.util.UUID;
+
+import static io.restassured.RestAssured.given;
+import static io.restassured.http.ContentType.JSON;
+import static jakarta.json.Json.createObjectBuilder;
+import static org.eclipse.edc.api.model.IdResponse.ID_RESPONSE_CREATED_AT;
+import static org.eclipse.edc.api.model.IdResponse.ID_RESPONSE_TYPE;
+import static org.eclipse.edc.jsonld.spi.JsonLdKeywords.CONTEXT;
+import static org.eclipse.edc.jsonld.spi.JsonLdKeywords.ID;
+import static org.eclipse.edc.jsonld.spi.JsonLdKeywords.TYPE;
+import static org.hamcrest.Matchers.is;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.ArgumentMatchers.isA;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
+import static org.mockito.Mockito.when;
+
+public abstract class CelExpressionApiControllerTestBase extends RestControllerTestBase {
+
+    protected final TypeTransformerRegistry transformerRegistry = mock();
+    protected final CelPolicyExpressionService service = mock();
+
+    private RequestSpecification baseRequest() {
+        return given()
+                .baseUri("http://localhost:" + port + "/" + versionPath())
+                .when();
+    }
+
+    protected abstract String versionPath();
+
+    private CelExpression celExpression() {
+        return CelExpression.Builder.newInstance()
+                .id(UUID.randomUUID().toString())
+                .leftOperand("leftOperand")
+                .expression("expr")
+                .description("description")
+                .build();
+    }
+
+    private ParticipantContextConfiguration.Builder createParticipantContextBuilder() {
+        return ParticipantContextConfiguration.Builder.newInstance();
+    }
+
+    @BeforeEach
+    void setup() {
+        when(transformerRegistry.transform(isA(IdResponse.class), eq(JsonObject.class))).thenAnswer(a -> {
+            var idResponse = (IdResponse) a.getArgument(0);
+            return Result.success(createObjectBuilder()
+                    .add(TYPE, ID_RESPONSE_TYPE)
+                    .add(ID, idResponse.getId())
+                    .add(ID_RESPONSE_CREATED_AT, idResponse.getCreatedAt())
+                    .build()
+            );
+        });
+    }
+
+    @Nested
+    class Create {
+        @Test
+        void create() {
+            var expr = celExpression();
+            when(transformerRegistry.transform(any(), eq(CelExpression.class))).thenReturn(Result.success(expr));
+
+            when(service.create(any())).thenReturn(ServiceResult.success());
+            var requestBody = Json.createObjectBuilder()
+                    .add("policy", Json.createObjectBuilder()
+                            .add(CONTEXT, "context")
+                            .add(TYPE, "Set")
+                            .build())
+                    .build();
+
+            baseRequest()
+                    .body(requestBody)
+                    .contentType(JSON)
+                    .post("/celexpressions")
+                    .then()
+                    .statusCode(200);
+            verify(transformerRegistry).transform(isA(JsonObject.class), eq(CelExpression.class));
+            verify(service).create(expr);
+        }
+
+        @Test
+        void create_shouldReturnBadRequest_whenTransformationFails() {
+            when(transformerRegistry.transform(any(), any())).thenReturn(Result.failure("error"));
+            var requestBody = Json.createObjectBuilder()
+                    .add("policy", Json.createObjectBuilder()
+                            .add(CONTEXT, "context")
+                            .add(TYPE, "Set")
+                            .build())
+                    .build();
+
+            baseRequest()
+                    .body(requestBody)
+                    .contentType(JSON)
+                    .post("/celexpressions")
+                    .then()
+                    .statusCode(400);
+            verifyNoInteractions(service);
+        }
+    }
+
+    @Nested
+    class FindById {
+        @Test
+        void findById() {
+            var expr = celExpression();
+            var expandedBody = Json.createObjectBuilder().add("id", "id").add("createdAt", 1234).build();
+            when(service.findById(any())).thenReturn(ServiceResult.success(expr));
+            when(transformerRegistry.transform(any(), eq(JsonObject.class))).thenReturn(Result.success(expandedBody));
+
+            baseRequest()
+                    .get("/celexpressions/" + expr.getId())
+                    .then()
+                    .statusCode(200)
+                    .contentType(JSON)
+                    .body("id", is("id"))
+                    .body("createdAt", is(1234));
+            verify(service).findById(expr.getId());
+            verify(transformerRegistry).transform(expr, JsonObject.class);
+        }
+
+        @Test
+        void get_shouldReturnNotFound_whenNotFound() {
+            when(service.findById(any())).thenReturn(ServiceResult.notFound("not found"));
+
+            baseRequest()
+                    .get("/celexpressions/id")
+                    .then()
+                    .statusCode(404)
+                    .contentType(JSON);
+            verifyNoInteractions(transformerRegistry);
+        }
+
+    }
+
+    @Nested
+    class Update {
+
+        @Test
+        void update() {
+            var expr = celExpression();
+            when(transformerRegistry.transform(any(), eq(CelExpression.class))).thenReturn(Result.success(expr));
+
+            when(service.update(any())).thenReturn(ServiceResult.success());
+
+            baseRequest()
+                    .body("{}")
+                    .contentType(JSON)
+                    .put("/celexpressions/" + expr.getId())
+                    .then()
+                    .statusCode(204);
+            verify(transformerRegistry).transform(isA(JsonObject.class), eq(CelExpression.class));
+            verify(service).update(expr);
+        }
+
+        @Test
+        void update_shouldReturnBadRequest_whenTransformationFails() {
+            when(transformerRegistry.transform(any(), any())).thenReturn(Result.failure("error"));
+            var requestBody = Json.createObjectBuilder()
+                    .add("policy", Json.createObjectBuilder()
+                            .add(CONTEXT, "context")
+                            .add(TYPE, "Set")
+                            .build())
+                    .build();
+
+            baseRequest()
+                    .body(requestBody)
+                    .contentType(JSON)
+                    .put("/celexpressions/1")
+                    .then()
+                    .statusCode(400);
+            verifyNoInteractions(service);
+        }
+    }
+
+    @Nested
+    class Query {
+        @Test
+        void query() {
+            var querySpec = QuerySpec.none();
+            var expr = celExpression();
+            var expandedBody = Json.createObjectBuilder().add("id", "id").add("createdAt", 1234).build();
+            when(transformerRegistry.transform(any(), eq(QuerySpec.class))).thenReturn(Result.success(querySpec));
+            when(service.query(any())).thenReturn(ServiceResult.success(List.of(expr)));
+            when(transformerRegistry.transform(any(), eq(JsonObject.class))).thenReturn(Result.success(expandedBody));
+
+            baseRequest()
+                    .contentType(JSON)
+                    .body("{}")
+                    .post("/celexpressions/request")
+                    .then()
+                    .statusCode(200)
+                    .contentType(JSON)
+                    .body("size()", is(1))
+                    .body("[0].id", is("id"))
+                    .body("[0].createdAt", is(1234));
+
+            verify(service).query(querySpec);
+            verify(transformerRegistry).transform(expr, JsonObject.class);
+        }
+
+        @Test
+        void query_whenTransformFails() {
+            when(service.findById(any())).thenReturn(ServiceResult.notFound("not found"));
+            when(transformerRegistry.transform(any(JsonObject.class), eq(QuerySpec.class))).thenReturn(Result.failure("failure"));
+
+            baseRequest()
+                    .body("{}")
+                    .contentType(JSON)
+                    .post("/celexpressions/request")
+                    .then()
+                    .statusCode(400)
+                    .contentType(JSON);
+        }
+
+    }
+
+    @Nested
+    class Delete {
+
+        @Test
+        void delete() {
+            var expr = celExpression();
+            when(service.delete(any())).thenReturn(ServiceResult.success());
+
+            baseRequest()
+                    .delete("/celexpressions/" + expr.getId())
+                    .then()
+                    .statusCode(204);
+
+            verify(service).delete(expr.getId());
+        }
+
+        @Test
+        void delete_shouldReturnNotFound_whenNotFound() {
+            when(service.delete(any())).thenReturn(ServiceResult.notFound("not found"));
+
+            baseRequest()
+                    .delete("/celexpressions/id")
+                    .then()
+                    .statusCode(404);
+
+        }
+
+    }
+
+
+}

--- a/extensions/control-plane/api/management-api/cel-api/src/test/java/org/eclipse/edc/virtualized/connector/controlplane/api/management/cel/transform/JsonObjectFromCelExpressionTransformerTest.java
+++ b/extensions/control-plane/api/management-api/cel-api/src/test/java/org/eclipse/edc/virtualized/connector/controlplane/api/management/cel/transform/JsonObjectFromCelExpressionTransformerTest.java
@@ -1,0 +1,85 @@
+/*
+ *  Copyright (c) 2025 Metaform Systems, Inc.
+ *
+ *  This program and the accompanying materials are made available under the
+ *  terms of the Apache License, Version 2.0 which is available at
+ *  https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Contributors:
+ *       Metaform Systems, Inc. - initial API and implementation
+ *
+ */
+
+package org.eclipse.edc.virtualized.connector.controlplane.api.management.cel.transform;
+
+import jakarta.json.Json;
+import org.eclipse.edc.transform.spi.TransformerContext;
+import org.eclipse.edc.virtualized.policy.cel.model.CelExpression;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.util.Set;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.eclipse.edc.jsonld.spi.JsonLdKeywords.ID;
+import static org.eclipse.edc.jsonld.spi.JsonLdKeywords.TYPE;
+import static org.eclipse.edc.virtualized.policy.cel.model.CelExpression.CEL_EXPRESSION_DESCRIPTION_IRI;
+import static org.eclipse.edc.virtualized.policy.cel.model.CelExpression.CEL_EXPRESSION_EXPRESSION_IRI;
+import static org.eclipse.edc.virtualized.policy.cel.model.CelExpression.CEL_EXPRESSION_LEFT_OPERAND_IRI;
+import static org.eclipse.edc.virtualized.policy.cel.model.CelExpression.CEL_EXPRESSION_SCOPES_IRI;
+import static org.eclipse.edc.virtualized.policy.cel.model.CelExpression.CEL_EXPRESSION_TYPE_IRI;
+import static org.eclipse.edc.virtualized.policy.cel.model.CelExpression.MATCH_ALL_SCOPE;
+import static org.mockito.Mockito.mock;
+
+class JsonObjectFromCelExpressionTransformerTest {
+
+    private JsonObjectFromCelExpressionTransformer transformer;
+    private TransformerContext context;
+
+    @BeforeEach
+    void setUp() {
+        transformer = new JsonObjectFromCelExpressionTransformer(Json.createBuilderFactory(null));
+        context = mock(TransformerContext.class);
+    }
+
+    @Test
+    void transform_shouldConvertCelExpressionToJsonObject() {
+        var celExpression = CelExpression.Builder.newInstance()
+                .id("test-id")
+                .leftOperand("user.role")
+                .expression("== 'admin'")
+                .description("Check if user is admin")
+                .scopes(Set.of("read", "write"))
+                .build();
+
+        var result = transformer.transform(celExpression, context);
+
+        assertThat(result).isNotNull();
+        assertThat(result.getString(ID)).isEqualTo("test-id");
+        assertThat(result.getString(TYPE)).isEqualTo(CEL_EXPRESSION_TYPE_IRI);
+        assertThat(result.getString(CEL_EXPRESSION_LEFT_OPERAND_IRI)).isEqualTo("user.role");
+        assertThat(result.getString(CEL_EXPRESSION_EXPRESSION_IRI)).isEqualTo("== 'admin'");
+        assertThat(result.getString(CEL_EXPRESSION_DESCRIPTION_IRI)).isEqualTo("Check if user is admin");
+        assertThat(result.getJsonArray(CEL_EXPRESSION_SCOPES_IRI))
+                .hasSize(2)
+                .containsExactlyInAnyOrder(Json.createValue("read"), Json.createValue("write"));
+    }
+
+    @Test
+    void transform_shouldHandleEmptyScopes() {
+        var celExpression = CelExpression.Builder.newInstance()
+                .id("test-id")
+                .leftOperand("user.role")
+                .expression("== 'admin'")
+                .description("Test")
+                .build();
+
+        var result = transformer.transform(celExpression, context);
+
+        assertThat(result).isNotNull();
+        assertThat(result.getJsonArray(CEL_EXPRESSION_SCOPES_IRI))
+                .contains(Json.createValue(MATCH_ALL_SCOPE));
+    }
+}

--- a/extensions/control-plane/api/management-api/cel-api/src/test/java/org/eclipse/edc/virtualized/connector/controlplane/api/management/cel/transform/JsonObjectToCelExpressionTransformerTest.java
+++ b/extensions/control-plane/api/management-api/cel-api/src/test/java/org/eclipse/edc/virtualized/connector/controlplane/api/management/cel/transform/JsonObjectToCelExpressionTransformerTest.java
@@ -1,0 +1,94 @@
+/*
+ *  Copyright (c) 2025 Metaform Systems, Inc.
+ *
+ *  This program and the accompanying materials are made available under the
+ *  terms of the Apache License, Version 2.0 which is available at
+ *  https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Contributors:
+ *       Metaform Systems, Inc. - initial API and implementation
+ *
+ */
+
+package org.eclipse.edc.virtualized.connector.controlplane.api.management.cel.transform;
+
+import jakarta.json.Json;
+import org.eclipse.edc.transform.spi.TransformerContext;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.eclipse.edc.jsonld.spi.JsonLdKeywords.ID;
+import static org.eclipse.edc.jsonld.spi.JsonLdKeywords.VALUE;
+import static org.eclipse.edc.virtualized.policy.cel.model.CelExpression.CEL_EXPRESSION_DESCRIPTION_IRI;
+import static org.eclipse.edc.virtualized.policy.cel.model.CelExpression.CEL_EXPRESSION_EXPRESSION_IRI;
+import static org.eclipse.edc.virtualized.policy.cel.model.CelExpression.CEL_EXPRESSION_LEFT_OPERAND_IRI;
+import static org.eclipse.edc.virtualized.policy.cel.model.CelExpression.CEL_EXPRESSION_SCOPES_IRI;
+import static org.eclipse.edc.virtualized.policy.cel.model.CelExpression.MATCH_ALL_SCOPE;
+import static org.mockito.Mockito.mock;
+
+class JsonObjectToCelExpressionTransformerTest {
+
+    private JsonObjectToCelExpressionTransformer transformer;
+    private TransformerContext context;
+
+    @BeforeEach
+    void setUp() {
+        transformer = new JsonObjectToCelExpressionTransformer();
+        context = mock(TransformerContext.class);
+    }
+
+    @Test
+    void transform_shouldConvertJsonObjectToCelExpression() {
+        var json = Json.createObjectBuilder()
+                .add(ID, "test-id")
+                .add(CEL_EXPRESSION_LEFT_OPERAND_IRI, "user.role")
+                .add(CEL_EXPRESSION_EXPRESSION_IRI, "== 'admin'")
+                .add(CEL_EXPRESSION_DESCRIPTION_IRI, "Check if user is admin")
+                .add(CEL_EXPRESSION_SCOPES_IRI, Json.createArrayBuilder()
+                        .add(Json.createObjectBuilder().add(VALUE, "read"))
+                        .add(Json.createObjectBuilder().add(VALUE, "write")))
+                .build();
+
+        var result = transformer.transform(json, context);
+
+        assertThat(result).isNotNull();
+        assertThat(result.getId()).isEqualTo("test-id");
+        assertThat(result.getLeftOperand()).isEqualTo("user.role");
+        assertThat(result.getExpression()).isEqualTo("== 'admin'");
+        assertThat(result.getDescription()).isEqualTo("Check if user is admin");
+        assertThat(result.getScopes()).containsExactlyInAnyOrder("read", "write");
+    }
+
+    @Test
+    void transform_shouldGenerateIdWhenMissing() {
+        var json = Json.createObjectBuilder()
+                .add(CEL_EXPRESSION_LEFT_OPERAND_IRI, "user.role")
+                .add(CEL_EXPRESSION_EXPRESSION_IRI, "== 'admin'")
+                .add(CEL_EXPRESSION_DESCRIPTION_IRI, "description")
+                .build();
+
+        var result = transformer.transform(json, context);
+
+        assertThat(result).isNotNull();
+        assertThat(result.getId()).isNotNull().isNotEmpty();
+    }
+
+    @Test
+    void transform_shouldHandleEmptyScopes() {
+        var json = Json.createObjectBuilder()
+                .add(ID, "test-id")
+                .add(CEL_EXPRESSION_LEFT_OPERAND_IRI, "user.role")
+                .add(CEL_EXPRESSION_EXPRESSION_IRI, "== 'admin'")
+                .add(CEL_EXPRESSION_DESCRIPTION_IRI, "description")
+                .build();
+
+        var result = transformer.transform(json, context);
+
+        assertThat(result).isNotNull();
+        assertThat(result.getScopes()).containsExactly(MATCH_ALL_SCOPE);
+    }
+
+}

--- a/extensions/control-plane/api/management-api/cel-api/src/test/java/org/eclipse/edc/virtualized/connector/controlplane/api/management/cel/v4/CelExpressionApiV4ControllerTest.java
+++ b/extensions/control-plane/api/management-api/cel-api/src/test/java/org/eclipse/edc/virtualized/connector/controlplane/api/management/cel/v4/CelExpressionApiV4ControllerTest.java
@@ -1,0 +1,30 @@
+/*
+ *  Copyright (c) 2025 Metaform Systems, Inc.
+ *
+ *  This program and the accompanying materials are made available under the
+ *  terms of the Apache License, Version 2.0 which is available at
+ *  https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Contributors:
+ *       Metaform Systems, Inc. - initial API and implementation
+ *
+ */
+
+package org.eclipse.edc.virtualized.connector.controlplane.api.management.cel.v4;
+
+
+import org.eclipse.edc.virtualized.connector.controlplane.api.management.cel.CelExpressionApiControllerTestBase;
+
+public class CelExpressionApiV4ControllerTest extends CelExpressionApiControllerTestBase {
+    @Override
+    protected String versionPath() {
+        return "v4alpha";
+    }
+
+    @Override
+    protected Object controller() {
+        return new CelExpressionApiV4Controller(service, transformerRegistry);
+    }
+}

--- a/extensions/control-plane/api/management-api/management-api-configuration/build.gradle.kts
+++ b/extensions/control-plane/api/management-api/management-api-configuration/build.gradle.kts
@@ -21,6 +21,7 @@ plugins {
 dependencies {
 
     api(project(":spi:v-auth-spi"))
+    api(project(":extensions:common:api:lib:v-management-api-lib"))
     implementation(libs.edc.lib.jersey.providers)
     implementation(libs.edc.lib.mgmtapi)
     implementation(libs.edc.lib.validator)

--- a/extensions/control-plane/api/management-api/management-api-configuration/src/main/resources/document/v-management-context-v2.jsonld
+++ b/extensions/control-plane/api/management-api/management-api-configuration/src/main/resources/document/v-management-context-v2.jsonld
@@ -1,0 +1,18 @@
+{
+  "@context": {
+    "@version": 1.1,
+    "edc": "https://w3id.org/edc/v0.0.1/ns/",
+    "CelExpression": {
+      "@id": "edc:CelExpression",
+      "@context": {
+        "leftOperand": "edc:leftOperand",
+        "scopes": {
+          "@id": "edc:scopes",
+          "@container": "@set"
+        },
+        "expression": "edc:expression",
+        "description": "edc:description"
+      }
+    }
+  }
+}

--- a/extensions/control-plane/api/management-api/participant-context-config-api/src/main/java/org/eclipse/edc/virtualized/connector/controlplane/api/management/participantcontext/config/v4/ParticipantContextConfigApiV4Controller.java
+++ b/extensions/control-plane/api/management-api/participant-context-config-api/src/main/java/org/eclipse/edc/virtualized/connector/controlplane/api/management/participantcontext/config/v4/ParticipantContextConfigApiV4Controller.java
@@ -27,7 +27,6 @@ import jakarta.ws.rs.core.Context;
 import jakarta.ws.rs.core.SecurityContext;
 import org.eclipse.edc.api.auth.spi.ParticipantPrincipal;
 import org.eclipse.edc.api.auth.spi.RequiredScope;
-import org.eclipse.edc.connector.controlplane.policy.spi.PolicyDefinition;
 import org.eclipse.edc.participantcontext.spi.config.model.ParticipantContextConfiguration;
 import org.eclipse.edc.participantcontext.spi.config.service.ParticipantContextConfigService;
 import org.eclipse.edc.participantcontext.spi.types.ParticipantContext;
@@ -67,7 +66,7 @@ public class ParticipantContextConfigApiV4Controller implements ParticipantConte
                 .build();
 
         configService.save(config)
-                .orElseThrow(exceptionMapper(PolicyDefinition.class, config.getParticipantContextId()));
+                .orElseThrow(exceptionMapper(ParticipantContextConfiguration.class, config.getParticipantContextId()));
 
     }
 

--- a/extensions/control-plane/api/management-api/v-management-api-schema-validator/build.gradle.kts
+++ b/extensions/control-plane/api/management-api/v-management-api-schema-validator/build.gradle.kts
@@ -1,0 +1,28 @@
+/*
+ *  Copyright (c) 2025 Metaform Systems, Inc.
+ *
+ *  This program and the accompanying materials are made available under the
+ *  terms of the Apache License, Version 2.0 which is available at
+ *  https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Contributors:
+ *       Metaform Systems, Inc. - initial API and implementation
+ *
+ */
+
+plugins {
+    `java-library`
+}
+
+dependencies {
+    api(libs.edc.spi.core)
+    api(project(":extensions:cel:cel-spi"))
+
+    implementation(project(":extensions:common:api:lib:v-management-api-lib"))
+
+    implementation(libs.jsonschema)
+}
+
+

--- a/extensions/control-plane/api/management-api/v-management-api-schema-validator/src/main/java/org/eclipse/edc/virtual/connector/api/management/schema/ManagementApiSchemaValidatorExtension.java
+++ b/extensions/control-plane/api/management-api/v-management-api-schema-validator/src/main/java/org/eclipse/edc/virtual/connector/api/management/schema/ManagementApiSchemaValidatorExtension.java
@@ -1,0 +1,72 @@
+/*
+ *  Copyright (c) 2025 Metaform Systems, Inc.
+ *
+ *  This program and the accompanying materials are made available under the
+ *  terms of the Apache License, Version 2.0 which is available at
+ *  https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Contributors:
+ *       Metaform Systems, Inc. - initial API and implementation
+ *
+ */
+
+package org.eclipse.edc.virtual.connector.api.management.schema;
+
+import org.eclipse.edc.runtime.metamodel.annotation.Extension;
+import org.eclipse.edc.runtime.metamodel.annotation.Inject;
+import org.eclipse.edc.spi.system.ServiceExtension;
+import org.eclipse.edc.spi.system.ServiceExtensionContext;
+import org.eclipse.edc.spi.types.TypeManager;
+import org.eclipse.edc.validator.spi.JsonObjectValidatorRegistry;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import static org.eclipse.edc.api.management.schema.ManagementApiJsonSchema.EDC_MGMT_V4_SCHEMA_PREFIX;
+import static org.eclipse.edc.spi.constants.CoreConstants.JSON_LD;
+import static org.eclipse.edc.virtual.connector.api.management.schema.ManagementApiSchemaValidatorExtension.NAME;
+import static org.eclipse.edc.virtualized.policy.cel.model.CelExpression.CEL_EXPRESSION_TYPE_TERM;
+import static org.eclipse.virtualized.api.management.schema.VirtualManagementApiJsonSchema.V4.CEL_EXPRESSION;
+import static org.eclipse.virtualized.api.management.schema.VirtualManagementApiJsonSchema.VIRTUAL_EDC_MGMT_V4_SCHEMA_PREFIX;
+
+@Extension(NAME)
+public class ManagementApiSchemaValidatorExtension implements ServiceExtension {
+
+    public static final String NAME = "Management API Schema Validator";
+    public static final String V_4 = "v4";
+    public static final String V_4_PREFIX = V_4 + ":";
+    private static final String EDC_CLASSPATH_SCHEMA = "classpath:schema/connector/management/v4";
+    private static final String VIRTUAL_EDC_CLASSPATH_SCHEMA = "classpath:schema/virtual-connector/management/v4";
+
+    private final Map<String, String> schemaV4 = new HashMap<>() {
+        {
+
+            put(CEL_EXPRESSION_TYPE_TERM, CEL_EXPRESSION);
+
+        }
+    };
+
+    @Inject
+    private TypeManager typeManager;
+    @Inject
+    private JsonObjectValidatorRegistry validator;
+
+    @Override
+    public void initialize(ServiceExtensionContext context) {
+
+        var schemaValidatorProvider = ManagementApiSchemaValidatorProvider.Builder.newInstance()
+                .objectMapper(() -> typeManager.getMapper(JSON_LD))
+                .prefixMapping(EDC_MGMT_V4_SCHEMA_PREFIX, EDC_CLASSPATH_SCHEMA)
+                .prefixMapping(VIRTUAL_EDC_MGMT_V4_SCHEMA_PREFIX, VIRTUAL_EDC_CLASSPATH_SCHEMA)
+                .build();
+
+        registerValidatorsV4(schemaValidatorProvider);
+    }
+
+    void registerValidatorsV4(ManagementApiSchemaValidatorProvider validatorProvider) {
+        schemaV4.forEach((type, schema) -> validator.register(V_4_PREFIX + type, validatorProvider.validatorFor(schema)));
+    }
+
+}

--- a/extensions/control-plane/api/management-api/v-management-api-schema-validator/src/main/java/org/eclipse/edc/virtual/connector/api/management/schema/ManagementApiSchemaValidatorProvider.java
+++ b/extensions/control-plane/api/management-api/v-management-api-schema-validator/src/main/java/org/eclipse/edc/virtual/connector/api/management/schema/ManagementApiSchemaValidatorProvider.java
@@ -1,0 +1,93 @@
+/*
+ *  Copyright (c) 2025 Metaform Systems, Inc.
+ *
+ *  This program and the accompanying materials are made available under the
+ *  terms of the Apache License, Version 2.0 which is available at
+ *  https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Contributors:
+ *       Metaform Systems, Inc. - initial API and implementation
+ *
+ */
+
+package org.eclipse.edc.virtual.connector.api.management.schema;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.networknt.schema.SchemaLocation;
+import com.networknt.schema.SchemaRegistry;
+import com.networknt.schema.dialect.Dialects;
+import jakarta.json.JsonObject;
+import org.eclipse.edc.validator.spi.ValidationResult;
+import org.eclipse.edc.validator.spi.Validator;
+import org.eclipse.edc.validator.spi.Violation;
+
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Objects;
+import java.util.function.Supplier;
+
+public class ManagementApiSchemaValidatorProvider {
+
+    private SchemaRegistry schemaFactory;
+    private Supplier<ObjectMapper> objectMapperSupplier;
+
+    private ManagementApiSchemaValidatorProvider() {
+    }
+
+    public Validator<JsonObject> validatorFor(String schema) {
+        var schemaValidator = schemaFactory.getSchema(SchemaLocation.of(schema));
+        return (input) -> {
+            var node = objectMapperSupplier.get().convertValue(input, JsonNode.class);
+            var response = schemaValidator.validate(node);
+            if (response.isEmpty()) {
+                return ValidationResult.success();
+            }
+
+            var violations = response.stream()
+                    .map(error -> Violation.violation(error.getMessage(), error.getInstanceLocation().toString()))
+                    .toList();
+
+            return ValidationResult.failure(violations);
+        };
+    }
+
+
+    public static class Builder {
+
+        private final ManagementApiSchemaValidatorProvider provider;
+
+        private final Map<String, String> prefixMappings = new HashMap<>();
+
+        private Builder() {
+            provider = new ManagementApiSchemaValidatorProvider();
+        }
+
+        public static Builder newInstance() {
+            return new Builder();
+        }
+
+        public Builder objectMapper(Supplier<ObjectMapper> objectMapperSupplier) {
+            provider.objectMapperSupplier = objectMapperSupplier;
+            return this;
+        }
+
+        public Builder prefixMapping(String prefix, String location) {
+            Objects.requireNonNull(prefix, "Prefix must not be null");
+            Objects.requireNonNull(location, "Location must not be null");
+            prefixMappings.put(prefix, location);
+            return this;
+        }
+
+        public ManagementApiSchemaValidatorProvider build() {
+            Objects.requireNonNull(provider.objectMapperSupplier);
+            provider.schemaFactory = SchemaRegistry.withDialect(Dialects.getDraft201909(), builder ->
+                    builder.schemaIdResolvers(schemaIdResolvers -> prefixMappings.forEach(schemaIdResolvers::mapPrefix)));
+            return provider;
+        }
+
+    }
+
+}

--- a/extensions/control-plane/api/management-api/v-management-api-schema-validator/src/main/resources/META-INF/services/org.eclipse.edc.spi.system.ServiceExtension
+++ b/extensions/control-plane/api/management-api/v-management-api-schema-validator/src/main/resources/META-INF/services/org.eclipse.edc.spi.system.ServiceExtension
@@ -1,0 +1,15 @@
+#
+#  Copyright (c) 2025 Metaform Systems, Inc.
+#
+#  This program and the accompanying materials are made available under the
+#  terms of the Apache License, Version 2.0 which is available at
+#  https://www.apache.org/licenses/LICENSE-2.0
+#
+#  SPDX-License-Identifier: Apache-2.0
+#
+#  Contributors:
+#       Metaform Systems, Inc. - initial API and implementation
+#
+#
+
+org.eclipse.edc.virtual.connector.api.management.schema.ManagementApiSchemaValidatorExtension

--- a/extensions/control-plane/api/management-api/v-management-api-schema-validator/src/main/resources/schema/connector/management/v4/context-schema.json
+++ b/extensions/control-plane/api/management-api/v-management-api-schema-validator/src/main/resources/schema/connector/management/v4/context-schema.json
@@ -1,0 +1,28 @@
+{
+  "$schema": "https://json-schema.org/draft/2019-09/schema",
+  "title": "ContextSchema",
+  "type": "array",
+  "items": {
+    "type": "string"
+  },
+  "allOf": [
+    {
+      "$ref": "#/definitions/ContextSchema"
+    }
+  ],
+  "$id": "https://w3id.org/edc/connector/management/schema/v4/context-schema.json",
+  "definitions": {
+    "ContextSchema": {
+      "type": "array",
+      "items": {
+        "type": "string",
+        "items": {
+          "type": "string"
+        }
+      },
+      "contains": {
+        "const": "https://w3id.org/edc/connector/management/v2"
+      }
+    }
+  }
+}

--- a/extensions/control-plane/api/management-api/v-management-api-schema-validator/src/main/resources/schema/virtual-connector/management/v4/cel-expression-schema.json
+++ b/extensions/control-plane/api/management-api/v-management-api-schema-validator/src/main/resources/schema/virtual-connector/management/v4/cel-expression-schema.json
@@ -1,0 +1,51 @@
+{
+  "$schema": "https://json-schema.org/draft/2019-09/schema",
+  "title": "CelExpressionSchema",
+  "type": "object",
+  "allOf": [
+    {
+      "$ref": "#/definitions/CelExpression"
+    }
+  ],
+  "$id": "https://w3id.org/edc/virtual-connector/management/schema/v4/cel-expression-schema.json",
+  "definitions": {
+    "CelExpression": {
+      "type": "object",
+      "properties": {
+        "@context": {
+          "$ref": "https://w3id.org/edc/connector/management/schema/v4/context-schema.json"
+        },
+        "@type": {
+          "type": "string",
+          "const": "CelExpression"
+        },
+        "@id": {
+          "type": "string"
+        },
+        "leftOperand": {
+          "type": "string"
+        },
+        "expression": {
+          "type": "string"
+        },
+        "description": {
+          "type": "string"
+        },
+        "scopes": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          },
+          "uniqueItems": true
+        }
+      },
+      "required": [
+        "@context",
+        "@type",
+        "leftOperand",
+        "expression",
+        "description"
+      ]
+    }
+  }
+}

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -17,8 +17,8 @@ wiremock = "3.13.1"
 bouncyCastle-jdk18on = "1.82"
 jakarta-annotation = "2.1.1"
 swagger = "2.2.40"
-
 cel = "0.11.1"
+jsonschema = "2.0.0"
 
 [libraries]
 # EDC SPI modules
@@ -142,6 +142,7 @@ bouncyCastle-bcpkixJdk18on = { module = "org.bouncycastle:bcpkix-jdk18on", versi
 bouncyCastle-bcprovJdk18on = { module = "org.bouncycastle:bcprov-jdk18on", version.ref = "bouncyCastle-jdk18on" }
 jersey-common = { module = "org.glassfish.jersey.core:jersey-common", version.ref = "jersey" }
 cel = { module = "dev.cel:cel", version.ref = "cel" }
+jsonschema = { module = "com.networknt:json-schema-validator", version.ref = "jsonschema" }
 
 [bundles]
 dcp = [

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -70,10 +70,12 @@ include(":extensions:control-plane:api:management-api:contract-negotiation-api")
 include(":extensions:control-plane:api:management-api:transfer-process-api")
 include(":extensions:control-plane:api:management-api:participant-context-api")
 include(":extensions:control-plane:api:management-api:participant-context-config-api")
+include(":extensions:control-plane:api:management-api:cel-api")
 include(":extensions:control-plane:api:management-api:management-api-configuration")
+include(":extensions:control-plane:api:management-api:v-management-api-schema-validator")
 
 // lib
-include(":extensions:common:api:lib:management-api-lib")
+include(":extensions:common:api:lib:v-management-api-lib")
 include(":extensions:common:api:lib:api-authorization-lib")
 include(":extensions:common:api:lib:api-authentication-lib")
 

--- a/system-tests/management-api/management-api-tests/build.gradle.kts
+++ b/system-tests/management-api/management-api-tests/build.gradle.kts
@@ -18,6 +18,9 @@ plugins {
 
 dependencies {
     testImplementation(project(":spi:v-auth-spi"))
+    testImplementation(project(":extensions:cel:cel-spi"))
+    testImplementation(project(":extensions:common:api:lib:v-management-api-lib"))
+
     testImplementation(libs.edc.spi.dataplane)
     testImplementation(libs.edc.spi.dataplane.selector)
     testImplementation(libs.edc.spi.participantcontext.config)

--- a/system-tests/management-api/management-api-tests/src/test/java/org/eclipse/edc/test/e2e/managementapi/v4/CatalogApiV4EndToEndTest.java
+++ b/system-tests/management-api/management-api-tests/src/test/java/org/eclipse/edc/test/e2e/managementapi/v4/CatalogApiV4EndToEndTest.java
@@ -83,7 +83,6 @@ import static org.hamcrest.Matchers.matchesRegex;
 @ApiTest
 public class CatalogApiV4EndToEndTest {
 
-    @SuppressWarnings("JUnitMalformedDeclaration")
     abstract static class Tests {
         private static final String PARTICIPANT_CONTEXT_ID = "test-participant";
         /**

--- a/system-tests/management-api/management-api-tests/src/test/java/org/eclipse/edc/test/e2e/managementapi/v4/CelExpressionApiV4EndToEndTest.java
+++ b/system-tests/management-api/management-api-tests/src/test/java/org/eclipse/edc/test/e2e/managementapi/v4/CelExpressionApiV4EndToEndTest.java
@@ -1,0 +1,461 @@
+/*
+ *  Copyright (c) 2025 Metaform Systems, Inc.
+ *
+ *  This program and the accompanying materials are made available under the
+ *  terms of the Apache License, Version 2.0 which is available at
+ *  https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Contributors:
+ *       Metaform Systems, Inc. - initial API and implementation
+ *
+ */
+
+package org.eclipse.edc.test.e2e.managementapi.v4;
+
+import com.github.tomakehurst.wiremock.junit5.WireMockExtension;
+import com.nimbusds.jose.JOSEException;
+import com.nimbusds.jose.jwk.Curve;
+import com.nimbusds.jose.jwk.ECKey;
+import com.nimbusds.jose.jwk.gen.ECKeyGenerator;
+import org.assertj.core.api.Assertions;
+import org.eclipse.edc.connector.controlplane.policy.spi.store.PolicyDefinitionStore;
+import org.eclipse.edc.junit.annotations.EndToEndTest;
+import org.eclipse.edc.junit.annotations.PostgresqlIntegrationTest;
+import org.eclipse.edc.junit.extensions.ComponentRuntimeExtension;
+import org.eclipse.edc.junit.extensions.RuntimeExtension;
+import org.eclipse.edc.participantcontext.spi.service.ParticipantContextService;
+import org.eclipse.edc.spi.query.QuerySpec;
+import org.eclipse.edc.spi.system.configuration.Config;
+import org.eclipse.edc.spi.system.configuration.ConfigFactory;
+import org.eclipse.edc.sql.testfixtures.PostgresqlEndToEndExtension;
+import org.eclipse.edc.test.e2e.managementapi.ManagementEndToEndTestContext;
+import org.eclipse.edc.test.e2e.managementapi.Runtimes;
+import org.eclipse.edc.virtualized.nats.testfixtures.NatsEndToEndExtension;
+import org.eclipse.edc.virtualized.policy.cel.model.CelExpression;
+import org.eclipse.edc.virtualized.policy.cel.service.CelPolicyExpressionService;
+import org.eclipse.edc.virtualized.policy.cel.store.CelExpressionStore;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Order;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.BeforeAllCallback;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.UUID;
+
+import static com.github.tomakehurst.wiremock.client.WireMock.aResponse;
+import static com.github.tomakehurst.wiremock.client.WireMock.any;
+import static com.github.tomakehurst.wiremock.client.WireMock.urlPathEqualTo;
+import static com.github.tomakehurst.wiremock.core.WireMockConfiguration.wireMockConfig;
+import static io.restassured.http.ContentType.JSON;
+import static jakarta.json.Json.createArrayBuilder;
+import static jakarta.json.Json.createObjectBuilder;
+import static org.eclipse.edc.jsonld.spi.JsonLdKeywords.CONTEXT;
+import static org.eclipse.edc.jsonld.spi.JsonLdKeywords.ID;
+import static org.eclipse.edc.jsonld.spi.JsonLdKeywords.TYPE;
+import static org.eclipse.edc.junit.assertions.AbstractResultAssert.assertThat;
+import static org.eclipse.edc.spi.constants.CoreConstants.EDC_CONNECTOR_MANAGEMENT_CONTEXT_V2;
+import static org.eclipse.edc.spi.query.Criterion.criterion;
+import static org.eclipse.edc.test.e2e.managementapi.v4.TestFunction.createParticipant;
+import static org.eclipse.edc.test.e2e.managementapi.v4.TestFunction.jsonLdContext;
+import static org.eclipse.edc.virtualized.test.system.fixtures.DockerImages.createPgContainer;
+import static org.eclipse.virtualized.api.management.VirtualManagementApi.EDC_V_CONNECTOR_MANAGEMENT_CONTEXT_V2;
+import static org.hamcrest.Matchers.contains;
+import static org.hamcrest.Matchers.containsString;
+import static org.hamcrest.Matchers.is;
+
+
+public class CelExpressionApiV4EndToEndTest {
+
+
+    abstract static class Tests {
+
+        private static final String PARTICIPANT_CONTEXT_ID = "test-participant";
+        @Order(0)
+        @RegisterExtension
+        static WireMockExtension mockJwksServer = WireMockExtension.newInstance()
+                .options(wireMockConfig().dynamicPort())
+                .build();
+        private String adminToken;
+        private ECKey oauthServerSigningKey;
+
+        private CelExpression expression(String leftOperand, String expr) {
+            return CelExpression.Builder.newInstance().id(UUID.randomUUID().toString())
+                    .leftOperand(leftOperand)
+                    .expression(expr)
+                    .description("description")
+                    .build();
+        }
+
+        @BeforeEach
+        void setup(ManagementEndToEndTestContext context, ParticipantContextService participantContextService) throws JOSEException {
+            createParticipant(participantContextService, PARTICIPANT_CONTEXT_ID);
+
+            // stub JWKS endpoint at /jwks/ returning 200 OK with a simple JWKS
+            oauthServerSigningKey = new ECKeyGenerator(Curve.P_256).keyID(UUID.randomUUID().toString()).generate();
+            adminToken = context.createAdminToken(oauthServerSigningKey);
+
+            // create JWKS with the participant's key
+            var jwks = createObjectBuilder()
+                    .add("keys", createArrayBuilder().add(createObjectBuilder(oauthServerSigningKey.toPublicJWK().toJSONObject())))
+                    .build()
+                    .toString();
+
+            // use wiremock to host a JWKS endpoint
+            mockJwksServer.stubFor(any(urlPathEqualTo("/.well-known/jwks"))
+                    .willReturn(aResponse()
+                            .withStatus(200)
+                            .withHeader("Content-Type", "application/json")
+                            .withBody(jwks)));
+        }
+
+        @AfterEach
+        void teardown(ParticipantContextService participantContextService, PolicyDefinitionStore store) {
+            participantContextService.deleteParticipantContext(PARTICIPANT_CONTEXT_ID)
+                    .orElseThrow(f -> new AssertionError(f.getFailureDetail()));
+
+            store.findAll(QuerySpec.max()).forEach(pd -> store.delete(pd.getId()));
+        }
+
+        @Test
+        void create(ManagementEndToEndTestContext context, CelPolicyExpressionService service) {
+            var requestBody = createObjectBuilder()
+                    .add(CONTEXT, jsonLdContext())
+                    .add(TYPE, "CelExpression")
+                    .add("leftOperand", "leftOperand")
+                    .add("expression", "ctx.agent.id == 'agent-123'")
+                    .add("description", "desc")
+                    .build();
+
+            var id = context.baseRequest(adminToken)
+                    .body(requestBody.toString())
+                    .contentType(JSON)
+                    .post("/v4alpha/celexpressions")
+                    .then()
+                    .log().ifValidationFails()
+                    .contentType(JSON)
+                    .statusCode(200)
+                    .extract().jsonPath().getString(ID);
+
+            assertThat(service.findById(id)).isSucceeded()
+                    .satisfies(c -> {
+                        Assertions.assertThat(c.getId()).isEqualTo(id);
+                    });
+
+        }
+
+        @Test
+        void create_validationFails(ManagementEndToEndTestContext context) {
+            var requestBody = createObjectBuilder()
+                    .add(CONTEXT, jsonLdContext())
+                    .add(TYPE, "CelExpression")
+                    .build();
+
+            context.baseRequest(adminToken)
+                    .body(requestBody.toString())
+                    .contentType(JSON)
+                    .post("/v4alpha/celexpressions")
+                    .then()
+                    .log().ifValidationFails()
+                    .contentType(JSON)
+                    .statusCode(400);
+        }
+
+        @Test
+        void create_NotAdmin(ManagementEndToEndTestContext context, ParticipantContextService service) {
+            var requestBody = createObjectBuilder()
+                    .add(CONTEXT, jsonLdContext())
+                    .add(TYPE, "CelExpression")
+                    .add("leftOperand", "leftOperand")
+                    .add("expression", "ctx.agent.id == 'agent-123'")
+                    .build();
+
+            var token = context.createToken(PARTICIPANT_CONTEXT_ID, oauthServerSigningKey, Map.of("scope", "management-api:write"));
+
+            context.baseRequest(token)
+                    .body(requestBody.toString())
+                    .contentType(JSON)
+                    .post("/v4alpha/celexpressions")
+                    .then()
+                    .log().ifError()
+                    .statusCode(403)
+                    .body(containsString("Required user role not satisfied."));
+        }
+
+        @Test
+        void get(ManagementEndToEndTestContext context, CelExpressionStore store, ParticipantContextService srv) {
+            var expr = expression("leftOperand", "ctx.agent.id == 'agent-123'");
+            store.create(expr)
+                    .orElseThrow(f -> new AssertionError(f.getFailureDetail()));
+
+            context.baseRequest(adminToken)
+                    .contentType(JSON)
+                    .get("/v4alpha/celexpressions/" + expr.getId())
+                    .then()
+                    .log().ifError()
+                    .statusCode(200)
+                    .body(ID, is(expr.getId()))
+                    .body(CONTEXT, contains(EDC_CONNECTOR_MANAGEMENT_CONTEXT_V2, EDC_V_CONNECTOR_MANAGEMENT_CONTEXT_V2))
+                    .body("leftOperand", is(expr.getLeftOperand()))
+                    .body("expression", is(expr.getExpression()))
+                    .body("description", is(expr.getDescription()))
+                    .body("scopes", is(new ArrayList<>(expr.getScopes())));
+        }
+
+
+        @Test
+        void get_NotAdmin(ManagementEndToEndTestContext context, CelExpressionStore store) {
+
+            var expr = expression("leftOperand", "ctx.agent.id == 'agent-123'");
+            store.create(expr)
+                    .orElseThrow(f -> new AssertionError(f.getFailureDetail()));
+
+            var token = context.createToken(PARTICIPANT_CONTEXT_ID, oauthServerSigningKey, Map.of("scope", "management-api:read"));
+
+            context.baseRequest(token)
+                    .contentType(JSON)
+                    .get("/v4alpha/celexpressions/" + expr.getId())
+                    .then()
+                    .log().ifError()
+                    .statusCode(403)
+                    .body(containsString("Required user role not satisfied."));
+
+        }
+
+        @Test
+        void query(ManagementEndToEndTestContext context, CelExpressionStore store) {
+            var expr = expression("leftOperand", "ctx.agent.id == 'agent-123'");
+            store.create(expr)
+                    .orElseThrow(f -> new AssertionError(f.getFailureDetail()));
+
+            var matchingQuery = context.query(
+                    criterion("id", "=", expr.getId())
+            );
+
+            context.baseRequest(adminToken)
+                    .body(matchingQuery.toString())
+                    .contentType(JSON)
+                    .post("/v4alpha/celexpressions/request")
+                    .then()
+                    .log().ifError()
+                    .statusCode(200)
+                    .body("size()", is(1));
+
+
+            var nonMatchingQuery = context.query(
+                    criterion("id", "=", "notFound")
+            );
+
+            context.baseRequest(adminToken)
+                    .body(nonMatchingQuery.toString())
+                    .contentType(JSON)
+                    .post("/v4alpha/celexpressions/request")
+                    .then()
+                    .log().ifError()
+                    .statusCode(200)
+                    .body("size()", is(0));
+        }
+
+        @Test
+        void query_NotAdmin(ManagementEndToEndTestContext context, CelExpressionStore store) {
+            var expr = expression("leftOperand", "ctx.agent.id == 'agent-123'");
+            store.create(expr)
+                    .orElseThrow(f -> new AssertionError(f.getFailureDetail()));
+
+            var matchingQuery = context.query(
+                    criterion("id", "=", expr.getId())
+            );
+
+            var token = context.createToken(PARTICIPANT_CONTEXT_ID, oauthServerSigningKey, Map.of("scope", "management-api:read"));
+
+            context.baseRequest(token)
+                    .body(matchingQuery.toString())
+                    .contentType(JSON)
+                    .post("/v4alpha/celexpressions/request")
+                    .then()
+                    .log().ifError()
+                    .statusCode(403)
+                    .body(containsString("Required user role not satisfied."));
+
+        }
+
+        @Test
+        void update(ManagementEndToEndTestContext context, CelPolicyExpressionService service) {
+            var expr = expression("leftOperand", "ctx.agent.id == 'agent-123'");
+            service.create(expr)
+                    .orElseThrow(f -> new AssertionError(f.getFailureDetail()));
+
+            var requestBody = createObjectBuilder()
+                    .add(CONTEXT, jsonLdContext())
+                    .add(TYPE, "CelExpression")
+                    .add(ID, expr.getId())
+                    .add("leftOperand", "leftOperand")
+                    .add("expression", "ctx.agent.id == 'agent-125'")
+                    .add("description", "desc")
+                    .build();
+
+            context.baseRequest(adminToken)
+                    .body(requestBody.toString())
+                    .contentType(JSON)
+                    .put("/v4alpha/celexpressions/" + expr.getId())
+                    .then()
+                    .statusCode(204);
+
+            assertThat(service.findById(expr.getId())).isSucceeded()
+                    .extracting(CelExpression::getExpression)
+                    .isEqualTo("ctx.agent.id == 'agent-125'");
+        }
+
+
+        @Test
+        void update_whenSchemaValidationFails(ManagementEndToEndTestContext context) {
+            var requestBody = createObjectBuilder()
+                    .add(CONTEXT, jsonLdContext())
+                    .add(TYPE, "CelExpression")
+                    .build();
+
+            context.baseRequest(adminToken)
+                    .body(requestBody.toString())
+                    .contentType(JSON)
+                    .put("/v4alpha/celexpressions/id")
+                    .then()
+                    .log().ifValidationFails()
+                    .contentType(JSON)
+                    .statusCode(400);
+        }
+
+        @Test
+        void update_NotAdmin(ManagementEndToEndTestContext context) {
+
+            var requestBody = createObjectBuilder()
+                    .add(CONTEXT, jsonLdContext())
+                    .add(TYPE, "CelExpression")
+                    .build();
+
+            var token = context.createToken(PARTICIPANT_CONTEXT_ID, oauthServerSigningKey, Map.of("scope", "management-api:write"));
+
+            context.baseRequest(token)
+                    .contentType(JSON)
+                    .body(requestBody.toString())
+                    .put("/v4alpha/celexpressions/id")
+                    .then()
+                    .log().ifValidationFails()
+                    .statusCode(403)
+                    .body(containsString("Required user role not satisfied."));
+
+        }
+
+
+        @Test
+        void delete(ManagementEndToEndTestContext context, CelPolicyExpressionService service) {
+            var expr = expression("leftOperand", "ctx.agent.id == 'agent-123'");
+            service.create(expr)
+                    .orElseThrow(f -> new AssertionError(f.getFailureDetail()));
+
+
+            context.baseRequest(adminToken)
+                    .delete("/v4alpha/celexpressions/" + expr.getId())
+                    .then()
+                    .statusCode(204);
+
+            context.baseRequest(adminToken)
+                    .delete("/v4alpha/celexpressions/" + expr.getId())
+                    .then()
+                    .statusCode(404);
+        }
+
+
+        @Test
+        void delete_NotAdmin(ManagementEndToEndTestContext context) {
+
+            var token = context.createToken(PARTICIPANT_CONTEXT_ID, oauthServerSigningKey, Map.of("scope", "management-api:write"));
+
+            context.baseRequest(token)
+                    .delete("/v4alpha/celexpressions/id")
+                    .then()
+                    .statusCode(403)
+                    .body(containsString("Required user role not satisfied."));
+        }
+    }
+
+    @Nested
+    @EndToEndTest
+    class InMemory extends Tests {
+
+        @RegisterExtension
+        static RuntimeExtension runtime = ComponentRuntimeExtension.Builder.newInstance()
+                .name(Runtimes.ControlPlane.NAME)
+                .modules(Runtimes.ControlPlane.MODULES)
+                .endpoints(Runtimes.ControlPlane.ENDPOINTS.build())
+                .configurationProvider(Runtimes.ControlPlane::config)
+                .paramProvider(ManagementEndToEndTestContext.class, ManagementEndToEndTestContext::forContext)
+                .configurationProvider(() -> ConfigFactory.fromMap(Map.of("edc.iam.oauth2.jwks.url", "http://localhost:" + mockJwksServer.getPort() + "/.well-known/jwks")))
+                .build();
+    }
+
+    @Nested
+    @PostgresqlIntegrationTest
+    class Postgres extends Tests {
+
+        @RegisterExtension
+        @Order(0)
+        static final PostgresqlEndToEndExtension POSTGRES_EXTENSION = new PostgresqlEndToEndExtension(createPgContainer());
+
+        @Order(0)
+        @RegisterExtension
+        static final NatsEndToEndExtension NATS_EXTENSION = new NatsEndToEndExtension();
+
+        @Order(1)
+        @RegisterExtension
+        static final BeforeAllCallback SETUP = context -> {
+            POSTGRES_EXTENSION.createDatabase(Runtimes.ControlPlane.NAME.toLowerCase());
+            NATS_EXTENSION.createStream("state_machine", "negotiations.>", "transfers.>");
+            NATS_EXTENSION.createConsumer("state_machine", "cn-subscriber", "negotiations.>");
+            NATS_EXTENSION.createConsumer("state_machine", "tp-subscriber", "transfers.>");
+        };
+
+        @Order(3)
+        @RegisterExtension
+        static final BeforeAllCallback SEED = context -> {
+            POSTGRES_EXTENSION.execute(Runtimes.ControlPlane.NAME.toLowerCase(), "ALTER TABLE edc_contract_negotiation REPLICA IDENTITY FULL;");
+            POSTGRES_EXTENSION.execute(Runtimes.ControlPlane.NAME.toLowerCase(), "ALTER TABLE edc_transfer_process REPLICA IDENTITY FULL;");
+        };
+
+        @Order(2)
+        @RegisterExtension
+        static RuntimeExtension runtime = ComponentRuntimeExtension.Builder.newInstance()
+                .name(Runtimes.ControlPlane.NAME)
+                .modules(Runtimes.ControlPlane.MODULES)
+                .modules(Runtimes.ControlPlane.PG_MODULES)
+                .endpoints(Runtimes.ControlPlane.ENDPOINTS.build())
+                .configurationProvider(Runtimes.ControlPlane::config)
+                .configurationProvider(() -> POSTGRES_EXTENSION.configFor(Runtimes.ControlPlane.NAME.toLowerCase()))
+                .configurationProvider(Postgres::runtimeConfiguration)
+                .configurationProvider(() -> ConfigFactory.fromMap(Map.of("edc.iam.oauth2.jwks.url", "http://localhost:" + mockJwksServer.getPort() + "/.well-known/jwks")))
+                .paramProvider(ManagementEndToEndTestContext.class, ManagementEndToEndTestContext::forContext)
+                .build();
+
+        private static Config runtimeConfiguration() {
+            return ConfigFactory.fromMap(new HashMap<>() {
+                {
+                    put("edc.postgres.cdc.url", POSTGRES_EXTENSION.getJdbcUrl(Runtimes.ControlPlane.NAME.toLowerCase()));
+                    put("edc.postgres.cdc.user", POSTGRES_EXTENSION.getUsername());
+                    put("edc.postgres.cdc.password", POSTGRES_EXTENSION.getPassword());
+                    put("edc.postgres.cdc.slot", "edc_cdc_slot_" + Runtimes.ControlPlane.NAME.toLowerCase());
+                    put("edc.nats.cn.subscriber.url", NATS_EXTENSION.getNatsUrl());
+                    put("edc.nats.cn.publisher.url", NATS_EXTENSION.getNatsUrl());
+                    put("edc.nats.tp.subscriber.url", NATS_EXTENSION.getNatsUrl());
+                    put("edc.nats.tp.publisher.url", NATS_EXTENSION.getNatsUrl());
+                }
+            });
+        }
+
+    }
+
+}

--- a/system-tests/management-api/management-api-tests/src/test/java/org/eclipse/edc/test/e2e/managementapi/v4/ContractDefinitionApiV4EndToEndTest.java
+++ b/system-tests/management-api/management-api-tests/src/test/java/org/eclipse/edc/test/e2e/managementapi/v4/ContractDefinitionApiV4EndToEndTest.java
@@ -80,7 +80,6 @@ import static org.hamcrest.Matchers.matchesRegex;
 @ApiTest
 public class ContractDefinitionApiV4EndToEndTest {
 
-    @SuppressWarnings("JUnitMalformedDeclaration")
     abstract static class Tests {
         private static final String PARTICIPANT_CONTEXT_ID = "test-participant";
         @Order(0)

--- a/system-tests/management-api/management-api-tests/src/test/java/org/eclipse/edc/test/e2e/managementapi/v4/ContractNegotiationApiV4EndToEndTest.java
+++ b/system-tests/management-api/management-api-tests/src/test/java/org/eclipse/edc/test/e2e/managementapi/v4/ContractNegotiationApiV4EndToEndTest.java
@@ -76,6 +76,7 @@ import static org.eclipse.edc.spi.constants.CoreConstants.EDC_CONNECTOR_MANAGEME
 import static org.eclipse.edc.test.e2e.managementapi.v4.TestFunction.PARTICIPANT_CONTEXT_ID;
 import static org.eclipse.edc.test.e2e.managementapi.v4.TestFunction.createParticipant;
 import static org.eclipse.edc.test.e2e.managementapi.v4.TestFunction.jsonLdContext;
+import static org.eclipse.edc.test.e2e.managementapi.v4.TestFunction.jsonLdContextArray;
 import static org.eclipse.edc.virtualized.test.system.fixtures.DockerImages.createPgContainer;
 import static org.hamcrest.Matchers.contains;
 import static org.hamcrest.Matchers.containsString;
@@ -236,7 +237,7 @@ public class ContractNegotiationApiV4EndToEndTest {
                     .then()
                     .statusCode(200)
                     .contentType(JSON)
-                    .body(CONTEXT, contains(EDC_CONNECTOR_MANAGEMENT_CONTEXT_V2))
+                    .body(CONTEXT, contains(jsonLdContextArray()))
                     .body(TYPE, equalTo("ContractNegotiation"))
                     .body(ID, is("cn1"))
                     .body("protocol", equalTo("dataspace-protocol-http"));
@@ -329,7 +330,7 @@ public class ContractNegotiationApiV4EndToEndTest {
                     .then()
                     .statusCode(200)
                     .contentType(JSON)
-                    .body(CONTEXT, contains(EDC_CONNECTOR_MANAGEMENT_CONTEXT_V2))
+                    .body(CONTEXT, contains(jsonLdContextArray()))
                     .body(TYPE, equalTo("ContractAgreement"))
                     .body(ID, is("cn1"))
                     .body("assetId", equalTo(agreement.getAssetId()))

--- a/system-tests/management-api/management-api-tests/src/test/java/org/eclipse/edc/test/e2e/managementapi/v4/PolicyDefinitionApiV4EndToEndTest.java
+++ b/system-tests/management-api/management-api-tests/src/test/java/org/eclipse/edc/test/e2e/managementapi/v4/PolicyDefinitionApiV4EndToEndTest.java
@@ -20,7 +20,6 @@ import com.nimbusds.jose.jwk.Curve;
 import com.nimbusds.jose.jwk.ECKey;
 import com.nimbusds.jose.jwk.gen.ECKeyGenerator;
 import io.restassured.http.ContentType;
-import jakarta.json.JsonArray;
 import jakarta.json.JsonObject;
 import org.eclipse.edc.connector.controlplane.policy.spi.PolicyDefinition;
 import org.eclipse.edc.connector.controlplane.policy.spi.store.PolicyDefinitionStore;
@@ -64,8 +63,9 @@ import static org.assertj.core.api.InstanceOfAssertFactories.MAP;
 import static org.eclipse.edc.jsonld.spi.JsonLdKeywords.CONTEXT;
 import static org.eclipse.edc.jsonld.spi.JsonLdKeywords.ID;
 import static org.eclipse.edc.jsonld.spi.JsonLdKeywords.TYPE;
-import static org.eclipse.edc.spi.constants.CoreConstants.EDC_CONNECTOR_MANAGEMENT_CONTEXT_V2;
 import static org.eclipse.edc.spi.query.Criterion.criterion;
+import static org.eclipse.edc.test.e2e.managementapi.v4.TestFunction.jsonLdContext;
+import static org.eclipse.edc.test.e2e.managementapi.v4.TestFunction.jsonLdContextArray;
 import static org.eclipse.edc.virtualized.test.system.fixtures.DockerImages.createPgContainer;
 import static org.hamcrest.Matchers.contains;
 import static org.hamcrest.Matchers.containsString;
@@ -145,7 +145,7 @@ public class PolicyDefinitionApiV4EndToEndTest {
                     .statusCode(200)
                     .contentType(JSON)
                     .body(ID, is(id))
-                    .body(CONTEXT, contains(EDC_CONNECTOR_MANAGEMENT_CONTEXT_V2))
+                    .body(CONTEXT, contains(jsonLdContextArray()))
                     .body("policy.permission[0].constraint[0].leftOperand", is("inForceDate"))
                     .body("policy.permission[0].constraint[0].operator", is("gteq"))
                     .body("policy.permission[0].constraint[0].rightOperand", is("contractAgreement+0s"))
@@ -188,7 +188,7 @@ public class PolicyDefinitionApiV4EndToEndTest {
                     .statusCode(200)
                     .contentType(JSON)
                     .body(ID, is(id))
-                    .body(CONTEXT, contains(EDC_CONNECTOR_MANAGEMENT_CONTEXT_V2))
+                    .body(CONTEXT, contains(jsonLdContextArray()))
                     .log().all()
                     .body("policy.permission[0].constraint[0].operator", is("gteq"));
         }
@@ -320,7 +320,7 @@ public class PolicyDefinitionApiV4EndToEndTest {
                     .log().ifError()
                     .statusCode(200)
                     .body(ID, is(stored.getId()))
-                    .body(CONTEXT, contains(EDC_CONNECTOR_MANAGEMENT_CONTEXT_V2));
+                    .body(CONTEXT, contains(jsonLdContextArray()));
         }
 
         @Test
@@ -911,12 +911,6 @@ public class PolicyDefinitionApiV4EndToEndTest {
                                     .add("action", "use")
                             )
                     )
-                    .build();
-        }
-
-        private JsonArray jsonLdContext() {
-            return createArrayBuilder()
-                    .add(EDC_CONNECTOR_MANAGEMENT_CONTEXT_V2)
                     .build();
         }
 

--- a/system-tests/management-api/management-api-tests/src/test/java/org/eclipse/edc/test/e2e/managementapi/v4/TestFunction.java
+++ b/system-tests/management-api/management-api-tests/src/test/java/org/eclipse/edc/test/e2e/managementapi/v4/TestFunction.java
@@ -19,10 +19,12 @@ import org.eclipse.edc.participantcontext.spi.service.ParticipantContextService;
 import org.eclipse.edc.participantcontext.spi.types.ParticipantContext;
 import org.eclipse.edc.participantcontext.spi.types.ParticipantContextState;
 
+import java.util.Arrays;
 import java.util.Map;
 
 import static jakarta.json.Json.createArrayBuilder;
 import static org.eclipse.edc.spi.constants.CoreConstants.EDC_CONNECTOR_MANAGEMENT_CONTEXT_V2;
+import static org.eclipse.virtualized.api.management.VirtualManagementApi.EDC_V_CONNECTOR_MANAGEMENT_CONTEXT_V2;
 
 public class TestFunction {
 
@@ -44,8 +46,14 @@ public class TestFunction {
     }
 
     public static JsonArray jsonLdContext() {
-        return createArrayBuilder()
-                .add(EDC_CONNECTOR_MANAGEMENT_CONTEXT_V2)
+        return createArrayBuilder(Arrays.stream(jsonLdContextArray()).toList())
                 .build();
+    }
+
+    public static String[] jsonLdContextArray() {
+        return new String[]{
+                EDC_CONNECTOR_MANAGEMENT_CONTEXT_V2,
+                EDC_V_CONNECTOR_MANAGEMENT_CONTEXT_V2
+        };
     }
 }

--- a/system-tests/management-api/management-api-tests/src/test/java/org/eclipse/edc/test/e2e/managementapi/v4/TransferProcessApiV4EndToEndTest.java
+++ b/system-tests/management-api/management-api-tests/src/test/java/org/eclipse/edc/test/e2e/managementapi/v4/TransferProcessApiV4EndToEndTest.java
@@ -83,7 +83,10 @@ import static org.eclipse.edc.jsonld.spi.JsonLdKeywords.ID;
 import static org.eclipse.edc.jsonld.spi.JsonLdKeywords.TYPE;
 import static org.eclipse.edc.spi.constants.CoreConstants.EDC_CONNECTOR_MANAGEMENT_CONTEXT_V2;
 import static org.eclipse.edc.spi.query.Criterion.criterion;
+import static org.eclipse.edc.test.e2e.managementapi.v4.TestFunction.jsonLdContext;
+import static org.eclipse.edc.test.e2e.managementapi.v4.TestFunction.jsonLdContextArray;
 import static org.eclipse.edc.virtualized.test.system.fixtures.DockerImages.createPgContainer;
+import static org.eclipse.virtualized.api.management.VirtualManagementApi.EDC_V_CONNECTOR_MANAGEMENT_CONTEXT_V2;
 import static org.hamcrest.CoreMatchers.anyOf;
 import static org.hamcrest.Matchers.contains;
 import static org.hamcrest.Matchers.containsString;
@@ -198,7 +201,7 @@ public class TransferProcessApiV4EndToEndTest {
         void initiate_whenValidationFails(ManagementEndToEndTestContext context, TransferProcessStore transferProcessStore) {
 
             var requestBody = createObjectBuilder()
-                    .add(CONTEXT, createArrayBuilder().add(EDC_CONNECTOR_MANAGEMENT_CONTEXT_V2))
+                    .add(CONTEXT, jsonLdContext())
                     .add(TYPE, "TransferRequest")
                     .build();
 
@@ -261,7 +264,7 @@ public class TransferProcessApiV4EndToEndTest {
                     .statusCode(200)
                     .body(TYPE, is("TransferProcess"))
                     .body(ID, is("tp2"))
-                    .body(CONTEXT, contains(EDC_CONNECTOR_MANAGEMENT_CONTEXT_V2));
+                    .body(CONTEXT, contains(EDC_CONNECTOR_MANAGEMENT_CONTEXT_V2, EDC_V_CONNECTOR_MANAGEMENT_CONTEXT_V2));
         }
 
         @Test
@@ -303,7 +306,7 @@ public class TransferProcessApiV4EndToEndTest {
                     .statusCode(200)
                     .contentType(JSON)
                     .body(TYPE, is("TransferState"))
-                    .body(CONTEXT, contains(EDC_CONNECTOR_MANAGEMENT_CONTEXT_V2))
+                    .body(CONTEXT, contains(EDC_CONNECTOR_MANAGEMENT_CONTEXT_V2, EDC_V_CONNECTOR_MANAGEMENT_CONTEXT_V2))
                     .body("state", is("COMPLETED"));
         }
 
@@ -497,7 +500,7 @@ public class TransferProcessApiV4EndToEndTest {
             var id = UUID.randomUUID().toString();
             store.save(createTransferProcessBuilder(id).state(STARTED.code()).build());
             var requestBody = createObjectBuilder()
-                    .add(CONTEXT, createArrayBuilder().add(EDC_CONNECTOR_MANAGEMENT_CONTEXT_V2))
+                    .add(CONTEXT, jsonLdContext())
                     .add(TYPE, "SuspendTransfer")
                     .add("reason", "any")
                     .build();
@@ -577,9 +580,9 @@ public class TransferProcessApiV4EndToEndTest {
                     .statusCode(200)
                     .body("size()", is(2))
                     .body("[0].@id", anyOf(is(id1), is(id2)))
-                    .body("[0].@context", contains(EDC_CONNECTOR_MANAGEMENT_CONTEXT_V2))
+                    .body("[0].@context", contains(jsonLdContextArray()))
                     .body("[1].@id", anyOf(is(id1), is(id2)))
-                    .body("[1].@context", contains(EDC_CONNECTOR_MANAGEMENT_CONTEXT_V2));
+                    .body("[1].@context", contains(jsonLdContextArray()));
 
         }
 

--- a/system-tests/runtime-tests/src/test/java/org/eclipse/edc/virtualized/transfer/DcpTransferPullEndToEndTest.java
+++ b/system-tests/runtime-tests/src/test/java/org/eclipse/edc/virtualized/transfer/DcpTransferPullEndToEndTest.java
@@ -126,7 +126,12 @@ class DcpTransferPullEndToEndTest {
                     """;
 
             var providerAddress = env.getProtocolEndpoint().get() + "/" + participants.provider().contextId() + "/2025-1";
-            celPolicyExpressionService.create(new CelExpression("id", leftOperand, expression, "membership expression"))
+            var expr = CelExpression.Builder.newInstance().id("id")
+                    .leftOperand(leftOperand)
+                    .expression(expression)
+                    .description("membership expression")
+                    .build();
+            celPolicyExpressionService.create(expr)
                     .orElseThrow(f -> new RuntimeException("Failed to store CEL expression: " + f.getFailureDetail()));
 
             var policy = Policy.Builder.newInstance()


### PR DESCRIPTION
## What this PR changes/adds

Cel expression api

In order to make it work with api v4 we had to

- create a custom JSON-LD context with `CelExpression` terms
- create a json schema extension with `CelExpression` schema

Since this is still experimental the JSON-LD context and the json schema won't be published yet
and are only cached locally.


Additionally the `CelExpression` has been refactored to be a class with a `Builder`

## Why it does that

_Briefly state why the change was necessary._

## Further notes

_List other areas of code that have changed but are not necessarily linked to the main feature. This could be method
signature changes, package declarations, bugs that were encountered and were fixed inline, etc._


## Who will sponsor this feature?

_Please @-mention the committer that will sponsor your feature_.


## Linked Issue(s)

Closes #65 

_Please be sure to take a look at the [contributing guidelines](https://github.com/eclipse-edc/.github/blob/main/CONTRIBUTING.md#submit-a-pull-request) and our [etiquette for pull requests](https://github.com/eclipse-edc/.github/blob/main/contributing/pr_etiquette.md)._
