### PR TITLE
chore: fix compile issue after upstream changes

### DIFF
--- a/core/transfer-process-manager/src/test/java/org/eclipse/edc/virtualized/controlplane/transfer/process/VirtualTransferProcessManagerTest.java
+++ b/core/transfer-process-manager/src/test/java/org/eclipse/edc/virtualized/controlplane/transfer/process/VirtualTransferProcessManagerTest.java
@@ -46,6 +46,10 @@ public class VirtualTransferProcessManagerTest {
     private final TransferProcessObservable observable = new MockTransferObservable(listener);
     private final PolicyArchive policyArchive = mock();
     private final VirtualTransferProcessManager transferProcessManager = new VirtualTransferProcessManager(store, observable, policyArchive, Clock.systemUTC(), mock());
+    private final ParticipantContext participantContext = ParticipantContext.Builder.newInstance()
+            .participantContextId("participantContextId")
+            .identity("identity")
+            .build();
 
     @Test
     void initiateConsumerRequest() {
@@ -62,7 +66,7 @@ public class VirtualTransferProcessManagerTest {
 
         var captor = ArgumentCaptor.forClass(TransferProcess.class);
 
-        var result = transferProcessManager.initiateConsumerRequest(new ParticipantContext("participantContextId"), transferRequest);
+        var result = transferProcessManager.initiateConsumerRequest(participantContext, transferRequest);
 
         assertThat(result).isSucceeded().isNotNull();
         verify(store).save(captor.capture());
@@ -86,7 +90,7 @@ public class VirtualTransferProcessManagerTest {
                 .dataDestination(DataAddress.Builder.newInstance().type("test").build())
                 .build();
 
-        var result = transferProcessManager.initiateConsumerRequest(new ParticipantContext("participantContextId"), transferRequest);
+        var result = transferProcessManager.initiateConsumerRequest(participantContext, transferRequest);
 
         assertThat(result).isFailed();
     }

--- a/core/v-connector-core/src/main/java/org/eclipse/edc/virtualized/controlplane/VirtualCoreServicesExtension.java
+++ b/core/v-connector-core/src/main/java/org/eclipse/edc/virtualized/controlplane/VirtualCoreServicesExtension.java
@@ -14,13 +14,13 @@
 
 package org.eclipse.edc.virtualized.controlplane;
 
-import org.eclipse.edc.participantcontext.spi.config.ParticipantContextConfig;
 import org.eclipse.edc.participantcontext.spi.identity.ParticipantIdentityResolver;
+import org.eclipse.edc.participantcontext.spi.service.ParticipantContextService;
 import org.eclipse.edc.protocol.spi.DataspaceProfileContextRegistry;
 import org.eclipse.edc.runtime.metamodel.annotation.Extension;
 import org.eclipse.edc.runtime.metamodel.annotation.Inject;
 import org.eclipse.edc.runtime.metamodel.annotation.Provider;
-import org.eclipse.edc.runtime.metamodel.annotation.Setting;
+import org.eclipse.edc.spi.monitor.Monitor;
 import org.eclipse.edc.spi.system.ServiceExtension;
 import org.eclipse.edc.virtualized.controlplane.participantcontext.ParticipantContextIdentityResolverImpl;
 import org.eclipse.edc.virtualized.controlplane.participantcontext.ParticipantWebhookResolverImpl;
@@ -33,14 +33,14 @@ public class VirtualCoreServicesExtension implements ServiceExtension {
 
     public static final String NAME = "EDC-V Core Services";
 
-    @Setting(description = "Configures the participant id this runtime is operating on behalf of")
-    public static final String PARTICIPANT_ID = "edc.participant.id";
-
     @Inject
-    private ParticipantContextConfig contextConfig;
+    private ParticipantContextService participantContextService;
 
     @Inject
     private DataspaceProfileContextRegistry dataspaceProfileContextRegistry;
+
+    @Inject
+    private Monitor monitor;
 
     @Provider
     public ParticipantWebhookResolver participantWebhookResolver() {
@@ -49,6 +49,6 @@ public class VirtualCoreServicesExtension implements ServiceExtension {
 
     @Provider
     public ParticipantIdentityResolver participantIdentityResolver() {
-        return new ParticipantContextIdentityResolverImpl(contextConfig);
+        return new ParticipantContextIdentityResolverImpl(participantContextService, monitor);
     }
 }

--- a/core/v-connector-core/src/main/java/org/eclipse/edc/virtualized/controlplane/participantcontext/ParticipantContextIdentityResolverImpl.java
+++ b/core/v-connector-core/src/main/java/org/eclipse/edc/virtualized/controlplane/participantcontext/ParticipantContextIdentityResolverImpl.java
@@ -14,22 +14,27 @@
 
 package org.eclipse.edc.virtualized.controlplane.participantcontext;
 
-import org.eclipse.edc.participantcontext.spi.config.ParticipantContextConfig;
 import org.eclipse.edc.participantcontext.spi.identity.ParticipantIdentityResolver;
+import org.eclipse.edc.participantcontext.spi.service.ParticipantContextService;
+import org.eclipse.edc.participantcontext.spi.types.ParticipantContext;
+import org.eclipse.edc.spi.monitor.Monitor;
 import org.jetbrains.annotations.Nullable;
-
-import static org.eclipse.edc.virtualized.controlplane.VirtualCoreServicesExtension.PARTICIPANT_ID;
 
 public class ParticipantContextIdentityResolverImpl implements ParticipantIdentityResolver {
 
-    private final ParticipantContextConfig contextConfig;
+    private final ParticipantContextService participantContextService;
+    private final Monitor monitor;
 
-    public ParticipantContextIdentityResolverImpl(ParticipantContextConfig contextConfig) {
-        this.contextConfig = contextConfig;
+    public ParticipantContextIdentityResolverImpl(ParticipantContextService participantContextService, Monitor monitor) {
+        this.participantContextService = participantContextService;
+        this.monitor = monitor;
     }
 
     @Override
     public @Nullable String getParticipantId(String participantContextId, String protocol) {
-        return contextConfig.getString(participantContextId, PARTICIPANT_ID);
+        return participantContextService.getParticipantContext(participantContextId)
+                .map(ParticipantContext::getIdentity)
+                .getContent();
+
     }
 }

--- a/data-protocols/dsp/dsp-2025/dsp-catalog-2025/dsp-catalog-http-api-2025/src/test/java/org/eclipse/edc/virtual/protocol/dsp/catalog/http/api/v2025/controller/DspCatalogApiControllerV20251Test.java
+++ b/data-protocols/dsp/dsp-2025/dsp-catalog-2025/dsp-catalog-http-api-2025/src/test/java/org/eclipse/edc/virtual/protocol/dsp/catalog/http/api/v2025/controller/DspCatalogApiControllerV20251Test.java
@@ -32,7 +32,10 @@ import static org.mockito.Mockito.when;
 public class DspCatalogApiControllerV20251Test extends DspCatalogApiControllerTestBase {
 
     private final ParticipantContextService participantContextService = mock();
-    private final ParticipantContext participantContext = new ParticipantContext("participantContextId");
+    private final ParticipantContext participantContext = ParticipantContext.Builder.newInstance()
+            .participantContextId("participantContextId")
+            .identity("identity")
+            .build();
 
 
     void beforeAll() {

--- a/data-protocols/dsp/dsp-2025/dsp-negotiation-2025/dsp-negotiation-http-api-2025/src/test/java/org/eclipse/edc/virtual/protocol/dsp/negotiation/http/api/v2025/controller/DspNegotiationApiControllerV20251Test.java
+++ b/data-protocols/dsp/dsp-2025/dsp-negotiation-2025/dsp-negotiation-http-api-2025/src/test/java/org/eclipse/edc/virtual/protocol/dsp/negotiation/http/api/v2025/controller/DspNegotiationApiControllerV20251Test.java
@@ -34,8 +34,10 @@ import static org.mockito.Mockito.when;
 class DspNegotiationApiControllerV20251Test extends DspNegotiationApiControllerTestBase {
 
     private final ParticipantContextService participantContextService = mock();
-    private final ParticipantContext participantContext = new ParticipantContext("participantContextId");
-
+    private final ParticipantContext participantContext = ParticipantContext.Builder.newInstance()
+            .participantContextId("participantContextId")
+            .identity("identity")
+            .build();
 
     void beforeAll() {
         when(participantContextService.getParticipantContext(participantContext.getParticipantContextId()))

--- a/data-protocols/dsp/dsp-2025/dsp-transfer-process-2025/dsp-transfer-process-http-api-2025/src/test/java/org/eclipse/edc/virtual/protocol/dsp/negotiation/http/api/v2025/controller/DspTransferProcessApiControllerV20251Test.java
+++ b/data-protocols/dsp/dsp-2025/dsp-transfer-process-2025/dsp-transfer-process-http-api-2025/src/test/java/org/eclipse/edc/virtual/protocol/dsp/negotiation/http/api/v2025/controller/DspTransferProcessApiControllerV20251Test.java
@@ -33,8 +33,10 @@ import static org.mockito.Mockito.when;
 class DspTransferProcessApiControllerV20251Test extends DspTransferProcessApiControllerBaseTest {
 
     private final ParticipantContextService participantContextService = mock();
-    private final ParticipantContext participantContext = new ParticipantContext("participantContextId");
-
+    private final ParticipantContext participantContext = ParticipantContext.Builder.newInstance()
+            .participantContextId("participantContextId")
+            .identity("identity")
+            .build();
 
     void beforeAll() {
         when(participantContextService.getParticipantContext(participantContext.getParticipantContextId()))

--- a/data-protocols/dsp/dsp-metadata-http-api/src/test/java/org/eclipse/edc/virtual/protocol/dsp/metadata/http/api/DspMetadataApiControllerTest.java
+++ b/data-protocols/dsp/dsp-metadata-http-api/src/test/java/org/eclipse/edc/virtual/protocol/dsp/metadata/http/api/DspMetadataApiControllerTest.java
@@ -53,7 +53,8 @@ class DspMetadataApiControllerTest extends RestControllerTestBase {
         var participantContextId = "participantcontextId";
 
         when(participantContextService.getParticipantContext(participantContextId))
-                .thenReturn(ServiceResult.success(ParticipantContext.Builder.newInstance().participantContextId("participantcontextId").build()));
+                .thenReturn(ServiceResult.success(ParticipantContext.Builder.newInstance().identity("identity")
+                        .participantContextId("participantcontextId").build()));
         var versions = new ProtocolVersions(List.of(new ProtocolVersion("version", "/1.0", "binding")));
         var output = Json.createObjectBuilder()
                 .add("protocolVersions", Json.createArrayBuilder()

--- a/extensions/cel/cel-spi/src/main/java/org/eclipse/edc/virtualized/policy/cel/model/CelExpression.java
+++ b/extensions/cel/cel-spi/src/main/java/org/eclipse/edc/virtualized/policy/cel/model/CelExpression.java
@@ -116,10 +116,10 @@ public class CelExpression extends Entity {
         }
 
         public CelExpression build() {
+            super.build();
             Objects.requireNonNull(entity.leftOperand, "CelExpression leftOperand cannot be null");
             Objects.requireNonNull(entity.expression, "CelExpression expression cannot be null");
             Objects.requireNonNull(entity.description, "CelExpression description cannot be null");
-
             if (entity.getUpdatedAt() == 0L) {
                 entity.updatedAt = entity.getCreatedAt();
             }
@@ -127,8 +127,8 @@ public class CelExpression extends Entity {
             if (entity.scopes.isEmpty()) {
                 entity.scopes.add(MATCH_ALL_SCOPE);
             }
+            return entity;
 
-            return super.build();
         }
 
     }

--- a/extensions/common/api/lib/api-authentication-lib/src/test/java/org/eclipse/edc/virtualized/api/authorization/filter/ServicePrincipalAuthenticationFilterTest.java
+++ b/extensions/common/api/lib/api-authentication-lib/src/test/java/org/eclipse/edc/virtualized/api/authorization/filter/ServicePrincipalAuthenticationFilterTest.java
@@ -44,6 +44,7 @@ class ServicePrincipalAuthenticationFilterTest {
         when(participantContextService.getParticipantContext(anyString()))
                 .thenAnswer(i ->
                         ServiceResult.success(ParticipantContext.Builder.newInstance()
+                                .identity(i.getArgument(0))
                                 .participantContextId(i.getArgument(0))
                                 .build()));
     }

--- a/extensions/control-plane/api/management-api/catalog-api/src/test/java/org/eclipse/edc/virtual/connector/controlplane/api/management/catalog/BaseCatalogApiControllerTest.java
+++ b/extensions/control-plane/api/management-api/catalog-api/src/test/java/org/eclipse/edc/virtual/connector/controlplane/api/management/catalog/BaseCatalogApiControllerTest.java
@@ -65,7 +65,8 @@ public abstract class BaseCatalogApiControllerTest extends RestControllerTestBas
     @BeforeEach
     void setup() {
         when(participantContextService.getParticipantContext(eq(participantContextId)))
-                .thenReturn(ServiceResult.success(ParticipantContext.Builder.newInstance().participantContextId(participantContextId).build()));
+                .thenReturn(ServiceResult.success(ParticipantContext.Builder.newInstance().participantContextId(participantContextId)
+                        .identity(participantContextId).build()));
 
         when(authorizationService.authorize(any(), any(), any(), any())).thenReturn(ServiceResult.success());
     }

--- a/extensions/control-plane/api/management-api/contract-negotiation-api/src/test/java/org/eclipse/edc/virtual/connector/controlplane/api/management/contractnegotiation/ContractNegotiationApiControllerTestBase.java
+++ b/extensions/control-plane/api/management-api/contract-negotiation-api/src/test/java/org/eclipse/edc/virtual/connector/controlplane/api/management/contractnegotiation/ContractNegotiationApiControllerTestBase.java
@@ -223,7 +223,8 @@ public abstract class ContractNegotiationApiControllerTestBase extends RestContr
                                     .build())
                             .build()));
 
-            when(participantContextService.getParticipantContext(any())).thenReturn(ServiceResult.success(ParticipantContext.Builder.newInstance().participantContextId(participantContextId).build()));
+            when(participantContextService.getParticipantContext(any()))
+                    .thenReturn(ServiceResult.success(ParticipantContext.Builder.newInstance().participantContextId(participantContextId).identity(participantContextId).build()));
             when(transformerRegistry.transform(any(), eq(JsonObject.class))).thenReturn(Result.success(responseBody));
             when(service.initiateNegotiation(any(ParticipantContext.class), any(ContractRequest.class))).thenReturn(contractNegotiation);
 

--- a/extensions/control-plane/api/management-api/participant-context-api/src/test/java/org/eclipse/edc/virtualized/connector/controlplane/api/management/participantcontext/ParticipantContextApiControllerTestBase.java
+++ b/extensions/control-plane/api/management-api/participant-context-api/src/test/java/org/eclipse/edc/virtualized/connector/controlplane/api/management/participantcontext/ParticipantContextApiControllerTestBase.java
@@ -83,6 +83,7 @@ public abstract class ParticipantContextApiControllerTestBase extends RestContro
     private ParticipantContext createParticipantContext() {
         return createParticipantContextBuilder()
                 .participantContextId(UUID.randomUUID().toString())
+                .identity(UUID.randomUUID().toString())
                 .properties(Map.of())
                 .build();
     }

--- a/extensions/control-plane/api/management-api/transfer-process-api/src/test/java/org/eclipse/edc/virtual/connector/controlplane/api/management/transferprocess/BaseTransferProcessApiControllerTest.java
+++ b/extensions/control-plane/api/management-api/transfer-process-api/src/test/java/org/eclipse/edc/virtual/connector/controlplane/api/management/transferprocess/BaseTransferProcessApiControllerTest.java
@@ -269,7 +269,8 @@ public abstract class BaseTransferProcessApiControllerTest extends RestControlle
             var transferRequest = TransferRequest.Builder.newInstance().build();
             var transferProcess = createTransferProcess().id("id").build();
             var responseBody = Json.createObjectBuilder().add(ID, "transferProcessId").build();
-            when(participantContextService.getParticipantContext(any())).thenReturn(ServiceResult.success(ParticipantContext.Builder.newInstance().participantContextId(participantContextId).build()));
+            when(participantContextService.getParticipantContext(any()))
+                    .thenReturn(ServiceResult.success(ParticipantContext.Builder.newInstance().participantContextId(participantContextId).identity(participantContextId).build()));
             when(transformerRegistry.transform(any(), eq(TransferRequest.class))).thenReturn(Result.success(transferRequest));
             when(service.initiateTransfer(isA(ParticipantContext.class), any())).thenReturn(ServiceResult.success(transferProcess));
             when(transformerRegistry.transform(any(), eq(JsonObject.class))).thenReturn(Result.success(responseBody));
@@ -306,7 +307,8 @@ public abstract class BaseTransferProcessApiControllerTest extends RestControlle
         @Test
         void shouldReturnConflict_whenItAlreadyExists() {
             var transferRequest = TransferRequest.Builder.newInstance().build();
-            when(participantContextService.getParticipantContext(any())).thenReturn(ServiceResult.success(ParticipantContext.Builder.newInstance().participantContextId(participantContextId).build()));
+            when(participantContextService.getParticipantContext(any()))
+                    .thenReturn(ServiceResult.success(ParticipantContext.Builder.newInstance().participantContextId(participantContextId).identity(participantContextId).build()));
             when(transformerRegistry.transform(any(), eq(TransferRequest.class))).thenReturn(Result.success(transferRequest));
             when(service.initiateTransfer(any(), any())).thenReturn(ServiceResult.conflict("already exists"));
             var requestBody = Json.createObjectBuilder().build();

--- a/system-tests/extensions/v-tck-extension/src/main/java/org/eclipse/edc/virtua/tck/dsp/DspTckExtension.java
+++ b/system-tests/extensions/v-tck-extension/src/main/java/org/eclipse/edc/virtua/tck/dsp/DspTckExtension.java
@@ -31,7 +31,10 @@ public class DspTckExtension implements ServiceExtension {
 
     @Override
     public void prepare() {
-        participantContextService.createParticipantContext(ParticipantContext.Builder.newInstance().participantContextId("participantContextId").build())
+        participantContextService.createParticipantContext(ParticipantContext.Builder.newInstance()
+                        .participantContextId("participantContextId")
+                        .identity("participantContextId")
+                        .build())
                 .orElseThrow(f -> new EdcException("Failed to create ParticipantContext"));
     }
 }

--- a/system-tests/management-api/management-api-tests/src/test/java/org/eclipse/edc/test/e2e/managementapi/v4/AssetApiV4EndToEndTest.java
+++ b/system-tests/management-api/management-api-tests/src/test/java/org/eclipse/edc/test/e2e/managementapi/v4/AssetApiV4EndToEndTest.java
@@ -29,8 +29,6 @@ import org.eclipse.edc.junit.annotations.PostgresqlIntegrationTest;
 import org.eclipse.edc.junit.extensions.ComponentRuntimeExtension;
 import org.eclipse.edc.junit.extensions.RuntimeExtension;
 import org.eclipse.edc.participantcontext.spi.service.ParticipantContextService;
-import org.eclipse.edc.participantcontext.spi.types.ParticipantContext;
-import org.eclipse.edc.participantcontext.spi.types.ParticipantContextState;
 import org.eclipse.edc.spi.system.configuration.Config;
 import org.eclipse.edc.spi.system.configuration.ConfigFactory;
 import org.eclipse.edc.spi.types.domain.DataAddress;
@@ -67,6 +65,8 @@ import static org.eclipse.edc.jsonld.spi.JsonLdKeywords.VALUE;
 import static org.eclipse.edc.spi.constants.CoreConstants.EDC_CONNECTOR_MANAGEMENT_CONTEXT_V2;
 import static org.eclipse.edc.spi.constants.CoreConstants.EDC_NAMESPACE;
 import static org.eclipse.edc.spi.query.Criterion.criterion;
+import static org.eclipse.edc.test.e2e.managementapi.v4.TestFunction.createParticipant;
+import static org.eclipse.edc.test.e2e.managementapi.v4.TestFunction.participantContext;
 import static org.eclipse.edc.virtualized.test.system.fixtures.DockerImages.createPgContainer;
 import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.is;
@@ -410,8 +410,7 @@ public class AssetApiV4EndToEndTest {
                                                    ParticipantContextService srv) {
             var otherParticipantId = UUID.randomUUID().toString();
 
-            srv.createParticipantContext(ParticipantContext.Builder.newInstance()
-                            .participantContextId(otherParticipantId).build())
+            srv.createParticipantContext(participantContext(otherParticipantId))
                     .orElseThrow(f -> new AssertionError(f.getFailureDetail()));
 
             var ownAssetId = UUID.randomUUID().toString();
@@ -450,8 +449,7 @@ public class AssetApiV4EndToEndTest {
         void queryAsset_tokenBearerNotEqualResourceOwner(ManagementEndToEndTestContext context,
                                                          AssetIndex assetIndex, ParticipantContextService srv) {
             var participantId = UUID.randomUUID().toString();
-            srv.createParticipantContext(ParticipantContext.Builder.newInstance()
-                            .participantContextId(participantId).build())
+            srv.createParticipantContext(participantContext(participantId))
                     .orElseThrow(f -> new AssertionError(
                             "ParticipantContext " + participantId + " not created."));
 
@@ -662,8 +660,7 @@ public class AssetApiV4EndToEndTest {
                                           ParticipantContextService service) {
             var json = createAssetJson(createAsset().build());
             var id = "other-participant";
-            var pc = service.createParticipantContext(
-                            ParticipantContext.Builder.newInstance().participantContextId(id).build())
+            service.createParticipantContext(participantContext(id))
                     .orElseThrow(f -> new AssertionError(
                             "ParticipantContext " + id + " not created."));
 
@@ -860,17 +857,6 @@ public class AssetApiV4EndToEndTest {
                                     .build()))
                     .build()
                     .toString();
-        }
-
-        private void createParticipant(ParticipantContextService participantContextService,
-                                       String participantContextId) {
-            var pc = ParticipantContext.Builder.newInstance()
-                    .participantContextId(participantContextId)
-                    .state(ParticipantContextState.ACTIVATED)
-                    .build();
-
-            participantContextService.createParticipantContext(pc)
-                    .orElseThrow(f -> new AssertionError(f.getFailureDetail()));
         }
 
         private DataAddress.Builder createDataAddress() {

--- a/system-tests/management-api/management-api-tests/src/test/java/org/eclipse/edc/test/e2e/managementapi/v4/CatalogApiV4EndToEndTest.java
+++ b/system-tests/management-api/management-api-tests/src/test/java/org/eclipse/edc/test/e2e/managementapi/v4/CatalogApiV4EndToEndTest.java
@@ -595,12 +595,13 @@ public class CatalogApiV4EndToEndTest {
             var pc = ParticipantContext.Builder.newInstance()
                     .participantContextId(participantContextId)
                     .state(ParticipantContextState.ACTIVATED)
+                    .identity(participantContextId)
                     .build();
 
             var config = ParticipantContextConfiguration.Builder.newInstance()
                     .participantContextId(participantContextId)
                     .entries(Map.of("edc.mock.region", "eu",
-                            "edc.participant.id", "did:web:" + PARTICIPANT_CONTEXT_ID
+                            "edc.participant.id", "did:web:" + participantContextId
                     ))
                     .build();
 

--- a/system-tests/management-api/management-api-tests/src/test/java/org/eclipse/edc/test/e2e/managementapi/v4/ContractDefinitionApiV4EndToEndTest.java
+++ b/system-tests/management-api/management-api-tests/src/test/java/org/eclipse/edc/test/e2e/managementapi/v4/ContractDefinitionApiV4EndToEndTest.java
@@ -19,7 +19,6 @@ import com.nimbusds.jose.JOSEException;
 import com.nimbusds.jose.jwk.Curve;
 import com.nimbusds.jose.jwk.ECKey;
 import com.nimbusds.jose.jwk.gen.ECKeyGenerator;
-import jakarta.json.JsonArray;
 import jakarta.json.JsonObjectBuilder;
 import org.eclipse.edc.connector.controlplane.contract.spi.offer.store.ContractDefinitionStore;
 import org.eclipse.edc.connector.controlplane.contract.spi.types.offer.ContractDefinition;
@@ -29,8 +28,6 @@ import org.eclipse.edc.junit.annotations.PostgresqlIntegrationTest;
 import org.eclipse.edc.junit.extensions.ComponentRuntimeExtension;
 import org.eclipse.edc.junit.extensions.RuntimeExtension;
 import org.eclipse.edc.participantcontext.spi.service.ParticipantContextService;
-import org.eclipse.edc.participantcontext.spi.types.ParticipantContext;
-import org.eclipse.edc.participantcontext.spi.types.ParticipantContextState;
 import org.eclipse.edc.spi.system.configuration.Config;
 import org.eclipse.edc.spi.system.configuration.ConfigFactory;
 import org.eclipse.edc.sql.testfixtures.PostgresqlEndToEndExtension;
@@ -66,9 +63,10 @@ import static org.assertj.core.api.InstanceOfAssertFactories.LIST;
 import static org.eclipse.edc.jsonld.spi.JsonLdKeywords.CONTEXT;
 import static org.eclipse.edc.jsonld.spi.JsonLdKeywords.ID;
 import static org.eclipse.edc.jsonld.spi.JsonLdKeywords.TYPE;
-import static org.eclipse.edc.spi.constants.CoreConstants.EDC_CONNECTOR_MANAGEMENT_CONTEXT_V2;
 import static org.eclipse.edc.spi.constants.CoreConstants.EDC_NAMESPACE;
 import static org.eclipse.edc.spi.query.Criterion.criterion;
+import static org.eclipse.edc.test.e2e.managementapi.v4.TestFunction.createParticipant;
+import static org.eclipse.edc.test.e2e.managementapi.v4.TestFunction.jsonLdContext;
 import static org.eclipse.edc.virtualized.test.system.fixtures.DockerImages.createPgContainer;
 import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.equalTo;
@@ -716,23 +714,6 @@ public class ContractDefinitionApiV4EndToEndTest {
                     .participantContextId(PARTICIPANT_CONTEXT_ID)
                     .assetsSelectorCriterion(criterion("foo", "=", "bar"))
                     .assetsSelectorCriterion(criterion("bar", "=", "baz"));
-        }
-
-        private JsonArray jsonLdContext() {
-            return createArrayBuilder()
-                    .add(EDC_CONNECTOR_MANAGEMENT_CONTEXT_V2)
-                    .build();
-        }
-
-        private void createParticipant(ParticipantContextService participantContextService,
-                                       String participantContextId) {
-            var pc = ParticipantContext.Builder.newInstance()
-                    .participantContextId(participantContextId)
-                    .state(ParticipantContextState.ACTIVATED)
-                    .build();
-
-            participantContextService.createParticipantContext(pc)
-                    .orElseThrow(f -> new AssertionError(f.getFailureDetail()));
         }
     }
 

--- a/system-tests/management-api/management-api-tests/src/test/java/org/eclipse/edc/test/e2e/managementapi/v4/ContractNegotiationApiV4EndToEndTest.java
+++ b/system-tests/management-api/management-api-tests/src/test/java/org/eclipse/edc/test/e2e/managementapi/v4/ContractNegotiationApiV4EndToEndTest.java
@@ -32,7 +32,6 @@ import org.eclipse.edc.junit.annotations.PostgresqlIntegrationTest;
 import org.eclipse.edc.junit.extensions.ComponentRuntimeExtension;
 import org.eclipse.edc.junit.extensions.RuntimeExtension;
 import org.eclipse.edc.participantcontext.spi.service.ParticipantContextService;
-import org.eclipse.edc.participantcontext.spi.types.ParticipantContext;
 import org.eclipse.edc.policy.model.Policy;
 import org.eclipse.edc.policy.model.PolicyType;
 import org.eclipse.edc.spi.query.QuerySpec;
@@ -77,6 +76,7 @@ import static org.eclipse.edc.test.e2e.managementapi.v4.TestFunction.PARTICIPANT
 import static org.eclipse.edc.test.e2e.managementapi.v4.TestFunction.createParticipant;
 import static org.eclipse.edc.test.e2e.managementapi.v4.TestFunction.jsonLdContext;
 import static org.eclipse.edc.test.e2e.managementapi.v4.TestFunction.jsonLdContextArray;
+import static org.eclipse.edc.test.e2e.managementapi.v4.TestFunction.participantContext;
 import static org.eclipse.edc.virtualized.test.system.fixtures.DockerImages.createPgContainer;
 import static org.hamcrest.Matchers.contains;
 import static org.hamcrest.Matchers.containsString;
@@ -171,7 +171,7 @@ public class ContractNegotiationApiV4EndToEndTest {
 
             var otherParticipantId = UUID.randomUUID().toString();
 
-            service.createParticipantContext(ParticipantContext.Builder.newInstance().participantContextId(otherParticipantId).build())
+            service.createParticipantContext(participantContext(otherParticipantId))
                     .orElseThrow(f -> new AssertionError("ParticipantContext " + otherParticipantId + " not created."));
 
             var token = context.createToken(otherParticipantId, oauthServerSigningKey);
@@ -192,7 +192,7 @@ public class ContractNegotiationApiV4EndToEndTest {
 
             var otherParticipantId = UUID.randomUUID().toString();
 
-            service.createParticipantContext(ParticipantContext.Builder.newInstance().participantContextId(otherParticipantId).build())
+            service.createParticipantContext(participantContext(otherParticipantId))
                     .orElseThrow(f -> new AssertionError("ParticipantContext " + otherParticipantId + " not created."));
 
             var token = context.createToken(PARTICIPANT_CONTEXT_ID, oauthServerSigningKey, Map.of("scope", "management-api:read"));
@@ -508,7 +508,7 @@ public class ContractNegotiationApiV4EndToEndTest {
         @Test
         void query_tokenBearerNotEqualResourceOwner(ManagementEndToEndTestContext context, ContractNegotiationStore store, ParticipantContextService srv) {
             var otherParticipantId = UUID.randomUUID().toString();
-            srv.createParticipantContext(ParticipantContext.Builder.newInstance().participantContextId(otherParticipantId).build())
+            srv.createParticipantContext(participantContext(otherParticipantId))
                     .orElseThrow(f -> new AssertionError("ParticipantContext " + otherParticipantId + " not created."));
             var id = UUID.randomUUID().toString();
             store.save(createContractNegotiationBuilder(id).counterPartyAddress(context.providerProtocolUrl(COUNTER_PARTY_ID)).build());

--- a/system-tests/management-api/management-api-tests/src/test/java/org/eclipse/edc/test/e2e/managementapi/v4/ParticipantContextApiEndToEndTest.java
+++ b/system-tests/management-api/management-api-tests/src/test/java/org/eclipse/edc/test/e2e/managementapi/v4/ParticipantContextApiEndToEndTest.java
@@ -24,8 +24,6 @@ import org.eclipse.edc.junit.annotations.PostgresqlIntegrationTest;
 import org.eclipse.edc.junit.extensions.ComponentRuntimeExtension;
 import org.eclipse.edc.junit.extensions.RuntimeExtension;
 import org.eclipse.edc.participantcontext.spi.service.ParticipantContextService;
-import org.eclipse.edc.participantcontext.spi.types.ParticipantContext;
-import org.eclipse.edc.participantcontext.spi.types.ParticipantContextState;
 import org.eclipse.edc.spi.query.QuerySpec;
 import org.eclipse.edc.spi.system.configuration.Config;
 import org.eclipse.edc.spi.system.configuration.ConfigFactory;
@@ -59,6 +57,7 @@ import static org.eclipse.edc.jsonld.spi.JsonLdKeywords.ID;
 import static org.eclipse.edc.jsonld.spi.JsonLdKeywords.TYPE;
 import static org.eclipse.edc.test.e2e.managementapi.v4.TestFunction.createParticipant;
 import static org.eclipse.edc.test.e2e.managementapi.v4.TestFunction.jsonLdContext;
+import static org.eclipse.edc.test.e2e.managementapi.v4.TestFunction.participantContext;
 import static org.eclipse.edc.virtualized.test.system.fixtures.DockerImages.createPgContainer;
 import static org.hamcrest.Matchers.equalTo;
 
@@ -105,6 +104,7 @@ public class ParticipantContextApiEndToEndTest {
                     .add(CONTEXT, jsonLdContext())
                     .add(TYPE, "ParticipantContext")
                     .add(ID, participantContextId)
+                    .add("identity", participantContextId)
                     .add("properties", createObjectBuilder().add("test", "test"))
                     .build()
                     .toString();
@@ -202,13 +202,14 @@ public class ParticipantContextApiEndToEndTest {
         void update(ManagementEndToEndTestContext context, ParticipantContextService service) {
             var participantContextId = "test-user";
 
-            service.createParticipantContext(ParticipantContext.Builder.newInstance().participantContextId(participantContextId).build());
+            service.createParticipantContext(participantContext(participantContextId));
 
             var props = Map.of("newKey", "newValue");
             var body = createObjectBuilder()
                     .add(CONTEXT, jsonLdContext())
                     .add(TYPE, "ParticipantContext")
                     .add(ID, participantContextId)
+                    .add("identity", participantContextId)
                     .add("properties", createObjectBuilder(props))
                     .build()
                     .toString();
@@ -278,9 +279,7 @@ public class ParticipantContextApiEndToEndTest {
 
             range(0, 10).forEach(i -> {
                 var participantContextId = "user" + i;
-                service.createParticipantContext(ParticipantContext.Builder.newInstance()
-                        .state(ParticipantContextState.CREATED)
-                        .participantContextId(participantContextId).build());
+                service.createParticipantContext(participantContext(participantContextId));
             });
 
             var token = context.createProvisionerToken(oauthServerSigningKey);
@@ -297,9 +296,7 @@ public class ParticipantContextApiEndToEndTest {
 
             range(0, 10).forEach(i -> {
                 var participantContextId = "user" + i;
-                service.createParticipantContext(ParticipantContext.Builder.newInstance()
-                        .state(ParticipantContextState.CREATED)
-                        .participantContextId(participantContextId).build());
+                service.createParticipantContext(participantContext(participantContextId));
             });
 
             var token = context.createProvisionerToken(oauthServerSigningKey);
@@ -319,9 +316,7 @@ public class ParticipantContextApiEndToEndTest {
 
             range(0, 10).forEach(i -> {
                 var participantContextId = "user" + i;
-                service.createParticipantContext(ParticipantContext.Builder.newInstance()
-                        .state(ParticipantContextState.CREATED)
-                        .participantContextId(participantContextId).build());
+                service.createParticipantContext(participantContext(participantContextId));
             });
 
             var token = context.createToken(otherParticipantId, oauthServerSigningKey);

--- a/system-tests/management-api/management-api-tests/src/test/java/org/eclipse/edc/test/e2e/managementapi/v4/PolicyDefinitionApiV4EndToEndTest.java
+++ b/system-tests/management-api/management-api-tests/src/test/java/org/eclipse/edc/test/e2e/managementapi/v4/PolicyDefinitionApiV4EndToEndTest.java
@@ -28,8 +28,6 @@ import org.eclipse.edc.junit.annotations.PostgresqlIntegrationTest;
 import org.eclipse.edc.junit.extensions.ComponentRuntimeExtension;
 import org.eclipse.edc.junit.extensions.RuntimeExtension;
 import org.eclipse.edc.participantcontext.spi.service.ParticipantContextService;
-import org.eclipse.edc.participantcontext.spi.types.ParticipantContext;
-import org.eclipse.edc.participantcontext.spi.types.ParticipantContextState;
 import org.eclipse.edc.policy.model.Policy;
 import org.eclipse.edc.spi.query.QuerySpec;
 import org.eclipse.edc.spi.system.configuration.Config;
@@ -64,8 +62,10 @@ import static org.eclipse.edc.jsonld.spi.JsonLdKeywords.CONTEXT;
 import static org.eclipse.edc.jsonld.spi.JsonLdKeywords.ID;
 import static org.eclipse.edc.jsonld.spi.JsonLdKeywords.TYPE;
 import static org.eclipse.edc.spi.query.Criterion.criterion;
+import static org.eclipse.edc.test.e2e.managementapi.v4.TestFunction.createParticipant;
 import static org.eclipse.edc.test.e2e.managementapi.v4.TestFunction.jsonLdContext;
 import static org.eclipse.edc.test.e2e.managementapi.v4.TestFunction.jsonLdContextArray;
+import static org.eclipse.edc.test.e2e.managementapi.v4.TestFunction.participantContext;
 import static org.eclipse.edc.virtualized.test.system.fixtures.DockerImages.createPgContainer;
 import static org.hamcrest.Matchers.contains;
 import static org.hamcrest.Matchers.containsString;
@@ -77,7 +77,6 @@ import static org.hamcrest.Matchers.startsWith;
 
 public class PolicyDefinitionApiV4EndToEndTest {
 
-    @SuppressWarnings("JUnitMalformedDeclaration")
     abstract static class Tests {
 
         private static final String PARTICIPANT_CONTEXT_ID = "test-participant";
@@ -222,7 +221,7 @@ public class PolicyDefinitionApiV4EndToEndTest {
                     .build();
             var id = "other-participant";
 
-            service.createParticipantContext(ParticipantContext.Builder.newInstance().participantContextId(id).build())
+            service.createParticipantContext(participantContext(id))
                     .orElseThrow(f -> new AssertionError("ParticipantContext " + id + " not created."));
 
             var token = context.createToken(id, oauthServerSigningKey);
@@ -467,8 +466,7 @@ public class PolicyDefinitionApiV4EndToEndTest {
         @Test
         void query_tokenBearerNotEqualResourceOwner(ManagementEndToEndTestContext context, PolicyDefinitionStore store, ParticipantContextService srv) {
             var participantId = UUID.randomUUID().toString();
-            srv.createParticipantContext(ParticipantContext.Builder.newInstance().participantContextId(participantId).build())
-                    .orElseThrow(f -> new AssertionError("ParticipantContext " + participantId + " not created."));
+            createParticipant(srv, participantId);
 
             var token = context.createToken(participantId, oauthServerSigningKey);
 
@@ -914,15 +912,6 @@ public class PolicyDefinitionApiV4EndToEndTest {
                     .build();
         }
 
-        private void createParticipant(ParticipantContextService participantContextService, String participantContextId) {
-            var pc = ParticipantContext.Builder.newInstance()
-                    .participantContextId(participantContextId)
-                    .state(ParticipantContextState.ACTIVATED)
-                    .build();
-
-            participantContextService.createParticipantContext(pc)
-                    .orElseThrow(f -> new AssertionError(f.getFailureDetail()));
-        }
     }
 
     @Nested

--- a/system-tests/management-api/management-api-tests/src/test/java/org/eclipse/edc/test/e2e/managementapi/v4/TestFunction.java
+++ b/system-tests/management-api/management-api-tests/src/test/java/org/eclipse/edc/test/e2e/managementapi/v4/TestFunction.java
@@ -35,14 +35,27 @@ public class TestFunction {
     }
 
     public static void createParticipant(ParticipantContextService participantContextService, String participantContextId, Map<String, Object> properties) {
-        var pc = ParticipantContext.Builder.newInstance()
-                .participantContextId(participantContextId)
-                .properties(properties)
-                .state(ParticipantContextState.ACTIVATED)
-                .build();
+        var pc = participantContext(participantContextId, properties);
 
         participantContextService.createParticipantContext(pc)
                 .orElseThrow(f -> new AssertionError(f.getFailureDetail()));
+    }
+
+    public static ParticipantContext participantContext(String participantContextId) {
+        return participantContext(participantContextId, participantContextId, Map.of());
+    }
+
+    public static ParticipantContext participantContext(String participantContextId, Map<String, Object> properties) {
+        return participantContext(participantContextId, participantContextId, properties);
+    }
+
+    public static ParticipantContext participantContext(String participantContextId, String identity, Map<String, Object> properties) {
+        return ParticipantContext.Builder.newInstance()
+                .participantContextId(participantContextId)
+                .properties(properties)
+                .identity(identity)
+                .state(ParticipantContextState.ACTIVATED)
+                .build();
     }
 
     public static JsonArray jsonLdContext() {

--- a/system-tests/management-api/management-api-tests/src/test/java/org/eclipse/edc/test/e2e/managementapi/v4/TransferProcessApiV4EndToEndTest.java
+++ b/system-tests/management-api/management-api-tests/src/test/java/org/eclipse/edc/test/e2e/managementapi/v4/TransferProcessApiV4EndToEndTest.java
@@ -34,8 +34,6 @@ import org.eclipse.edc.junit.annotations.PostgresqlIntegrationTest;
 import org.eclipse.edc.junit.extensions.ComponentRuntimeExtension;
 import org.eclipse.edc.junit.extensions.RuntimeExtension;
 import org.eclipse.edc.participantcontext.spi.service.ParticipantContextService;
-import org.eclipse.edc.participantcontext.spi.types.ParticipantContext;
-import org.eclipse.edc.participantcontext.spi.types.ParticipantContextState;
 import org.eclipse.edc.policy.model.Policy;
 import org.eclipse.edc.spi.query.QuerySpec;
 import org.eclipse.edc.spi.system.configuration.Config;
@@ -83,8 +81,10 @@ import static org.eclipse.edc.jsonld.spi.JsonLdKeywords.ID;
 import static org.eclipse.edc.jsonld.spi.JsonLdKeywords.TYPE;
 import static org.eclipse.edc.spi.constants.CoreConstants.EDC_CONNECTOR_MANAGEMENT_CONTEXT_V2;
 import static org.eclipse.edc.spi.query.Criterion.criterion;
+import static org.eclipse.edc.test.e2e.managementapi.v4.TestFunction.createParticipant;
 import static org.eclipse.edc.test.e2e.managementapi.v4.TestFunction.jsonLdContext;
 import static org.eclipse.edc.test.e2e.managementapi.v4.TestFunction.jsonLdContextArray;
+import static org.eclipse.edc.test.e2e.managementapi.v4.TestFunction.participantContext;
 import static org.eclipse.edc.virtualized.test.system.fixtures.DockerImages.createPgContainer;
 import static org.eclipse.virtualized.api.management.VirtualManagementApi.EDC_V_CONNECTOR_MANAGEMENT_CONTEXT_V2;
 import static org.hamcrest.CoreMatchers.anyOf;
@@ -134,17 +134,6 @@ public class TransferProcessApiV4EndToEndTest {
                     .orElseThrow(f -> new AssertionError(f.getFailureDetail()));
 
             store.findAll(QuerySpec.max()).forEach(tp -> store.delete(tp.getId()));
-
-        }
-
-        private void createParticipant(ParticipantContextService participantContextService, String participantContextId) {
-            var pc = ParticipantContext.Builder.newInstance()
-                    .participantContextId(participantContextId)
-                    .state(ParticipantContextState.ACTIVATED)
-                    .build();
-
-            participantContextService.createParticipantContext(pc)
-                    .orElseThrow(f -> new AssertionError(f.getFailureDetail()));
 
         }
 
@@ -198,7 +187,7 @@ public class TransferProcessApiV4EndToEndTest {
         }
 
         @Test
-        void initiate_whenValidationFails(ManagementEndToEndTestContext context, TransferProcessStore transferProcessStore) {
+        void initiate_whenValidationFails(ManagementEndToEndTestContext context) {
 
             var requestBody = createObjectBuilder()
                     .add(CONTEXT, jsonLdContext())
@@ -222,7 +211,7 @@ public class TransferProcessApiV4EndToEndTest {
 
             var otherParticipantId = UUID.randomUUID().toString();
 
-            service.createParticipantContext(ParticipantContext.Builder.newInstance().participantContextId(otherParticipantId).build())
+            service.createParticipantContext(participantContext(otherParticipantId))
                     .orElseThrow(f -> new AssertionError("ParticipantContext " + otherParticipantId + " not created."));
 
             var token = context.createToken(otherParticipantId, oauthServerSigningKey);
@@ -273,7 +262,7 @@ public class TransferProcessApiV4EndToEndTest {
 
             var otherParticipantId = UUID.randomUUID().toString();
 
-            service.createParticipantContext(ParticipantContext.Builder.newInstance().participantContextId(otherParticipantId).build())
+            service.createParticipantContext(participantContext(otherParticipantId))
                     .orElseThrow(f -> new AssertionError("ParticipantContext " + otherParticipantId + " not created."));
 
             var token = context.createToken(otherParticipantId, oauthServerSigningKey);
@@ -316,7 +305,7 @@ public class TransferProcessApiV4EndToEndTest {
 
             var otherParticipantId = UUID.randomUUID().toString();
 
-            service.createParticipantContext(ParticipantContext.Builder.newInstance().participantContextId(otherParticipantId).build())
+            service.createParticipantContext(participantContext(otherParticipantId))
                     .orElseThrow(f -> new AssertionError("ParticipantContext " + otherParticipantId + " not created."));
 
             var token = context.createToken(otherParticipantId, oauthServerSigningKey);
@@ -358,7 +347,7 @@ public class TransferProcessApiV4EndToEndTest {
 
             var otherParticipantId = UUID.randomUUID().toString();
 
-            service.createParticipantContext(ParticipantContext.Builder.newInstance().participantContextId(otherParticipantId).build())
+            service.createParticipantContext(participantContext(otherParticipantId))
                     .orElseThrow(f -> new AssertionError("ParticipantContext " + otherParticipantId + " not created."));
 
             var token = context.createToken(otherParticipantId, oauthServerSigningKey);
@@ -415,7 +404,7 @@ public class TransferProcessApiV4EndToEndTest {
 
             var otherParticipantId = UUID.randomUUID().toString();
 
-            service.createParticipantContext(ParticipantContext.Builder.newInstance().participantContextId(otherParticipantId).build())
+            service.createParticipantContext(participantContext(otherParticipantId))
                     .orElseThrow(f -> new AssertionError("ParticipantContext " + otherParticipantId + " not created."));
 
             var token = context.createToken(otherParticipantId, oauthServerSigningKey);
@@ -481,7 +470,7 @@ public class TransferProcessApiV4EndToEndTest {
 
             var otherParticipantId = UUID.randomUUID().toString();
 
-            service.createParticipantContext(ParticipantContext.Builder.newInstance().participantContextId(otherParticipantId).build())
+            service.createParticipantContext(participantContext(otherParticipantId))
                     .orElseThrow(f -> new AssertionError("ParticipantContext " + otherParticipantId + " not created."));
 
             var token = context.createToken(otherParticipantId, oauthServerSigningKey);
@@ -536,7 +525,7 @@ public class TransferProcessApiV4EndToEndTest {
 
             var otherParticipantId = UUID.randomUUID().toString();
 
-            service.createParticipantContext(ParticipantContext.Builder.newInstance().participantContextId(otherParticipantId).build())
+            service.createParticipantContext(participantContext(otherParticipantId))
                     .orElseThrow(f -> new AssertionError("ParticipantContext " + otherParticipantId + " not created."));
 
             var token = context.createToken(otherParticipantId, oauthServerSigningKey);
@@ -712,7 +701,7 @@ public class TransferProcessApiV4EndToEndTest {
         @Test
         void query_tokenBearerNotEqualResourceOwner(ManagementEndToEndTestContext context, TransferProcessStore store, ParticipantContextService srv) {
             var otherParticipantId = UUID.randomUUID().toString();
-            srv.createParticipantContext(ParticipantContext.Builder.newInstance().participantContextId(otherParticipantId).build())
+            srv.createParticipantContext(participantContext(otherParticipantId))
                     .orElseThrow(f -> new AssertionError("ParticipantContext " + otherParticipantId + " not created."));
 
             var id1 = UUID.randomUUID().toString();


### PR DESCRIPTION
## What this PR changes/adds

 fix compile issue after upstream changes.

Additionally changed the `identity` resolution to be loaded from the `ParticipantContext#identity` instead of config value

## Why it does that

_Briefly state why the change was necessary._

## Further notes

_List other areas of code that have changed but are not necessarily linked to the main feature. This could be method
signature changes, package declarations, bugs that were encountered and were fixed inline, etc._


## Who will sponsor this feature?

_Please @-mention the committer that will sponsor your feature_.


## Linked Issue(s)

Closes # <-- _insert Issue number if one exists_

_Please be sure to take a look at the [contributing guidelines](https://github.com/eclipse-edc/.github/blob/main/CONTRIBUTING.md#submit-a-pull-request) and our [etiquette for pull requests](https://github.com/eclipse-edc/.github/blob/main/contributing/pr_etiquette.md)._
