### PR TITLE
feat: auth junit extension

### DIFF
--- a/system-tests/management-api/management-api-tests/build.gradle.kts
+++ b/system-tests/management-api/management-api-tests/build.gradle.kts
@@ -42,6 +42,8 @@ dependencies {
     testImplementation(libs.testcontainers.junit)
     testImplementation(libs.testcontainers.postgres)
     testImplementation(testFixtures(project(":extensions:lib:nats-lib")))
+    testImplementation(testFixtures(libs.edc.lib.oauth2.authn))
+
     testImplementation(project(":system-tests:system-test-fixtures"))
 
     testRuntimeOnly(libs.bouncyCastle.bcprovJdk18on)

--- a/system-tests/management-api/management-api-tests/src/test/java/org/eclipse/edc/test/e2e/managementapi/ManagementEndToEndTestContext.java
+++ b/system-tests/management-api/management-api-tests/src/test/java/org/eclipse/edc/test/e2e/managementapi/ManagementEndToEndTestContext.java
@@ -14,29 +14,18 @@
 
 package org.eclipse.edc.test.e2e.managementapi;
 
-import com.nimbusds.jose.JWSHeader;
-import com.nimbusds.jose.crypto.ECDSASigner;
-import com.nimbusds.jose.jwk.ECKey;
-import com.nimbusds.jwt.JWTClaimsSet.Builder;
-import com.nimbusds.jwt.SignedJWT;
 import io.restassured.specification.RequestSpecification;
 import jakarta.json.Json;
 import jakarta.json.JsonObject;
 import jakarta.json.JsonValue;
-import org.eclipse.edc.api.auth.spi.ParticipantPrincipal;
 import org.eclipse.edc.junit.extensions.ComponentRuntimeContext;
 import org.eclipse.edc.junit.utils.LazySupplier;
 import org.eclipse.edc.spi.query.Criterion;
 
 import java.net.URI;
-import java.time.Instant;
 import java.util.Arrays;
 import java.util.Collection;
-import java.util.HashMap;
-import java.util.Map;
-import java.util.UUID;
 
-import static com.nimbusds.jose.JWSAlgorithm.ES256;
 import static io.restassured.RestAssured.given;
 import static jakarta.json.Json.createArrayBuilder;
 import static jakarta.json.Json.createObjectBuilder;
@@ -70,68 +59,6 @@ public record ManagementEndToEndTestContext(LazySupplier<URI> managementApiUri, 
 
     public JsonObject query(Criterion... criteria) {
         return query(createArrayBuilder().add(EDC_CONNECTOR_MANAGEMENT_CONTEXT_V2).build(), criteria);
-    }
-
-    public String createToken(String participantContextId, ECKey key) {
-        return createToken(participantContextId, key, Map.of());
-    }
-
-    public String createToken(String participantContextId, ECKey key, Map<String, String> additionalClaims) {
-
-        var defaultClaims = new HashMap<String, Object>(Map.of(
-                "sub", "test-subject",
-                "iss", "test-issuer",
-                "iat", Instant.now().getEpochSecond(),
-                "exp", Instant.now().plusSeconds(3600).getEpochSecond(),
-                "jti", UUID.randomUUID().toString(),
-                "scope", "management-api:read management-api:write",
-                "role", ParticipantPrincipal.ROLE_PARTICIPANT,
-                "participant_context_id", participantContextId
-        ));
-        defaultClaims.putAll(additionalClaims);
-        return createToken(key, defaultClaims);
-    }
-
-    public String createToken(ECKey key, Map<String, Object> claims) {
-        try {
-            var claimsBuilder = new Builder();
-            claims.forEach(claimsBuilder::claim);
-            var hdr = new JWSHeader.Builder(ES256).keyID(key.getKeyID()).build();
-            var jwt = new SignedJWT(hdr, claimsBuilder.build());
-            var signer = new ECDSASigner(key);
-            jwt.sign(signer);
-            return jwt.serialize();
-        } catch (Exception e) {
-            throw new RuntimeException(e);
-        }
-    }
-
-    public String createAdminToken(ECKey key) {
-        var defaultClaims = new HashMap<String, Object>(Map.of(
-                "sub", "test-subject",
-                "iss", "test-issuer",
-                "iat", Instant.now().getEpochSecond(),
-                "exp", Instant.now().plusSeconds(3600).getEpochSecond(),
-                "jti", UUID.randomUUID().toString(),
-                "scope", "management-api:read management-api:write",
-                "role", ParticipantPrincipal.ROLE_ADMIN
-        ));
-
-        return createToken(key, defaultClaims);
-    }
-
-    public String createProvisionerToken(ECKey key) {
-        var defaultClaims = new HashMap<String, Object>(Map.of(
-                "sub", "test-subject",
-                "iss", "test-issuer",
-                "iat", Instant.now().getEpochSecond(),
-                "exp", Instant.now().plusSeconds(3600).getEpochSecond(),
-                "jti", UUID.randomUUID().toString(),
-                "scope", "management-api:read management-api:write",
-                "role", ParticipantPrincipal.ROLE_PROVISIONER
-        ));
-
-        return createToken(key, defaultClaims);
     }
 
     private JsonObject query(JsonValue ctx, Criterion... criteria) {


### PR DESCRIPTION
## What this PR changes/adds

Add `AuthServerEndToEndExtension` that can be used to mock an auth server and can inject in tests an instance of `AuthServer` for minting tokens

## Why it does that

refactoring

## Further notes

_List other areas of code that have changed but are not necessarily linked to the main feature. This could be method
signature changes, package declarations, bugs that were encountered and were fixed inline, etc._


## Who will sponsor this feature?

_Please @-mention the committer that will sponsor your feature_.


## Linked Issue(s)

Closes # <-- _insert Issue number if one exists_

_Please be sure to take a look at the [contributing guidelines](https://github.com/eclipse-edc/.github/blob/main/CONTRIBUTING.md#submit-a-pull-request) and our [etiquette for pull requests](https://github.com/eclipse-edc/.github/blob/main/contributing/pr_etiquette.md)._
