### PR TITLE
feat: auto creation of nats resources

### DIFF
--- a/extensions/lib/nats-lib/build.gradle.kts
+++ b/extensions/lib/nats-lib/build.gradle.kts
@@ -19,6 +19,7 @@ plugins {
 
 dependencies {
     api(libs.edc.spi.core)
+    implementation(libs.nats.client)
 
     testFixturesImplementation(libs.nats.client)
     testFixturesImplementation(libs.testcontainers.junit)

--- a/extensions/lib/nats-lib/src/main/java/org/eclipse/edc/virtual/nats/NatsFunctions.java
+++ b/extensions/lib/nats-lib/src/main/java/org/eclipse/edc/virtual/nats/NatsFunctions.java
@@ -1,0 +1,70 @@
+/*
+ *  Copyright (c) 2025 Metaform Systems, Inc.
+ *
+ *  This program and the accompanying materials are made available under the
+ *  terms of the Apache License, Version 2.0 which is available at
+ *  https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Contributors:
+ *       Metaform Systems, Inc. - initial API and implementation
+ *
+ */
+
+package org.eclipse.edc.virtual.nats;
+
+import io.nats.client.JetStreamApiException;
+import io.nats.client.JetStreamManagement;
+import io.nats.client.api.ConsumerConfiguration;
+import io.nats.client.api.StorageType;
+import io.nats.client.api.StreamConfiguration;
+
+public class NatsFunctions {
+
+    public static void createStream(JetStreamManagement jsm, String streamName, StorageType storageType, String... subject) {
+        try {
+            if (!streamExists(jsm, streamName)) {
+                var streamConfig = StreamConfiguration.builder()
+                        .name(streamName)
+                        .subjects(subject)
+                        .storageType(storageType)
+                        .build();
+                jsm.addStream(streamConfig);
+            }
+        } catch (Exception e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    public static void createConsumer(JetStreamManagement jsm, String streamName, String consumerName) {
+        createConsumer(jsm, streamName, consumerName, null);
+    }
+
+    public static void createConsumer(JetStreamManagement jsm, String streamName, String consumerName, String filterSubject) {
+        try {
+            jsm.addOrUpdateConsumer(streamName, ConsumerConfiguration.builder()
+                    .durable(consumerName)
+                    .name(consumerName)
+                    .filterSubject(filterSubject)
+                    .build());
+        } catch (Exception e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    public static boolean streamExists(JetStreamManagement jsm, String streamName) {
+        try {
+            var si = jsm.getStreamInfo(streamName);
+            return si != null;
+        } catch (JetStreamApiException e) {
+            // This means the stream doesn't exist
+            if (e.getErrorCode() == 404) {
+                return false;
+            }
+            throw new RuntimeException(e);
+        } catch (Exception e) {
+            throw new RuntimeException(e);
+        }
+    }
+}

--- a/extensions/negotiation-subscriber-nats/build.gradle.kts
+++ b/extensions/negotiation-subscriber-nats/build.gradle.kts
@@ -21,6 +21,7 @@ dependencies {
     api(libs.edc.spi.contract)
     api(project(":spi:v-core-spi"))
     implementation(libs.nats.client)
+    implementation(project(":extensions:lib:nats-lib"))
     testImplementation(libs.awaitility)
     testImplementation(libs.edc.junit)
     testImplementation(testFixtures(libs.edc.spi.contract))

--- a/extensions/negotiation-subscriber-nats/src/main/java/org/eclipse/edc/virtualized/controlplane/contract/negotiation/subscriber/NatsContractNegotiationSubscriber.java
+++ b/extensions/negotiation-subscriber-nats/src/main/java/org/eclipse/edc/virtualized/controlplane/contract/negotiation/subscriber/NatsContractNegotiationSubscriber.java
@@ -101,6 +101,7 @@ public class NatsContractNegotiationSubscriber {
             connection = Nats.connect(config.url());
             var js = connection.jetStream();
             var pullOptions = PullSubscribeOptions.builder()
+                    .stream(config.stream())
                     .durable(config.name())
                     .build();
 

--- a/extensions/negotiation-subscriber-nats/src/test/java/org/eclipse/edc/virtualized/controlplane/contract/negotiation/subscriber/NatsContractNegotiationSubscriberTest.java
+++ b/extensions/negotiation-subscriber-nats/src/test/java/org/eclipse/edc/virtualized/controlplane/contract/negotiation/subscriber/NatsContractNegotiationSubscriberTest.java
@@ -80,7 +80,7 @@ public class NatsContractNegotiationSubscriberTest {
     void beforeEach() {
         NATS_EXTENSION.createStream(STREAM_NAME, "negotiations.>");
         NATS_EXTENSION.createConsumer(STREAM_NAME, CONSUMER_NAME, "negotiations.>");
-        var config = new NatsSubscriberConfig(NATS_EXTENSION.getNatsUrl(), CONSUMER_NAME, "negotiations.>");
+        var config = new NatsSubscriberConfig(NATS_EXTENSION.getNatsUrl(), CONSUMER_NAME, false, STREAM_NAME, "negotiations.>");
         subscriber = new NatsContractNegotiationSubscriber(config, stateMachineService, ObjectMapper::new, mock());
 
     }

--- a/extensions/postgres-cdc/build.gradle.kts
+++ b/extensions/postgres-cdc/build.gradle.kts
@@ -21,6 +21,7 @@ dependencies {
     api(libs.edc.spi.contract)
     api(libs.edc.spi.transfer)
     api(libs.edc.spi.transaction.datasource)
+    api(libs.edc.core.sql.bootstrapper)
     api(project(":spi:v-core-spi"))
     implementation(libs.postgres)
     testImplementation(libs.edc.junit)

--- a/extensions/postgres-cdc/src/main/resources/enable_cn_replication.sql
+++ b/extensions/postgres-cdc/src/main/resources/enable_cn_replication.sql
@@ -1,0 +1,16 @@
+/*
+ *  Copyright (c) 2025 Metaform Systems, Inc.
+ *
+ *  This program and the accompanying materials are made available under the
+ *  terms of the Apache License, Version 2.0 which is available at
+ *  https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Contributors:
+ *       Metaform Systems, Inc. - initial API and implementation
+ *
+ */
+
+-- enable full replication, otherwise
+ALTER TABLE edc_contract_negotiation REPLICA IDENTITY FULL;

--- a/extensions/postgres-cdc/src/main/resources/enable_tp_replication.sql
+++ b/extensions/postgres-cdc/src/main/resources/enable_tp_replication.sql
@@ -1,0 +1,16 @@
+/*
+ *  Copyright (c) 2025 Metaform Systems, Inc.
+ *
+ *  This program and the accompanying materials are made available under the
+ *  terms of the Apache License, Version 2.0 which is available at
+ *  https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Contributors:
+ *       Metaform Systems, Inc. - initial API and implementation
+ *
+ */
+
+-- enable full replication, otherwise
+ALTER TABLE edc_transfer_process REPLICA IDENTITY FULL;

--- a/extensions/transfer-process-subscriber-nats/build.gradle.kts
+++ b/extensions/transfer-process-subscriber-nats/build.gradle.kts
@@ -21,6 +21,7 @@ dependencies {
     api(libs.edc.spi.transfer)
     api(project(":spi:v-core-spi"))
     implementation(libs.nats.client)
+    implementation(project(":extensions:lib:nats-lib"))
     testImplementation(libs.awaitility)
     testImplementation(libs.edc.junit)
     testImplementation(testFixtures(libs.edc.spi.contract))

--- a/extensions/transfer-process-subscriber-nats/src/main/java/org/eclipse/edc/virtualized/controlplane/transfer/subscriber/nats/NatsTransferProcessSubscriber.java
+++ b/extensions/transfer-process-subscriber-nats/src/main/java/org/eclipse/edc/virtualized/controlplane/transfer/subscriber/nats/NatsTransferProcessSubscriber.java
@@ -122,6 +122,7 @@ public class NatsTransferProcessSubscriber {
             connection = Nats.connect(config.url());
             var js = connection.jetStream();
             var pullOptions = PullSubscribeOptions.builder()
+                    .stream(config.stream())
                     .durable(config.name())
                     .build();
 

--- a/extensions/transfer-process-subscriber-nats/src/main/java/org/eclipse/edc/virtualized/controlplane/transfer/subscriber/nats/NatsTransferProcessSubscriberExtension.java
+++ b/extensions/transfer-process-subscriber-nats/src/main/java/org/eclipse/edc/virtualized/controlplane/transfer/subscriber/nats/NatsTransferProcessSubscriberExtension.java
@@ -14,6 +14,8 @@
 
 package org.eclipse.edc.virtualized.controlplane.transfer.subscriber.nats;
 
+import io.nats.client.Nats;
+import io.nats.client.api.StorageType;
 import org.eclipse.edc.runtime.metamodel.annotation.Configuration;
 import org.eclipse.edc.runtime.metamodel.annotation.Inject;
 import org.eclipse.edc.runtime.metamodel.annotation.Setting;
@@ -25,9 +27,10 @@ import org.eclipse.edc.spi.types.TypeManager;
 import org.eclipse.edc.virtualized.controlplane.transfer.spi.TransferProcessStateMachineService;
 
 import static org.eclipse.edc.spi.constants.CoreConstants.JSON_LD;
+import static org.eclipse.edc.virtual.nats.NatsFunctions.createConsumer;
+import static org.eclipse.edc.virtual.nats.NatsFunctions.createStream;
 
 public class NatsTransferProcessSubscriberExtension implements ServiceExtension {
-
 
     @Configuration
     private NatsSubscriberConfig natsSubscriberConfig;
@@ -49,6 +52,20 @@ public class NatsTransferProcessSubscriberExtension implements ServiceExtension 
     }
 
     @Override
+    public void prepare() {
+        if (natsSubscriberConfig.autoCreate()) {
+            try (var conn = Nats.connect(natsSubscriberConfig.url())) {
+                conn.jetStream();
+                var jsm = conn.jetStreamManagement();
+                createStream(jsm, natsSubscriberConfig.stream(), StorageType.Memory, natsSubscriberConfig.subject());
+                createConsumer(jsm, natsSubscriberConfig.stream(), natsSubscriberConfig.name(), natsSubscriberConfig.subject());
+            } catch (Exception e) {
+                throw new RuntimeException(e);
+            }
+        }
+    }
+
+    @Override
     public void start() {
         if (subscriber != null) {
             subscriber.start();
@@ -64,10 +81,15 @@ public class NatsTransferProcessSubscriberExtension implements ServiceExtension 
 
     @Settings
     public record NatsSubscriberConfig(
+
             @Setting(key = "edc.nats.tp.subscriber.url", description = "The URL of the NATS server to connect to for transfer process events.", defaultValue = "nats://localhost:4222")
             String url,
             @Setting(key = "edc.nats.tp.subscriber.name", description = "The name of the consumer for transfer process events", defaultValue = "tp-subscriber")
             String name,
+            @Setting(key = "edc.nats.tp.subscriber.autocreate", description = "When true, it will automatically create the stream and the consumer if not present", defaultValue = "false")
+            Boolean autoCreate,
+            @Setting(key = "edc.nats.tp.subscriber.stream", description = "The stream name where to attach the consumer", defaultValue = "tp-stream")
+            String stream,
             @Setting(key = "edc.nats.tp.subscriber.subject", description = "The subject of the consumer for contract negotiation events", defaultValue = "transfers.>")
             String subject
     ) {

--- a/extensions/transfer-process-subscriber-nats/src/test/java/org/eclipse/edc/virtualized/controlplane/transfer/subscriber/nats/NatsTransferProcessSubscriberTest.java
+++ b/extensions/transfer-process-subscriber-nats/src/test/java/org/eclipse/edc/virtualized/controlplane/transfer/subscriber/nats/NatsTransferProcessSubscriberTest.java
@@ -94,7 +94,7 @@ public class NatsTransferProcessSubscriberTest {
     void beforeEach() {
         NATS_EXTENSION.createStream(STREAM_NAME, "transfers.>");
         NATS_EXTENSION.createConsumer(STREAM_NAME, CONSUMER_NAME, "transfers.>");
-        var config = new NatsSubscriberConfig(NATS_EXTENSION.getNatsUrl(), CONSUMER_NAME, "transfers.>");
+        var config = new NatsSubscriberConfig(NATS_EXTENSION.getNatsUrl(), CONSUMER_NAME, false, STREAM_NAME, "transfers.>");
         subscriber = new NatsTransferProcessSubscriber(config, stateMachineService, ObjectMapper::new, mock());
 
     }

--- a/system-tests/dsp-tck-tests/src/test/java/org/eclipse/edc/virtualized/tck/dsp/PostgresVirtualCompatibilityDockerTest.java
+++ b/system-tests/dsp-tck-tests/src/test/java/org/eclipse/edc/virtualized/tck/dsp/PostgresVirtualCompatibilityDockerTest.java
@@ -65,15 +65,13 @@ public class PostgresVirtualCompatibilityDockerTest {
             .modules(":system-tests:runtimes:tck:tck-controlplane-postgres")
             .configurationProvider(PostgresVirtualCompatibilityDockerTest::runtimeConfiguration)
             .configurationProvider(() -> POSTGRESQL_EXTENSION.configFor(CONNECTOR.toLowerCase()))
+            .configurationProvider(NATS_EXTENSION::configFor)
             .build();
 
     @Order(1)
     @RegisterExtension
     static final BeforeAllCallback SETUP = context -> {
         POSTGRESQL_EXTENSION.createDatabase(CONNECTOR.toLowerCase());
-        NATS_EXTENSION.createStream("state_machine", "negotiations.>", "transfers.>");
-        NATS_EXTENSION.createConsumer("state_machine", "cn-subscriber", "negotiations.>");
-        NATS_EXTENSION.createConsumer("state_machine", "tp-subscriber", "transfers.>");
     };
     private static final GenericContainer<?> TCK_CONTAINER = new TckContainer<>("eclipsedataspacetck/dsp-tck-runtime:1.0.0-RC4");
 
@@ -102,10 +100,6 @@ public class PostgresVirtualCompatibilityDockerTest {
                 put("edc.postgres.cdc.user", POSTGRESQL_EXTENSION.getUsername());
                 put("edc.postgres.cdc.password", POSTGRESQL_EXTENSION.getPassword());
                 put("edc.postgres.cdc.slot", "edc_cdc_slot_" + CONNECTOR.toLowerCase());
-                put("edc.nats.cn.subscriber.url", NATS_EXTENSION.getNatsUrl());
-                put("edc.nats.cn.publisher.url", NATS_EXTENSION.getNatsUrl());
-                put("edc.nats.tp.subscriber.url", NATS_EXTENSION.getNatsUrl());
-                put("edc.nats.tp.publisher.url", NATS_EXTENSION.getNatsUrl());
                 put("edc.iam.oauth2.jwks.url", "https://example.com/jwks");
                 put("edc.iam.oauth2.issuer", "test-issuer");
             }

--- a/system-tests/dsp-tck-tests/src/test/java/org/eclipse/edc/virtualized/tck/dsp/PostgresVirtualCompatibilityDockerTest.java
+++ b/system-tests/dsp-tck-tests/src/test/java/org/eclipse/edc/virtualized/tck/dsp/PostgresVirtualCompatibilityDockerTest.java
@@ -119,8 +119,6 @@ public class PostgresVirtualCompatibilityDockerTest {
     @Timeout(300)
     @Test
     void assertDspCompatibility() {
-        POSTGRESQL_EXTENSION.execute(CONNECTOR.toLowerCase(), "ALTER TABLE edc_contract_negotiation REPLICA IDENTITY FULL;");
-        POSTGRESQL_EXTENSION.execute(CONNECTOR.toLowerCase(), "ALTER TABLE edc_transfer_process REPLICA IDENTITY FULL;");
 
         // pipe the docker container's log to this console at the INFO level
         var monitor = new ConsoleMonitor(">>> TCK Runtime (Docker)", ConsoleMonitor.Level.INFO, true);

--- a/system-tests/management-api/management-api-tests/src/test/java/org/eclipse/edc/test/e2e/managementapi/v4/AssetApiV4EndToEndTest.java
+++ b/system-tests/management-api/management-api-tests/src/test/java/org/eclipse/edc/test/e2e/managementapi/v4/AssetApiV4EndToEndTest.java
@@ -932,14 +932,7 @@ public class AssetApiV4EndToEndTest {
             NATS_EXTENSION.createConsumer("state_machine", "cn-subscriber", "negotiations.>");
             NATS_EXTENSION.createConsumer("state_machine", "tp-subscriber", "transfers.>");
         };
-        @Order(3)
-        @RegisterExtension
-        static final BeforeAllCallback SEED = context -> {
-            POSTGRES_EXTENSION.execute(Runtimes.ControlPlane.NAME.toLowerCase(),
-                    "ALTER TABLE edc_contract_negotiation REPLICA IDENTITY FULL;");
-            POSTGRES_EXTENSION.execute(Runtimes.ControlPlane.NAME.toLowerCase(),
-                    "ALTER TABLE edc_transfer_process REPLICA IDENTITY FULL;");
-        };
+  
         @Order(2)
         @RegisterExtension
         static RuntimeExtension runtime = ComponentRuntimeExtension.Builder.newInstance()

--- a/system-tests/management-api/management-api-tests/src/test/java/org/eclipse/edc/test/e2e/managementapi/v4/AssetApiV4EndToEndTest.java
+++ b/system-tests/management-api/management-api-tests/src/test/java/org/eclipse/edc/test/e2e/managementapi/v4/AssetApiV4EndToEndTest.java
@@ -928,11 +928,8 @@ public class AssetApiV4EndToEndTest {
         @RegisterExtension
         static final BeforeAllCallback SETUP = context -> {
             POSTGRES_EXTENSION.createDatabase(Runtimes.ControlPlane.NAME.toLowerCase());
-            NATS_EXTENSION.createStream("state_machine", "negotiations.>", "transfers.>");
-            NATS_EXTENSION.createConsumer("state_machine", "cn-subscriber", "negotiations.>");
-            NATS_EXTENSION.createConsumer("state_machine", "tp-subscriber", "transfers.>");
         };
-  
+
         @Order(2)
         @RegisterExtension
         static RuntimeExtension runtime = ComponentRuntimeExtension.Builder.newInstance()
@@ -943,6 +940,7 @@ public class AssetApiV4EndToEndTest {
                 .configurationProvider(Runtimes.ControlPlane::config)
                 .configurationProvider(() -> POSTGRES_EXTENSION
                         .configFor(Runtimes.ControlPlane.NAME.toLowerCase()))
+                .configurationProvider(NATS_EXTENSION::configFor)
                 .configurationProvider(Postgres::runtimeConfiguration)
                 .configurationProvider(() -> ConfigFactory.fromMap(Map.of("edc.iam.oauth2.jwks.url",
                         "http://localhost:" + mockJwksServer.getPort() + "/.well-known/jwks")))
@@ -959,10 +957,6 @@ public class AssetApiV4EndToEndTest {
                     put("edc.postgres.cdc.password", POSTGRES_EXTENSION.getPassword());
                     put("edc.postgres.cdc.slot",
                             "edc_cdc_slot_" + Runtimes.ControlPlane.NAME.toLowerCase());
-                    put("edc.nats.cn.subscriber.url", NATS_EXTENSION.getNatsUrl());
-                    put("edc.nats.cn.publisher.url", NATS_EXTENSION.getNatsUrl());
-                    put("edc.nats.tp.subscriber.url", NATS_EXTENSION.getNatsUrl());
-                    put("edc.nats.tp.publisher.url", NATS_EXTENSION.getNatsUrl());
                 }
             });
         }

--- a/system-tests/management-api/management-api-tests/src/test/java/org/eclipse/edc/test/e2e/managementapi/v4/CatalogApiV4EndToEndTest.java
+++ b/system-tests/management-api/management-api-tests/src/test/java/org/eclipse/edc/test/e2e/managementapi/v4/CatalogApiV4EndToEndTest.java
@@ -647,11 +647,8 @@ public class CatalogApiV4EndToEndTest {
         @RegisterExtension
         static final BeforeAllCallback SETUP = context -> {
             POSTGRES_EXTENSION.createDatabase(Runtimes.ControlPlane.NAME.toLowerCase());
-            NATS_EXTENSION.createStream("state_machine", "negotiations.>", "transfers.>");
-            NATS_EXTENSION.createConsumer("state_machine", "cn-subscriber", "negotiations.>");
-            NATS_EXTENSION.createConsumer("state_machine", "tp-subscriber", "transfers.>");
         };
-        
+
         @Order(2)
         @RegisterExtension
         static RuntimeExtension runtime = ComponentRuntimeExtension.Builder.newInstance()
@@ -662,6 +659,7 @@ public class CatalogApiV4EndToEndTest {
                 .configurationProvider(Runtimes.ControlPlane::config)
                 .configurationProvider(() -> POSTGRES_EXTENSION
                         .configFor(Runtimes.ControlPlane.NAME.toLowerCase()))
+                .configurationProvider(NATS_EXTENSION::configFor)
                 .configurationProvider(
                         CatalogApiV4EndToEndTest.Postgres::runtimeConfiguration)
                 .configurationProvider(() -> ConfigFactory.fromMap(Map.of("edc.iam.oauth2.jwks.url",
@@ -679,10 +677,6 @@ public class CatalogApiV4EndToEndTest {
                     put("edc.postgres.cdc.password", POSTGRES_EXTENSION.getPassword());
                     put("edc.postgres.cdc.slot",
                             "edc_cdc_slot_" + Runtimes.ControlPlane.NAME.toLowerCase());
-                    put("edc.nats.cn.subscriber.url", NATS_EXTENSION.getNatsUrl());
-                    put("edc.nats.cn.publisher.url", NATS_EXTENSION.getNatsUrl());
-                    put("edc.nats.tp.subscriber.url", NATS_EXTENSION.getNatsUrl());
-                    put("edc.nats.tp.publisher.url", NATS_EXTENSION.getNatsUrl());
                 }
             });
         }

--- a/system-tests/management-api/management-api-tests/src/test/java/org/eclipse/edc/test/e2e/managementapi/v4/CatalogApiV4EndToEndTest.java
+++ b/system-tests/management-api/management-api-tests/src/test/java/org/eclipse/edc/test/e2e/managementapi/v4/CatalogApiV4EndToEndTest.java
@@ -651,14 +651,7 @@ public class CatalogApiV4EndToEndTest {
             NATS_EXTENSION.createConsumer("state_machine", "cn-subscriber", "negotiations.>");
             NATS_EXTENSION.createConsumer("state_machine", "tp-subscriber", "transfers.>");
         };
-        @Order(3)
-        @RegisterExtension
-        static final BeforeAllCallback SEED = context -> {
-            POSTGRES_EXTENSION.execute(Runtimes.ControlPlane.NAME.toLowerCase(),
-                    "ALTER TABLE edc_contract_negotiation REPLICA IDENTITY FULL;");
-            POSTGRES_EXTENSION.execute(Runtimes.ControlPlane.NAME.toLowerCase(),
-                    "ALTER TABLE edc_transfer_process REPLICA IDENTITY FULL;");
-        };
+        
         @Order(2)
         @RegisterExtension
         static RuntimeExtension runtime = ComponentRuntimeExtension.Builder.newInstance()

--- a/system-tests/management-api/management-api-tests/src/test/java/org/eclipse/edc/test/e2e/managementapi/v4/CelExpressionApiV4EndToEndTest.java
+++ b/system-tests/management-api/management-api-tests/src/test/java/org/eclipse/edc/test/e2e/managementapi/v4/CelExpressionApiV4EndToEndTest.java
@@ -415,9 +415,6 @@ public class CelExpressionApiV4EndToEndTest {
         @RegisterExtension
         static final BeforeAllCallback SETUP = context -> {
             POSTGRES_EXTENSION.createDatabase(Runtimes.ControlPlane.NAME.toLowerCase());
-            NATS_EXTENSION.createStream("state_machine", "negotiations.>", "transfers.>");
-            NATS_EXTENSION.createConsumer("state_machine", "cn-subscriber", "negotiations.>");
-            NATS_EXTENSION.createConsumer("state_machine", "tp-subscriber", "transfers.>");
         };
 
         @Order(2)
@@ -429,6 +426,7 @@ public class CelExpressionApiV4EndToEndTest {
                 .endpoints(Runtimes.ControlPlane.ENDPOINTS.build())
                 .configurationProvider(Runtimes.ControlPlane::config)
                 .configurationProvider(() -> POSTGRES_EXTENSION.configFor(Runtimes.ControlPlane.NAME.toLowerCase()))
+                .configurationProvider(NATS_EXTENSION::configFor)
                 .configurationProvider(Postgres::runtimeConfiguration)
                 .configurationProvider(() -> ConfigFactory.fromMap(Map.of("edc.iam.oauth2.jwks.url", "http://localhost:" + mockJwksServer.getPort() + "/.well-known/jwks")))
                 .paramProvider(ManagementEndToEndTestContext.class, ManagementEndToEndTestContext::forContext)
@@ -441,10 +439,6 @@ public class CelExpressionApiV4EndToEndTest {
                     put("edc.postgres.cdc.user", POSTGRES_EXTENSION.getUsername());
                     put("edc.postgres.cdc.password", POSTGRES_EXTENSION.getPassword());
                     put("edc.postgres.cdc.slot", "edc_cdc_slot_" + Runtimes.ControlPlane.NAME.toLowerCase());
-                    put("edc.nats.cn.subscriber.url", NATS_EXTENSION.getNatsUrl());
-                    put("edc.nats.cn.publisher.url", NATS_EXTENSION.getNatsUrl());
-                    put("edc.nats.tp.subscriber.url", NATS_EXTENSION.getNatsUrl());
-                    put("edc.nats.tp.publisher.url", NATS_EXTENSION.getNatsUrl());
                 }
             });
         }

--- a/system-tests/management-api/management-api-tests/src/test/java/org/eclipse/edc/test/e2e/managementapi/v4/CelExpressionApiV4EndToEndTest.java
+++ b/system-tests/management-api/management-api-tests/src/test/java/org/eclipse/edc/test/e2e/managementapi/v4/CelExpressionApiV4EndToEndTest.java
@@ -420,13 +420,6 @@ public class CelExpressionApiV4EndToEndTest {
             NATS_EXTENSION.createConsumer("state_machine", "tp-subscriber", "transfers.>");
         };
 
-        @Order(3)
-        @RegisterExtension
-        static final BeforeAllCallback SEED = context -> {
-            POSTGRES_EXTENSION.execute(Runtimes.ControlPlane.NAME.toLowerCase(), "ALTER TABLE edc_contract_negotiation REPLICA IDENTITY FULL;");
-            POSTGRES_EXTENSION.execute(Runtimes.ControlPlane.NAME.toLowerCase(), "ALTER TABLE edc_transfer_process REPLICA IDENTITY FULL;");
-        };
-
         @Order(2)
         @RegisterExtension
         static RuntimeExtension runtime = ComponentRuntimeExtension.Builder.newInstance()

--- a/system-tests/management-api/management-api-tests/src/test/java/org/eclipse/edc/test/e2e/managementapi/v4/ContractAgreementApiV4EndToEndTest.java
+++ b/system-tests/management-api/management-api-tests/src/test/java/org/eclipse/edc/test/e2e/managementapi/v4/ContractAgreementApiV4EndToEndTest.java
@@ -384,9 +384,6 @@ public class ContractAgreementApiV4EndToEndTest {
         @RegisterExtension
         static final BeforeAllCallback SETUP = context -> {
             POSTGRES_EXTENSION.createDatabase(Runtimes.ControlPlane.NAME.toLowerCase());
-            NATS_EXTENSION.createStream("state_machine", "negotiations.>", "transfers.>");
-            NATS_EXTENSION.createConsumer("state_machine", "cn-subscriber", "negotiations.>");
-            NATS_EXTENSION.createConsumer("state_machine", "tp-subscriber", "transfers.>");
         };
 
         @Order(2)
@@ -398,6 +395,7 @@ public class ContractAgreementApiV4EndToEndTest {
                 .endpoints(Runtimes.ControlPlane.ENDPOINTS.build())
                 .configurationProvider(Runtimes.ControlPlane::config)
                 .configurationProvider(() -> POSTGRES_EXTENSION.configFor(Runtimes.ControlPlane.NAME.toLowerCase()))
+                .configurationProvider(NATS_EXTENSION::configFor)
                 .configurationProvider(Postgres::runtimeConfiguration)
                 .configurationProvider(() -> ConfigFactory.fromMap(Map.of("edc.iam.oauth2.jwks.url", "http://localhost:" + mockJwksServer.getPort() + "/.well-known/jwks")))
                 .paramProvider(ManagementEndToEndTestContext.class, ManagementEndToEndTestContext::forContext)
@@ -410,10 +408,6 @@ public class ContractAgreementApiV4EndToEndTest {
                     put("edc.postgres.cdc.user", POSTGRES_EXTENSION.getUsername());
                     put("edc.postgres.cdc.password", POSTGRES_EXTENSION.getPassword());
                     put("edc.postgres.cdc.slot", "edc_cdc_slot_" + Runtimes.ControlPlane.NAME.toLowerCase());
-                    put("edc.nats.cn.subscriber.url", NATS_EXTENSION.getNatsUrl());
-                    put("edc.nats.cn.publisher.url", NATS_EXTENSION.getNatsUrl());
-                    put("edc.nats.tp.subscriber.url", NATS_EXTENSION.getNatsUrl());
-                    put("edc.nats.tp.publisher.url", NATS_EXTENSION.getNatsUrl());
                 }
             });
         }

--- a/system-tests/management-api/management-api-tests/src/test/java/org/eclipse/edc/test/e2e/managementapi/v4/ContractAgreementApiV4EndToEndTest.java
+++ b/system-tests/management-api/management-api-tests/src/test/java/org/eclipse/edc/test/e2e/managementapi/v4/ContractAgreementApiV4EndToEndTest.java
@@ -389,13 +389,6 @@ public class ContractAgreementApiV4EndToEndTest {
             NATS_EXTENSION.createConsumer("state_machine", "tp-subscriber", "transfers.>");
         };
 
-        @Order(3)
-        @RegisterExtension
-        static final BeforeAllCallback SEED = context -> {
-            POSTGRES_EXTENSION.execute(Runtimes.ControlPlane.NAME.toLowerCase(), "ALTER TABLE edc_contract_negotiation REPLICA IDENTITY FULL;");
-            POSTGRES_EXTENSION.execute(Runtimes.ControlPlane.NAME.toLowerCase(), "ALTER TABLE edc_transfer_process REPLICA IDENTITY FULL;");
-        };
-
         @Order(2)
         @RegisterExtension
         static RuntimeExtension runtime = ComponentRuntimeExtension.Builder.newInstance()

--- a/system-tests/management-api/management-api-tests/src/test/java/org/eclipse/edc/test/e2e/managementapi/v4/ContractDefinitionApiV4EndToEndTest.java
+++ b/system-tests/management-api/management-api-tests/src/test/java/org/eclipse/edc/test/e2e/managementapi/v4/ContractDefinitionApiV4EndToEndTest.java
@@ -752,9 +752,6 @@ public class ContractDefinitionApiV4EndToEndTest {
         @RegisterExtension
         static final BeforeAllCallback SETUP = context -> {
             POSTGRES_EXTENSION.createDatabase(Runtimes.ControlPlane.NAME.toLowerCase());
-            NATS_EXTENSION.createStream("state_machine", "negotiations.>", "transfers.>");
-            NATS_EXTENSION.createConsumer("state_machine", "cn-subscriber", "negotiations.>");
-            NATS_EXTENSION.createConsumer("state_machine", "tp-subscriber", "transfers.>");
         };
 
         @Order(2)
@@ -767,6 +764,7 @@ public class ContractDefinitionApiV4EndToEndTest {
                 .configurationProvider(Runtimes.ControlPlane::config)
                 .configurationProvider(() -> POSTGRES_EXTENSION
                         .configFor(Runtimes.ControlPlane.NAME.toLowerCase()))
+                .configurationProvider(NATS_EXTENSION::configFor)
                 .configurationProvider(
                         ContractDefinitionApiV4EndToEndTest.Postgres::runtimeConfiguration)
                 .configurationProvider(() -> ConfigFactory.fromMap(Map.of("edc.iam.oauth2.jwks.url",
@@ -784,10 +782,6 @@ public class ContractDefinitionApiV4EndToEndTest {
                     put("edc.postgres.cdc.password", POSTGRES_EXTENSION.getPassword());
                     put("edc.postgres.cdc.slot",
                             "edc_cdc_slot_" + Runtimes.ControlPlane.NAME.toLowerCase());
-                    put("edc.nats.cn.subscriber.url", NATS_EXTENSION.getNatsUrl());
-                    put("edc.nats.cn.publisher.url", NATS_EXTENSION.getNatsUrl());
-                    put("edc.nats.tp.subscriber.url", NATS_EXTENSION.getNatsUrl());
-                    put("edc.nats.tp.publisher.url", NATS_EXTENSION.getNatsUrl());
                 }
             });
         }

--- a/system-tests/management-api/management-api-tests/src/test/java/org/eclipse/edc/test/e2e/managementapi/v4/ContractDefinitionApiV4EndToEndTest.java
+++ b/system-tests/management-api/management-api-tests/src/test/java/org/eclipse/edc/test/e2e/managementapi/v4/ContractDefinitionApiV4EndToEndTest.java
@@ -756,14 +756,7 @@ public class ContractDefinitionApiV4EndToEndTest {
             NATS_EXTENSION.createConsumer("state_machine", "cn-subscriber", "negotiations.>");
             NATS_EXTENSION.createConsumer("state_machine", "tp-subscriber", "transfers.>");
         };
-        @Order(3)
-        @RegisterExtension
-        static final BeforeAllCallback SEED = context -> {
-            POSTGRES_EXTENSION.execute(Runtimes.ControlPlane.NAME.toLowerCase(),
-                    "ALTER TABLE edc_contract_negotiation REPLICA IDENTITY FULL;");
-            POSTGRES_EXTENSION.execute(Runtimes.ControlPlane.NAME.toLowerCase(),
-                    "ALTER TABLE edc_transfer_process REPLICA IDENTITY FULL;");
-        };
+
         @Order(2)
         @RegisterExtension
         static RuntimeExtension runtime = ComponentRuntimeExtension.Builder.newInstance()

--- a/system-tests/management-api/management-api-tests/src/test/java/org/eclipse/edc/test/e2e/managementapi/v4/ContractNegotiationApiV4EndToEndTest.java
+++ b/system-tests/management-api/management-api-tests/src/test/java/org/eclipse/edc/test/e2e/managementapi/v4/ContractNegotiationApiV4EndToEndTest.java
@@ -789,13 +789,6 @@ public class ContractNegotiationApiV4EndToEndTest {
             NATS_EXTENSION.createConsumer("state_machine", "tp-subscriber", "transfers.>");
         };
 
-        @Order(3)
-        @RegisterExtension
-        static final BeforeAllCallback SEED = context -> {
-            POSTGRES_EXTENSION.execute(Runtimes.ControlPlane.NAME.toLowerCase(), "ALTER TABLE edc_contract_negotiation REPLICA IDENTITY FULL;");
-            POSTGRES_EXTENSION.execute(Runtimes.ControlPlane.NAME.toLowerCase(), "ALTER TABLE edc_transfer_process REPLICA IDENTITY FULL;");
-        };
-
         @Order(2)
         @RegisterExtension
         static RuntimeExtension runtime = ComponentRuntimeExtension.Builder.newInstance()

--- a/system-tests/management-api/management-api-tests/src/test/java/org/eclipse/edc/test/e2e/managementapi/v4/ContractNegotiationApiV4EndToEndTest.java
+++ b/system-tests/management-api/management-api-tests/src/test/java/org/eclipse/edc/test/e2e/managementapi/v4/ContractNegotiationApiV4EndToEndTest.java
@@ -784,9 +784,6 @@ public class ContractNegotiationApiV4EndToEndTest {
         @RegisterExtension
         static final BeforeAllCallback SETUP = context -> {
             POSTGRES_EXTENSION.createDatabase(Runtimes.ControlPlane.NAME.toLowerCase());
-            NATS_EXTENSION.createStream("state_machine", "negotiations.>", "transfers.>");
-            NATS_EXTENSION.createConsumer("state_machine", "cn-subscriber", "negotiations.>");
-            NATS_EXTENSION.createConsumer("state_machine", "tp-subscriber", "transfers.>");
         };
 
         @Order(2)
@@ -798,6 +795,7 @@ public class ContractNegotiationApiV4EndToEndTest {
                 .endpoints(Runtimes.ControlPlane.ENDPOINTS.build())
                 .configurationProvider(Runtimes.ControlPlane::config)
                 .configurationProvider(() -> POSTGRES_EXTENSION.configFor(Runtimes.ControlPlane.NAME.toLowerCase()))
+                .configurationProvider(NATS_EXTENSION::configFor)
                 .configurationProvider(Postgres::runtimeConfiguration)
                 .configurationProvider(() -> ConfigFactory.fromMap(Map.of("edc.iam.oauth2.jwks.url", "http://localhost:" + mockJwksServer.getPort() + "/.well-known/jwks")))
                 .paramProvider(ManagementEndToEndTestContext.class, ManagementEndToEndTestContext::forContext)
@@ -810,10 +808,6 @@ public class ContractNegotiationApiV4EndToEndTest {
                     put("edc.postgres.cdc.user", POSTGRES_EXTENSION.getUsername());
                     put("edc.postgres.cdc.password", POSTGRES_EXTENSION.getPassword());
                     put("edc.postgres.cdc.slot", "edc_cdc_slot_" + Runtimes.ControlPlane.NAME.toLowerCase());
-                    put("edc.nats.cn.subscriber.url", NATS_EXTENSION.getNatsUrl());
-                    put("edc.nats.cn.publisher.url", NATS_EXTENSION.getNatsUrl());
-                    put("edc.nats.tp.subscriber.url", NATS_EXTENSION.getNatsUrl());
-                    put("edc.nats.tp.publisher.url", NATS_EXTENSION.getNatsUrl());
                 }
             });
         }

--- a/system-tests/management-api/management-api-tests/src/test/java/org/eclipse/edc/test/e2e/managementapi/v4/ParticipantContextApiEndToEndTest.java
+++ b/system-tests/management-api/management-api-tests/src/test/java/org/eclipse/edc/test/e2e/managementapi/v4/ParticipantContextApiEndToEndTest.java
@@ -360,9 +360,6 @@ public class ParticipantContextApiEndToEndTest {
         @RegisterExtension
         static final BeforeAllCallback SETUP = context -> {
             POSTGRES_EXTENSION.createDatabase(Runtimes.ControlPlane.NAME.toLowerCase());
-            NATS_EXTENSION.createStream("state_machine", "negotiations.>", "transfers.>");
-            NATS_EXTENSION.createConsumer("state_machine", "cn-subscriber", "negotiations.>");
-            NATS_EXTENSION.createConsumer("state_machine", "tp-subscriber", "transfers.>");
         };
 
         @Order(2)
@@ -374,6 +371,7 @@ public class ParticipantContextApiEndToEndTest {
                 .endpoints(Runtimes.ControlPlane.ENDPOINTS.build())
                 .configurationProvider(Runtimes.ControlPlane::config)
                 .configurationProvider(() -> POSTGRES_EXTENSION.configFor(Runtimes.ControlPlane.NAME.toLowerCase()))
+                .configurationProvider(NATS_EXTENSION::configFor)
                 .configurationProvider(Postgres::runtimeConfiguration)
                 .configurationProvider(() -> ConfigFactory.fromMap(Map.of("edc.iam.oauth2.jwks.url", "http://localhost:" + mockJwksServer.getPort() + "/.well-known/jwks")))
                 .paramProvider(ManagementEndToEndTestContext.class, ManagementEndToEndTestContext::forContext)
@@ -386,10 +384,6 @@ public class ParticipantContextApiEndToEndTest {
                     put("edc.postgres.cdc.user", POSTGRES_EXTENSION.getUsername());
                     put("edc.postgres.cdc.password", POSTGRES_EXTENSION.getPassword());
                     put("edc.postgres.cdc.slot", "edc_cdc_slot_" + Runtimes.ControlPlane.NAME.toLowerCase());
-                    put("edc.nats.cn.subscriber.url", NATS_EXTENSION.getNatsUrl());
-                    put("edc.nats.cn.publisher.url", NATS_EXTENSION.getNatsUrl());
-                    put("edc.nats.tp.subscriber.url", NATS_EXTENSION.getNatsUrl());
-                    put("edc.nats.tp.publisher.url", NATS_EXTENSION.getNatsUrl());
                 }
             });
         }

--- a/system-tests/management-api/management-api-tests/src/test/java/org/eclipse/edc/test/e2e/managementapi/v4/ParticipantContextApiEndToEndTest.java
+++ b/system-tests/management-api/management-api-tests/src/test/java/org/eclipse/edc/test/e2e/managementapi/v4/ParticipantContextApiEndToEndTest.java
@@ -365,13 +365,6 @@ public class ParticipantContextApiEndToEndTest {
             NATS_EXTENSION.createConsumer("state_machine", "tp-subscriber", "transfers.>");
         };
 
-        @Order(3)
-        @RegisterExtension
-        static final BeforeAllCallback SEED = context -> {
-            POSTGRES_EXTENSION.execute(Runtimes.ControlPlane.NAME.toLowerCase(), "ALTER TABLE edc_contract_negotiation REPLICA IDENTITY FULL;");
-            POSTGRES_EXTENSION.execute(Runtimes.ControlPlane.NAME.toLowerCase(), "ALTER TABLE edc_transfer_process REPLICA IDENTITY FULL;");
-        };
-
         @Order(2)
         @RegisterExtension
         static RuntimeExtension runtime = ComponentRuntimeExtension.Builder.newInstance()

--- a/system-tests/management-api/management-api-tests/src/test/java/org/eclipse/edc/test/e2e/managementapi/v4/ParticipantContextConfigApiEndToEndTest.java
+++ b/system-tests/management-api/management-api-tests/src/test/java/org/eclipse/edc/test/e2e/managementapi/v4/ParticipantContextConfigApiEndToEndTest.java
@@ -241,14 +241,7 @@ public class ParticipantContextConfigApiEndToEndTest {
             NATS_EXTENSION.createConsumer("state_machine", "cn-subscriber", "negotiations.>");
             NATS_EXTENSION.createConsumer("state_machine", "tp-subscriber", "transfers.>");
         };
-
-        @Order(3)
-        @RegisterExtension
-        static final BeforeAllCallback SEED = context -> {
-            POSTGRES_EXTENSION.execute(Runtimes.ControlPlane.NAME.toLowerCase(), "ALTER TABLE edc_contract_negotiation REPLICA IDENTITY FULL;");
-            POSTGRES_EXTENSION.execute(Runtimes.ControlPlane.NAME.toLowerCase(), "ALTER TABLE edc_transfer_process REPLICA IDENTITY FULL;");
-        };
-
+        
         @Order(2)
         @RegisterExtension
         static RuntimeExtension runtime = ComponentRuntimeExtension.Builder.newInstance()

--- a/system-tests/management-api/management-api-tests/src/test/java/org/eclipse/edc/test/e2e/managementapi/v4/ParticipantContextConfigApiEndToEndTest.java
+++ b/system-tests/management-api/management-api-tests/src/test/java/org/eclipse/edc/test/e2e/managementapi/v4/ParticipantContextConfigApiEndToEndTest.java
@@ -237,11 +237,8 @@ public class ParticipantContextConfigApiEndToEndTest {
         @RegisterExtension
         static final BeforeAllCallback SETUP = context -> {
             POSTGRES_EXTENSION.createDatabase(Runtimes.ControlPlane.NAME.toLowerCase());
-            NATS_EXTENSION.createStream("state_machine", "negotiations.>", "transfers.>");
-            NATS_EXTENSION.createConsumer("state_machine", "cn-subscriber", "negotiations.>");
-            NATS_EXTENSION.createConsumer("state_machine", "tp-subscriber", "transfers.>");
         };
-        
+
         @Order(2)
         @RegisterExtension
         static RuntimeExtension runtime = ComponentRuntimeExtension.Builder.newInstance()
@@ -251,6 +248,7 @@ public class ParticipantContextConfigApiEndToEndTest {
                 .endpoints(Runtimes.ControlPlane.ENDPOINTS.build())
                 .configurationProvider(Runtimes.ControlPlane::config)
                 .configurationProvider(() -> POSTGRES_EXTENSION.configFor(Runtimes.ControlPlane.NAME.toLowerCase()))
+                .configurationProvider(NATS_EXTENSION::configFor)
                 .configurationProvider(Postgres::runtimeConfiguration)
                 .configurationProvider(() -> ConfigFactory.fromMap(Map.of("edc.iam.oauth2.jwks.url", "http://localhost:" + mockJwksServer.getPort() + "/.well-known/jwks")))
                 .paramProvider(ManagementEndToEndTestContext.class, ManagementEndToEndTestContext::forContext)
@@ -263,10 +261,6 @@ public class ParticipantContextConfigApiEndToEndTest {
                     put("edc.postgres.cdc.user", POSTGRES_EXTENSION.getUsername());
                     put("edc.postgres.cdc.password", POSTGRES_EXTENSION.getPassword());
                     put("edc.postgres.cdc.slot", "edc_cdc_slot_" + Runtimes.ControlPlane.NAME.toLowerCase());
-                    put("edc.nats.cn.subscriber.url", NATS_EXTENSION.getNatsUrl());
-                    put("edc.nats.cn.publisher.url", NATS_EXTENSION.getNatsUrl());
-                    put("edc.nats.tp.subscriber.url", NATS_EXTENSION.getNatsUrl());
-                    put("edc.nats.tp.publisher.url", NATS_EXTENSION.getNatsUrl());
                 }
             });
         }

--- a/system-tests/management-api/management-api-tests/src/test/java/org/eclipse/edc/test/e2e/managementapi/v4/PolicyDefinitionApiV4EndToEndTest.java
+++ b/system-tests/management-api/management-api-tests/src/test/java/org/eclipse/edc/test/e2e/managementapi/v4/PolicyDefinitionApiV4EndToEndTest.java
@@ -950,13 +950,6 @@ public class PolicyDefinitionApiV4EndToEndTest {
             NATS_EXTENSION.createConsumer("state_machine", "tp-subscriber", "transfers.>");
         };
 
-        @Order(3)
-        @RegisterExtension
-        static final BeforeAllCallback SEED = context -> {
-            POSTGRES_EXTENSION.execute(Runtimes.ControlPlane.NAME.toLowerCase(), "ALTER TABLE edc_contract_negotiation REPLICA IDENTITY FULL;");
-            POSTGRES_EXTENSION.execute(Runtimes.ControlPlane.NAME.toLowerCase(), "ALTER TABLE edc_transfer_process REPLICA IDENTITY FULL;");
-        };
-
         @Order(2)
         @RegisterExtension
         static RuntimeExtension runtime = ComponentRuntimeExtension.Builder.newInstance()

--- a/system-tests/management-api/management-api-tests/src/test/java/org/eclipse/edc/test/e2e/managementapi/v4/PolicyDefinitionApiV4EndToEndTest.java
+++ b/system-tests/management-api/management-api-tests/src/test/java/org/eclipse/edc/test/e2e/managementapi/v4/PolicyDefinitionApiV4EndToEndTest.java
@@ -945,9 +945,6 @@ public class PolicyDefinitionApiV4EndToEndTest {
         @RegisterExtension
         static final BeforeAllCallback SETUP = context -> {
             POSTGRES_EXTENSION.createDatabase(Runtimes.ControlPlane.NAME.toLowerCase());
-            NATS_EXTENSION.createStream("state_machine", "negotiations.>", "transfers.>");
-            NATS_EXTENSION.createConsumer("state_machine", "cn-subscriber", "negotiations.>");
-            NATS_EXTENSION.createConsumer("state_machine", "tp-subscriber", "transfers.>");
         };
 
         @Order(2)
@@ -959,6 +956,7 @@ public class PolicyDefinitionApiV4EndToEndTest {
                 .endpoints(Runtimes.ControlPlane.ENDPOINTS.build())
                 .configurationProvider(Runtimes.ControlPlane::config)
                 .configurationProvider(() -> POSTGRES_EXTENSION.configFor(Runtimes.ControlPlane.NAME.toLowerCase()))
+                .configurationProvider(NATS_EXTENSION::configFor)
                 .configurationProvider(Postgres::runtimeConfiguration)
                 .configurationProvider(() -> ConfigFactory.fromMap(Map.of("edc.iam.oauth2.jwks.url", "http://localhost:" + mockJwksServer.getPort() + "/.well-known/jwks")))
                 .paramProvider(ManagementEndToEndTestContext.class, ManagementEndToEndTestContext::forContext)
@@ -971,10 +969,6 @@ public class PolicyDefinitionApiV4EndToEndTest {
                     put("edc.postgres.cdc.user", POSTGRES_EXTENSION.getUsername());
                     put("edc.postgres.cdc.password", POSTGRES_EXTENSION.getPassword());
                     put("edc.postgres.cdc.slot", "edc_cdc_slot_" + Runtimes.ControlPlane.NAME.toLowerCase());
-                    put("edc.nats.cn.subscriber.url", NATS_EXTENSION.getNatsUrl());
-                    put("edc.nats.cn.publisher.url", NATS_EXTENSION.getNatsUrl());
-                    put("edc.nats.tp.subscriber.url", NATS_EXTENSION.getNatsUrl());
-                    put("edc.nats.tp.publisher.url", NATS_EXTENSION.getNatsUrl());
                 }
             });
         }

--- a/system-tests/management-api/management-api-tests/src/test/java/org/eclipse/edc/test/e2e/managementapi/v4/TransferProcessApiV4EndToEndTest.java
+++ b/system-tests/management-api/management-api-tests/src/test/java/org/eclipse/edc/test/e2e/managementapi/v4/TransferProcessApiV4EndToEndTest.java
@@ -795,13 +795,6 @@ public class TransferProcessApiV4EndToEndTest {
             NATS_EXTENSION.createConsumer("state_machine", "tp-subscriber", "transfers.>");
         };
 
-        @Order(3)
-        @RegisterExtension
-        static final BeforeAllCallback SEED = context -> {
-            POSTGRES_EXTENSION.execute(Runtimes.ControlPlane.NAME.toLowerCase(), "ALTER TABLE edc_contract_negotiation REPLICA IDENTITY FULL;");
-            POSTGRES_EXTENSION.execute(Runtimes.ControlPlane.NAME.toLowerCase(), "ALTER TABLE edc_transfer_process REPLICA IDENTITY FULL;");
-        };
-
         @Order(2)
         @RegisterExtension
         static RuntimeExtension runtime = ComponentRuntimeExtension.Builder.newInstance()

--- a/system-tests/management-api/management-api-tests/src/test/java/org/eclipse/edc/test/e2e/managementapi/v4/TransferProcessApiV4EndToEndTest.java
+++ b/system-tests/management-api/management-api-tests/src/test/java/org/eclipse/edc/test/e2e/managementapi/v4/TransferProcessApiV4EndToEndTest.java
@@ -790,9 +790,6 @@ public class TransferProcessApiV4EndToEndTest {
         @RegisterExtension
         static final BeforeAllCallback SETUP = context -> {
             POSTGRES_EXTENSION.createDatabase(Runtimes.ControlPlane.NAME.toLowerCase());
-            NATS_EXTENSION.createStream("state_machine", "negotiations.>", "transfers.>");
-            NATS_EXTENSION.createConsumer("state_machine", "cn-subscriber", "negotiations.>");
-            NATS_EXTENSION.createConsumer("state_machine", "tp-subscriber", "transfers.>");
         };
 
         @Order(2)
@@ -804,6 +801,7 @@ public class TransferProcessApiV4EndToEndTest {
                 .endpoints(Runtimes.ControlPlane.ENDPOINTS.build())
                 .configurationProvider(Runtimes.ControlPlane::config)
                 .configurationProvider(() -> POSTGRES_EXTENSION.configFor(Runtimes.ControlPlane.NAME.toLowerCase()))
+                .configurationProvider(NATS_EXTENSION::configFor)
                 .configurationProvider(Postgres::runtimeConfiguration)
                 .configurationProvider(() -> ConfigFactory.fromMap(Map.of("edc.iam.oauth2.jwks.url", "http://localhost:" + mockJwksServer.getPort() + "/.well-known/jwks")))
                 .paramProvider(ManagementEndToEndTestContext.class, ManagementEndToEndTestContext::forContext)
@@ -816,10 +814,6 @@ public class TransferProcessApiV4EndToEndTest {
                     put("edc.postgres.cdc.user", POSTGRES_EXTENSION.getUsername());
                     put("edc.postgres.cdc.password", POSTGRES_EXTENSION.getPassword());
                     put("edc.postgres.cdc.slot", "edc_cdc_slot_" + Runtimes.ControlPlane.NAME.toLowerCase());
-                    put("edc.nats.cn.subscriber.url", NATS_EXTENSION.getNatsUrl());
-                    put("edc.nats.cn.publisher.url", NATS_EXTENSION.getNatsUrl());
-                    put("edc.nats.tp.subscriber.url", NATS_EXTENSION.getNatsUrl());
-                    put("edc.nats.tp.publisher.url", NATS_EXTENSION.getNatsUrl());
                 }
             });
         }

--- a/system-tests/runtime-tests/src/test/java/org/eclipse/edc/virtualized/transfer/DcpTransferPullEndToEndTest.java
+++ b/system-tests/runtime-tests/src/test/java/org/eclipse/edc/virtualized/transfer/DcpTransferPullEndToEndTest.java
@@ -245,14 +245,7 @@ class DcpTransferPullEndToEndTest {
                 .paramProvider(Participants.class, context -> participants(IDENTITY_HUB_ENDPOINTS))
                 .build()
                 .registerSystemExtension(ServiceExtension.class, new DcpPatchExtension());
-
-        @Order(4)
-        @RegisterExtension
-        static final BeforeAllCallback SEED = context -> {
-            POSTGRESQL_EXTENSION.execute(Runtimes.ControlPlane.NAME.toLowerCase(), "ALTER TABLE edc_contract_negotiation REPLICA IDENTITY FULL;");
-            POSTGRESQL_EXTENSION.execute(Runtimes.ControlPlane.NAME.toLowerCase(), "ALTER TABLE edc_transfer_process REPLICA IDENTITY FULL;");
-        };
-
+        
         private static Config runtimeConfiguration() {
             return ConfigFactory.fromMap(new HashMap<>() {
                 {

--- a/system-tests/runtime-tests/src/test/java/org/eclipse/edc/virtualized/transfer/DcpTransferPullEndToEndTest.java
+++ b/system-tests/runtime-tests/src/test/java/org/eclipse/edc/virtualized/transfer/DcpTransferPullEndToEndTest.java
@@ -198,9 +198,6 @@ class DcpTransferPullEndToEndTest {
             POSTGRESQL_EXTENSION.createDatabase(Runtimes.Issuer.NAME.toLowerCase());
             POSTGRESQL_EXTENSION.createDatabase(Runtimes.IdentityHub.NAME.toLowerCase());
             POSTGRESQL_EXTENSION.createDatabase(Runtimes.ControlPlane.NAME.toLowerCase());
-            NATS_EXTENSION.createStream("state_machine", "negotiations.>", "transfers.>");
-            NATS_EXTENSION.createConsumer("state_machine", "cn-subscriber", "negotiations.>");
-            NATS_EXTENSION.createConsumer("state_machine", "tp-subscriber", "transfers.>");
         };
 
 
@@ -239,13 +236,14 @@ class DcpTransferPullEndToEndTest {
                 .endpoints(Runtimes.ControlPlane.ENDPOINTS.build())
                 .configurationProvider(Runtimes.ControlPlane::config)
                 .configurationProvider(() -> POSTGRESQL_EXTENSION.configFor(Runtimes.ControlPlane.NAME.toLowerCase()))
+                .configurationProvider(NATS_EXTENSION::configFor)
                 .configurationProvider(Postgres::runtimeConfiguration)
                 .configurationProvider(() -> ConfigFactory.fromMap(Map.of("edc.iam.did.web.use.https", "false")))
                 .paramProvider(VirtualConnector.class, VirtualConnector::forContext)
                 .paramProvider(Participants.class, context -> participants(IDENTITY_HUB_ENDPOINTS))
                 .build()
                 .registerSystemExtension(ServiceExtension.class, new DcpPatchExtension());
-        
+
         private static Config runtimeConfiguration() {
             return ConfigFactory.fromMap(new HashMap<>() {
                 {
@@ -253,10 +251,6 @@ class DcpTransferPullEndToEndTest {
                     put("edc.postgres.cdc.user", POSTGRESQL_EXTENSION.getUsername());
                     put("edc.postgres.cdc.password", POSTGRESQL_EXTENSION.getPassword());
                     put("edc.postgres.cdc.slot", "edc_cdc_slot_" + Runtimes.ControlPlane.NAME.toLowerCase());
-                    put("edc.nats.cn.subscriber.url", NATS_EXTENSION.getNatsUrl());
-                    put("edc.nats.cn.publisher.url", NATS_EXTENSION.getNatsUrl());
-                    put("edc.nats.tp.subscriber.url", NATS_EXTENSION.getNatsUrl());
-                    put("edc.nats.tp.publisher.url", NATS_EXTENSION.getNatsUrl());
                 }
             });
         }

--- a/system-tests/runtime-tests/src/test/java/org/eclipse/edc/virtualized/transfer/TransferPullEndToEndTest.java
+++ b/system-tests/runtime-tests/src/test/java/org/eclipse/edc/virtualized/transfer/TransferPullEndToEndTest.java
@@ -79,9 +79,6 @@ class TransferPullEndToEndTest {
         @RegisterExtension
         static final BeforeAllCallback SETUP = context -> {
             POSTGRESQL_EXTENSION.createDatabase(Runtimes.ControlPlane.NAME.toLowerCase());
-            NATS_EXTENSION.createStream("state_machine", "negotiations.>", "transfers.>");
-            NATS_EXTENSION.createConsumer("state_machine", "cn-subscriber", "negotiations.>");
-            NATS_EXTENSION.createConsumer("state_machine", "tp-subscriber", "transfers.>");
         };
         @Order(2)
         @RegisterExtension
@@ -91,6 +88,7 @@ class TransferPullEndToEndTest {
                 .endpoints(Runtimes.ControlPlane.ENDPOINTS.build())
                 .configurationProvider(Runtimes.ControlPlane::config)
                 .configurationProvider(() -> POSTGRESQL_EXTENSION.configFor(Runtimes.ControlPlane.NAME.toLowerCase()))
+                .configurationProvider(NATS_EXTENSION::configFor)
                 .configurationProvider(Postgres::runtimeConfiguration)
                 .paramProvider(VirtualConnector.class, VirtualConnector::forContext)
                 .paramProvider(Participants.class, context -> participants())
@@ -103,10 +101,6 @@ class TransferPullEndToEndTest {
                     put("edc.postgres.cdc.user", POSTGRESQL_EXTENSION.getUsername());
                     put("edc.postgres.cdc.password", POSTGRESQL_EXTENSION.getPassword());
                     put("edc.postgres.cdc.slot", "edc_cdc_slot_" + Runtimes.ControlPlane.NAME.toLowerCase());
-                    put("edc.nats.cn.subscriber.url", NATS_EXTENSION.getNatsUrl());
-                    put("edc.nats.cn.publisher.url", NATS_EXTENSION.getNatsUrl());
-                    put("edc.nats.tp.subscriber.url", NATS_EXTENSION.getNatsUrl());
-                    put("edc.nats.tp.publisher.url", NATS_EXTENSION.getNatsUrl());
                 }
             });
         }

--- a/system-tests/runtime-tests/src/test/java/org/eclipse/edc/virtualized/transfer/TransferPullEndToEndTest.java
+++ b/system-tests/runtime-tests/src/test/java/org/eclipse/edc/virtualized/transfer/TransferPullEndToEndTest.java
@@ -95,12 +95,6 @@ class TransferPullEndToEndTest {
                 .paramProvider(VirtualConnector.class, VirtualConnector::forContext)
                 .paramProvider(Participants.class, context -> participants())
                 .build();
-        @Order(3)
-        @RegisterExtension
-        static final BeforeAllCallback SEED = context -> {
-            POSTGRESQL_EXTENSION.execute(Runtimes.ControlPlane.NAME.toLowerCase(), "ALTER TABLE edc_contract_negotiation REPLICA IDENTITY FULL;");
-            POSTGRESQL_EXTENSION.execute(Runtimes.ControlPlane.NAME.toLowerCase(), "ALTER TABLE edc_transfer_process REPLICA IDENTITY FULL;");
-        };
 
         private static Config runtimeConfiguration() {
             return ConfigFactory.fromMap(new HashMap<>() {


### PR DESCRIPTION
## What this PR changes/adds

Add auto creation of nats stream and consumers.

Additionally added the PG cdc alter table with replica full script to `SqlBoostrapper`

## Why it does that

Dev experience

## Further notes

_List other areas of code that have changed but are not necessarily linked to the main feature. This could be method
signature changes, package declarations, bugs that were encountered and were fixed inline, etc._


## Who will sponsor this feature?

_Please @-mention the committer that will sponsor your feature_.


## Linked Issue(s)

Closes #85

_Please be sure to take a look at the [contributing guidelines](https://github.com/eclipse-edc/.github/blob/main/CONTRIBUTING.md#submit-a-pull-request) and our [etiquette for pull requests](https://github.com/eclipse-edc/.github/blob/main/contributing/pr_etiquette.md)._
