### PR TITLE
chore: some fixes

### DIFF
--- a/core/transfer-process-manager/src/main/java/org/eclipse/edc/virtual/controlplane/transfer/process/TransferProcessStateMachineServiceImpl.java
+++ b/core/transfer-process-manager/src/main/java/org/eclipse/edc/virtual/controlplane/transfer/process/TransferProcessStateMachineServiceImpl.java
@@ -251,7 +251,7 @@ public class TransferProcessStateMachineServiceImpl implements TransferProcessSt
             transitionToSuspended(process);
             return StatusResult.success();
         } else {
-            return dispatch(TransferSuspensionMessage.Builder.newInstance(), process, Object.class)
+            return dispatch(TransferSuspensionMessage.Builder.newInstance().reason(process.getErrorDetail()), process, Object.class)
                     .onSuccess(c -> transitionToSuspended(process))
                     .mapEmpty();
         }

--- a/extensions/control-plane/api/management-api/asset-api/src/main/java/org/eclipse/edc/virtual/connector/controlplane/api/management/asset/v4/AssetApiV4Controller.java
+++ b/extensions/control-plane/api/management-api/asset-api/src/main/java/org/eclipse/edc/virtual/connector/controlplane/api/management/asset/v4/AssetApiV4Controller.java
@@ -178,7 +178,10 @@ public class AssetApiV4Controller implements AssetApiV4 {
         validator.validate(EDC_ASSET_TYPE, assetJson).orElseThrow(ValidationFailureException::new);
 
         var asset = typeTransformerRegistry.transform(assetJson, Asset.class)
-                .orElseThrow(InvalidRequestException::new);
+                .orElseThrow(InvalidRequestException::new)
+                .toBuilder()
+                .participantContextId(participantContextId)
+                .build();
 
         var assetId = asset.getId();
         authorizationService.authorize(securityContext, participantContextId, assetId, Asset.class).orElseThrow(exceptionMapper(Asset.class, assetId));

--- a/extensions/control-plane/api/management-api/policy-definition-api/src/main/java/org/eclipse/edc/virtual/connector/controlplane/api/management/policy/v4/PolicyDefinitionApiV4Controller.java
+++ b/extensions/control-plane/api/management-api/policy-definition-api/src/main/java/org/eclipse/edc/virtual/connector/controlplane/api/management/policy/v4/PolicyDefinitionApiV4Controller.java
@@ -187,7 +187,10 @@ public class PolicyDefinitionApiV4Controller implements PolicyDefinitionApiV4 {
                 .orElseThrow(exceptionMapper(PolicyDefinition.class, id));
 
         var policyDefinition = typeTransformerRegistry.transform(input, PolicyDefinition.class)
-                .orElseThrow(InvalidRequestException::new);
+                .orElseThrow(InvalidRequestException::new)
+                .toBuilder()
+                .participantContextId(participantContextId)
+                .build();
 
         policyDefinitionService.update(policyDefinition)
                 .onSuccess(d -> monitor.debug(format("Policy Definition updated %s", d.getId())))

--- a/system-tests/management-api/management-api-tests/src/test/java/org/eclipse/edc/test/e2e/managementapi/v4/AssetApiV4EndToEndTest.java
+++ b/system-tests/management-api/management-api-tests/src/test/java/org/eclipse/edc/test/e2e/managementapi/v4/AssetApiV4EndToEndTest.java
@@ -118,6 +118,8 @@ public class AssetApiV4EndToEndTest {
             assertThat(dbAsset.getDataAddress().getProperty(EDC_NAMESPACE + "complex"))
                     .asInstanceOf(MAP)
                     .containsEntry(EDC_NAMESPACE + "nested", List.of(Map.of(VALUE, "value")));
+
+            assertThat(asset.getParticipantContextId()).isEqualTo(PARTICIPANT_CONTEXT_ID);
         }
 
         @Test
@@ -497,6 +499,7 @@ public class AssetApiV4EndToEndTest {
                     .containsEntry(EDC_NAMESPACE + "nested",
                             List.of(Map.of(EDC_NAMESPACE + "innerValue",
                                     List.of(Map.of(VALUE, "value")))));
+            assertThat(asset.getParticipantContextId()).isEqualTo(PARTICIPANT_CONTEXT_ID);
         }
 
         @Test

--- a/system-tests/management-api/management-api-tests/src/test/java/org/eclipse/edc/test/e2e/managementapi/v4/PolicyDefinitionApiV4EndToEndTest.java
+++ b/system-tests/management-api/management-api-tests/src/test/java/org/eclipse/edc/test/e2e/managementapi/v4/PolicyDefinitionApiV4EndToEndTest.java
@@ -497,10 +497,14 @@ public class PolicyDefinitionApiV4EndToEndTest {
                     .then()
                     .statusCode(204);
 
-            assertThat(store.findById(id))
+            var policyDefinition = store.findById(id);
+            assertThat(policyDefinition)
                     .extracting(PolicyDefinition::getPrivateProperties)
                     .asInstanceOf(MAP)
                     .isNotEmpty();
+
+            assertThat(policyDefinition.getParticipantContextId()).isEqualTo(PARTICIPANT_CONTEXT_ID);
+
         }
 
         @Test


### PR DESCRIPTION
## What this PR changes/adds

- The reason was missing in the suspension message
- When using memory `participantContextId` was set to null in Assets/Policy update

## Why it does that

_Briefly state why the change was necessary._

## Further notes

_List other areas of code that have changed but are not necessarily linked to the main feature. This could be method
signature changes, package declarations, bugs that were encountered and were fixed inline, etc._


## Who will sponsor this feature?

_Please @-mention the committer that will sponsor your feature_.


## Linked Issue(s)

Closes # <-- _insert Issue number if one exists_

_Please be sure to take a look at the [contributing guidelines](https://github.com/eclipse-edc/.github/blob/main/CONTRIBUTING.md#submit-a-pull-request) and our [etiquette for pull requests](https://github.com/eclipse-edc/.github/blob/main/contributing/pr_etiquette.md)._
