### PR TITLE
chore: bump snapshot version

### DIFF
--- a/extensions/common/api/api-authentication/build.gradle.kts
+++ b/extensions/common/api/api-authentication/build.gradle.kts
@@ -19,7 +19,6 @@ plugins {
 
 dependencies {
     api(libs.edc.spi.core)
-    implementation(project(":extensions:common:api:lib:api-authentication-lib"))
     implementation(libs.edc.spi.web)
     implementation(libs.edc.lib.token)
     implementation(libs.edc.lib.common.crypto)

--- a/extensions/common/api/api-authentication/src/main/java/org/eclipse/edc/virtualized/api/ApiAuthenticationExtension.java
+++ b/extensions/common/api/api-authentication/src/main/java/org/eclipse/edc/virtualized/api/ApiAuthenticationExtension.java
@@ -14,6 +14,9 @@
 
 package org.eclipse.edc.virtualized.api;
 
+import org.eclipse.edc.api.authentication.JwksResolver;
+import org.eclipse.edc.api.authentication.filter.JwtValidatorFilter;
+import org.eclipse.edc.api.authentication.filter.ServicePrincipalAuthenticationFilter;
 import org.eclipse.edc.keys.spi.KeyParserRegistry;
 import org.eclipse.edc.participantcontext.spi.service.ParticipantContextService;
 import org.eclipse.edc.runtime.metamodel.annotation.Configuration;
@@ -29,9 +32,6 @@ import org.eclipse.edc.token.rules.IssuerEqualsValidationRule;
 import org.eclipse.edc.token.rules.NotBeforeValidationRule;
 import org.eclipse.edc.token.spi.TokenValidationRule;
 import org.eclipse.edc.token.spi.TokenValidationService;
-import org.eclipse.edc.virtualized.api.authentication.JwksResolver;
-import org.eclipse.edc.virtualized.api.authentication.filter.JwtValidatorFilter;
-import org.eclipse.edc.virtualized.api.authentication.filter.ServicePrincipalAuthenticationFilter;
 import org.eclipse.edc.web.spi.WebService;
 import org.eclipse.edc.web.spi.configuration.ApiContext;
 

--- a/extensions/common/api/api-authorization/build.gradle.kts
+++ b/extensions/common/api/api-authorization/build.gradle.kts
@@ -23,6 +23,4 @@ dependencies {
     api(project(":spi:v-auth-spi"))
     implementation(libs.edc.lib.oauth2.authz)
     implementation(libs.jakarta.annotation)
-
-    implementation(project(":extensions:common:api:lib:api-authorization-lib"))
 }

--- a/extensions/common/api/api-authorization/src/main/java/org/eclipse/edc/virtualized/api/ApiAuthorizationExtension.java
+++ b/extensions/common/api/api-authorization/src/main/java/org/eclipse/edc/virtualized/api/ApiAuthorizationExtension.java
@@ -15,9 +15,9 @@
 package org.eclipse.edc.virtualized.api;
 
 import org.eclipse.edc.api.auth.spi.AuthorizationService;
-import org.eclipse.edc.identityhub.api.authorization.filter.RoleBasedAccessFeature;
-import org.eclipse.edc.identityhub.api.authorization.filter.ScopeBasedAccessFeature;
-import org.eclipse.edc.identityhub.api.authorization.service.AuthorizationServiceImpl;
+import org.eclipse.edc.api.authorization.filter.RoleBasedAccessFeature;
+import org.eclipse.edc.api.authorization.filter.ScopeBasedAccessFeature;
+import org.eclipse.edc.api.authorization.service.AuthorizationServiceImpl;
 import org.eclipse.edc.runtime.metamodel.annotation.Extension;
 import org.eclipse.edc.runtime.metamodel.annotation.Inject;
 import org.eclipse.edc.runtime.metamodel.annotation.Provider;

--- a/gradle.properties
+++ b/gradle.properties
@@ -12,5 +12,5 @@
 #
 #
 group=org.eclipse.edc.virtualized
-version=0.15.0-SNAPSHOT
+version=0.16.0-SNAPSHOT
 

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -77,8 +77,6 @@ include(":extensions:control-plane:api:management-api:v-management-api-schema-va
 
 // lib
 include(":extensions:common:api:lib:v-management-api-lib")
-include(":extensions:common:api:lib:api-authorization-lib")
-include(":extensions:common:api:lib:api-authentication-lib")
 
 include(":system-tests:system-test-fixtures")
 include(":system-tests:runtimes:controlplane-base")


### PR DESCRIPTION
## What this PR changes/adds

this bumps the version from 0.15.0-SNAPSHOT to 0.16.0-SNAPSHOT to stay consistent with the rest of EDC

this is **not** an official release

## Why it does that

_Briefly state why the change was necessary._

## Further notes

_List other areas of code that have changed but are not necessarily linked to the main feature. This could be method
signature changes, package declarations, bugs that were encountered and were fixed inline, etc._

## Who will sponsor this feature?

_Please @-mention the committer that will sponsor your feature_.

## Linked Issue(s)

Closes # <-- _insert Issue number if one exists_

_Please be sure to take a look at the [contributing guidelines](https://github.com/eclipse-edc/.github/blob/main/CONTRIBUTING.md#submit-a-pull-request) and our [etiquette for pull requests](https://github.com/eclipse-edc/.github/blob/main/contributing/pr_etiquette.md)._
