### PR TITLE
feat: alternative to cdc state machine based on tasks

### DIFF
--- a/core/negotiation-manager/src/main/java/org/eclipse/edc/virtual/controlplane/contract/negotiation/ContractManagerExtension.java
+++ b/core/negotiation-manager/src/main/java/org/eclipse/edc/virtual/controlplane/contract/negotiation/ContractManagerExtension.java
@@ -74,4 +74,5 @@ public class ContractManagerExtension implements ServiceExtension {
     public ContractNegotiationStateMachineService contractNegotiationStateMachineService(ServiceExtensionContext context) {
         return new ContractNegotiationStateMachineServiceImpl(clock, identityResolver, webhookResolver, dispatcherRegistry, contractNegotiationStore, transactionContext, pendingGuard, observable, monitor);
     }
+
 }

--- a/core/negotiation-manager/src/main/java/org/eclipse/edc/virtual/controlplane/contract/negotiation/ContractNegotiationStateMachineServiceImpl.java
+++ b/core/negotiation-manager/src/main/java/org/eclipse/edc/virtual/controlplane/contract/negotiation/ContractNegotiationStateMachineServiceImpl.java
@@ -302,6 +302,7 @@ public class ContractNegotiationStateMachineServiceImpl implements ContractNegot
     protected void transitionToTerminated(ContractNegotiation negotiation, String message) {
         negotiation.setErrorDetail(message);
         transitionToTerminated(negotiation);
+        observable.invokeForEach(l -> l.terminated(negotiation));
     }
 
     protected void transitionToAgreeing(ContractNegotiation negotiation) {

--- a/core/negotiation-task-executor/build.gradle.kts
+++ b/core/negotiation-task-executor/build.gradle.kts
@@ -1,0 +1,28 @@
+/*
+ *  Copyright (c) 2026 Metaform Systems, Inc.
+ *
+ *  This program and the accompanying materials are made available under the
+ *  terms of the Apache License, Version 2.0 which is available at
+ *  https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Contributors:
+ *       Metaform Systems, Inc. - initial API and implementation
+ *
+ */
+
+plugins {
+    `java-library`
+}
+
+dependencies {
+    api(project(":spi:v-core-spi"))
+    api(project(":spi:v-task-spi"))
+    api(libs.edc.spi.core)
+    api(libs.edc.spi.transaction)
+    api(libs.edc.spi.protocol)
+    api(libs.edc.spi.contract)
+    implementation(libs.opentelemetry.instrumentation.annotations)
+}
+

--- a/core/negotiation-task-executor/src/main/java/org/eclipse/edc/virtual/controlplane/contract/negotiation/task/ContractNegotiationTaskExecutorImpl.java
+++ b/core/negotiation-task-executor/src/main/java/org/eclipse/edc/virtual/controlplane/contract/negotiation/task/ContractNegotiationTaskExecutorImpl.java
@@ -1,0 +1,450 @@
+/*
+ *  Copyright (c) 2026 Metaform Systems, Inc.
+ *
+ *  This program and the accompanying materials are made available under the
+ *  terms of the Apache License, Version 2.0 which is available at
+ *  https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Contributors:
+ *       Metaform Systems, Inc. - initial API and implementation
+ *
+ */
+
+package org.eclipse.edc.virtual.controlplane.contract.negotiation.task;
+
+import org.eclipse.edc.connector.controlplane.contract.spi.negotiation.ContractNegotiationPendingGuard;
+import org.eclipse.edc.connector.controlplane.contract.spi.negotiation.observe.ContractNegotiationObservable;
+import org.eclipse.edc.connector.controlplane.contract.spi.negotiation.store.ContractNegotiationStore;
+import org.eclipse.edc.connector.controlplane.contract.spi.types.agreement.ContractAgreement;
+import org.eclipse.edc.connector.controlplane.contract.spi.types.agreement.ContractAgreementMessage;
+import org.eclipse.edc.connector.controlplane.contract.spi.types.agreement.ContractAgreementVerificationMessage;
+import org.eclipse.edc.connector.controlplane.contract.spi.types.agreement.ContractNegotiationEventMessage;
+import org.eclipse.edc.connector.controlplane.contract.spi.types.negotiation.ContractNegotiation;
+import org.eclipse.edc.connector.controlplane.contract.spi.types.negotiation.ContractNegotiationStates;
+import org.eclipse.edc.connector.controlplane.contract.spi.types.negotiation.ContractRequestMessage;
+import org.eclipse.edc.connector.controlplane.contract.spi.types.protocol.ContractNegotiationAck;
+import org.eclipse.edc.participantcontext.spi.identity.ParticipantIdentityResolver;
+import org.eclipse.edc.policy.model.PolicyType;
+import org.eclipse.edc.spi.message.RemoteMessageDispatcherRegistry;
+import org.eclipse.edc.spi.monitor.Monitor;
+import org.eclipse.edc.spi.response.StatusResult;
+import org.eclipse.edc.spi.types.domain.message.ProcessRemoteMessage;
+import org.eclipse.edc.transaction.spi.TransactionContext;
+import org.eclipse.edc.virtual.controlplane.contract.spi.negotiation.ContractNegotiationTaskExecutor;
+import org.eclipse.edc.virtual.controlplane.contract.spi.negotiation.tasks.AgreeNegotiation;
+import org.eclipse.edc.virtual.controlplane.contract.spi.negotiation.tasks.ContractNegotiationTaskPayload;
+import org.eclipse.edc.virtual.controlplane.contract.spi.negotiation.tasks.FinalizeNegotiation;
+import org.eclipse.edc.virtual.controlplane.contract.spi.negotiation.tasks.RequestNegotiation;
+import org.eclipse.edc.virtual.controlplane.contract.spi.negotiation.tasks.SendAgreement;
+import org.eclipse.edc.virtual.controlplane.contract.spi.negotiation.tasks.SendFinalizeNegotiation;
+import org.eclipse.edc.virtual.controlplane.contract.spi.negotiation.tasks.SendRequestNegotiation;
+import org.eclipse.edc.virtual.controlplane.contract.spi.negotiation.tasks.SendVerificationNegotiation;
+import org.eclipse.edc.virtual.controlplane.contract.spi.negotiation.tasks.VerifyNegotiation;
+import org.eclipse.edc.virtual.controlplane.participantcontext.spi.ParticipantWebhookResolver;
+import org.eclipse.edc.virtual.controlplane.tasks.ProcessTaskPayload;
+import org.eclipse.edc.virtual.controlplane.tasks.Task;
+import org.eclipse.edc.virtual.controlplane.tasks.TaskService;
+
+import java.time.Clock;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Optional;
+import java.util.function.Function;
+
+import static org.eclipse.edc.connector.controlplane.contract.spi.types.negotiation.ContractNegotiationStates.from;
+import static org.eclipse.edc.spi.response.ResponseStatus.FATAL_ERROR;
+
+public class ContractNegotiationTaskExecutorImpl implements ContractNegotiationTaskExecutor {
+
+    private final Map<Class<? extends ContractNegotiationTaskPayload>, Handler> handlers = new HashMap<>();
+    protected Clock clock;
+    protected ParticipantIdentityResolver identityResolver;
+    protected ParticipantWebhookResolver webhookResolver;
+    protected RemoteMessageDispatcherRegistry dispatcherRegistry;
+    protected ContractNegotiationStore store;
+    protected TransactionContext transactionContext;
+    protected ContractNegotiationPendingGuard pendingGuard;
+    protected ContractNegotiationObservable observable;
+    protected Monitor monitor;
+    protected TaskService taskService;
+
+    private ContractNegotiationTaskExecutorImpl() {
+        registerStateHandlers();
+    }
+
+    private void registerStateHandlers() {
+        handlers.put(RequestNegotiation.class, new Handler(this::handleRequest, ContractNegotiation.Type.CONSUMER));
+        handlers.put(SendRequestNegotiation.class, new Handler(this::handleSendRequest, ContractNegotiation.Type.CONSUMER));
+        handlers.put(AgreeNegotiation.class, new Handler(this::handleAgree, ContractNegotiation.Type.PROVIDER));
+        handlers.put(SendAgreement.class, new Handler(this::handleSendAgreement, ContractNegotiation.Type.PROVIDER));
+        handlers.put(VerifyNegotiation.class, new Handler(this::handleVerify, ContractNegotiation.Type.CONSUMER));
+        handlers.put(SendVerificationNegotiation.class, new Handler(this::handleSendVerification, ContractNegotiation.Type.CONSUMER));
+        handlers.put(FinalizeNegotiation.class, new Handler(this::handleFinalize, ContractNegotiation.Type.PROVIDER));
+        handlers.put(SendFinalizeNegotiation.class, new Handler(this::handleSendFinalize, ContractNegotiation.Type.PROVIDER));
+    }
+
+    @Override
+    public StatusResult<Void> handle(ContractNegotiationTaskPayload task) {
+        return handleTask(task);
+    }
+
+    private void storeTask(ContractNegotiationTaskPayload payload) {
+        var task = Task.Builder.newInstance().at(clock.millis())
+                .payload(payload)
+                .build();
+        taskService.create(task);
+    }
+
+    private StatusResult<Void> handleTask(ContractNegotiationTaskPayload task) {
+        var expectedState = ContractNegotiationStates.valueOf(task.getProcessState());
+        var negotiationId = task.getProcessId();
+        return transactionContext.execute(() -> {
+            var negotiationResult = loadNegotiation(task.getProcessId());
+            if (negotiationResult.failed()) {
+                return StatusResult.failure(FATAL_ERROR, negotiationResult.getFailureDetail());
+            }
+
+            var negotiation = negotiationResult.getContent();
+            if (ContractNegotiationStates.isFinal(negotiation.getState())) {
+                monitor.debug("Skipping contract negotiation with id '%s' is in final state '%s'".formatted(task.getProcessId(), from(negotiation.getState())));
+                return StatusResult.success();
+            }
+
+            if (negotiation.getState() != expectedState.code()) {
+                monitor.warning("Skipping contract negotiation with id '%s' is in state '%s', expected '%s'".formatted(negotiationId, from(negotiation.getState()), expectedState));
+                return StatusResult.success();
+            }
+
+            var handler = handlers.get(task.getClass());
+            if (handler == null) {
+                monitor.debug("No handler for task '%s' in contract negotiation with id '%s'".formatted(task.getClass().getSimpleName(), negotiationId));
+                return StatusResult.success();
+            }
+
+            if (handler.type != null && handler.type != negotiation.getType()) {
+                monitor.debug("Skipping '%s' for contract negotiation with id '%s' due to type mismatch: expected '%s', got '%s'".formatted(expectedState, negotiationId, handler.type, negotiation.getType()));
+                return StatusResult.success();
+            }
+
+            if (pendingGuard.test(negotiation)) {
+                monitor.debug("Skipping '%s' for contract negotiation with id '%s' due matched guard".formatted(expectedState, negotiationId));
+                return StatusResult.success();
+            }
+
+            var result = handler.function.apply(negotiation);
+            if (result.fatalError()) {
+                monitor.severe("Processing contract negotiation with id '%s' in state '%s' failed: %s"
+                        .formatted(task.getProcessId(), expectedState, result.getFailureDetail()));
+                transitionToTerminated(negotiation, "Fatal error during processing: %s".formatted(result.getFailureDetail()));
+                return StatusResult.success();
+            } else {
+                return result;
+
+            }
+
+        });
+
+    }
+
+    private StatusResult<Void> handleAgree(ContractNegotiation negotiation) {
+        transitionToAgreeing(negotiation);
+        var task = baseBuilder(SendAgreement.Builder.newInstance(), negotiation)
+                .build();
+        storeTask(task);
+        return StatusResult.success();
+    }
+
+    private StatusResult<Void> handleSendRequest(ContractNegotiation negotiation) {
+        var callbackAddress = webhookResolver.getWebhook(negotiation.getParticipantContextId(), negotiation.getProtocol());
+
+        if (callbackAddress != null) {
+            var type = ContractRequestMessage.Type.INITIAL;
+            if (negotiation.getContractOffers().size() > 1) {
+                type = ContractRequestMessage.Type.COUNTER_OFFER;
+            }
+            var messageBuilder = ContractRequestMessage.Builder.newInstance()
+                    .contractOffer(negotiation.getLastContractOffer())
+                    .callbackAddress(callbackAddress.url())
+                    .type(type);
+
+            return dispatch(messageBuilder, negotiation, ContractNegotiationAck.class)
+                    .onSuccess(ack -> transitionToRequested(negotiation, ack))
+                    .mapEmpty();
+        } else {
+            transitionToTerminated(negotiation, "No callback address found for protocol: %s".formatted(negotiation.getProtocol()));
+            return StatusResult.success();
+        }
+    }
+
+    private StatusResult<Void> handleFinalize(ContractNegotiation negotiation) {
+        transitionToFinalizing(negotiation);
+        var task = baseBuilder(SendFinalizeNegotiation.Builder.newInstance(), negotiation)
+                .build();
+        storeTask(task);
+        return StatusResult.success();
+    }
+
+    protected StatusResult<Void> handleSendVerification(ContractNegotiation negotiation) {
+        var messageBuilder = ContractAgreementVerificationMessage.Builder.newInstance()
+                .policy(negotiation.getContractAgreement().getPolicy());
+
+        return dispatch(messageBuilder, negotiation, Object.class)
+                .onSuccess((n) -> transitionToVerified(negotiation))
+                .mapEmpty();
+    }
+
+    protected StatusResult<Void> handleSendAgreement(ContractNegotiation negotiation) {
+        var callbackAddress = webhookResolver.getWebhook(negotiation.getParticipantContextId(), negotiation.getProtocol());
+        if (callbackAddress == null) {
+            transitionToTerminated(negotiation, "No callback address found for protocol: %s".formatted(negotiation.getProtocol()));
+            return StatusResult.failure(FATAL_ERROR, "No callback address found for protocol: %s".formatted(negotiation.getProtocol()));
+        }
+
+        var agreement = Optional.ofNullable(negotiation.getContractAgreement())
+                .orElseGet(() -> {
+                    var lastOffer = negotiation.getLastContractOffer();
+
+                    var participantId = identityResolver.getParticipantId(negotiation.getParticipantContextId(), negotiation.getProtocol());
+
+                    var contractPolicy = lastOffer.getPolicy().toBuilder().type(PolicyType.CONTRACT)
+                            .assignee(negotiation.getCounterPartyId())
+                            .assigner(participantId)
+                            .build();
+
+                    return ContractAgreement.Builder.newInstance()
+                            .contractSigningDate(clock.instant().getEpochSecond())
+                            .providerId(participantId)
+                            .consumerId(negotiation.getCounterPartyId())
+                            .policy(contractPolicy)
+                            .assetId(lastOffer.getAssetId())
+                            .participantContextId(negotiation.getParticipantContextId())
+                            .build();
+                });
+
+        var messageBuilder = ContractAgreementMessage.Builder.newInstance()
+                .callbackAddress(callbackAddress.url())
+                .contractAgreement(agreement);
+
+        return dispatch(messageBuilder, negotiation, Object.class)
+                .onSuccess(v -> transitionToAgreed(negotiation, agreement))
+                .mapEmpty();
+    }
+
+    private StatusResult<Void> handleVerify(ContractNegotiation negotiation) {
+        transitionToVerifying(negotiation);
+        var task = baseBuilder(SendVerificationNegotiation.Builder.newInstance(), negotiation)
+                .build();
+        storeTask(task);
+        return StatusResult.success();
+    }
+
+    private StatusResult<Void> handleRequest(ContractNegotiation negotiation) {
+        transitionToRequesting(negotiation);
+        var task = baseBuilder(SendRequestNegotiation.Builder.newInstance(), negotiation)
+                .build();
+        storeTask(task);
+        return StatusResult.success();
+    }
+
+    private StatusResult<Void> handleSendFinalize(ContractNegotiation negotiation) {
+        var messageBuilder = ContractNegotiationEventMessage.Builder.newInstance()
+                .type(ContractNegotiationEventMessage.Type.FINALIZED)
+                .policy(negotiation.getContractAgreement().getPolicy());
+
+        return dispatch(messageBuilder, negotiation, Object.class)
+                .onSuccess((n) -> transitionToFinalized(negotiation))
+                .mapEmpty();
+    }
+
+    protected void transitionToTerminated(ContractNegotiation negotiation, String message) {
+        negotiation.setErrorDetail(message);
+        transitionToTerminated(negotiation);
+        observable.invokeForEach(l -> l.terminated(negotiation));
+    }
+
+    protected void transitionToAgreeing(ContractNegotiation negotiation) {
+        negotiation.transitionAgreeing();
+        update(negotiation);
+    }
+
+    protected void transitionToTerminated(ContractNegotiation negotiation) {
+        negotiation.transitionTerminated();
+        update(negotiation);
+        observable.invokeForEach(l -> l.terminated(negotiation));
+    }
+
+    protected void transitionToAgreed(ContractNegotiation negotiation, ContractAgreement agreement) {
+        negotiation.setContractAgreement(agreement);
+        negotiation.transitionAgreed();
+        update(negotiation);
+        observable.invokeForEach(l -> l.agreed(negotiation));
+    }
+
+    protected void transitionToFinalized(ContractNegotiation negotiation) {
+        negotiation.transitionFinalized();
+        update(negotiation);
+        observable.invokeForEach(l -> l.finalized(negotiation));
+    }
+
+    protected void transitionToFinalizing(ContractNegotiation negotiation) {
+        negotiation.transitionFinalizing();
+        update(negotiation);
+    }
+
+    protected void transitionToRequested(ContractNegotiation negotiation, ContractNegotiationAck ack) {
+        negotiation.transitionRequested();
+        negotiation.setCorrelationId(ack.getProviderPid());
+        update(negotiation);
+        observable.invokeForEach(l -> l.requested(negotiation));
+    }
+
+    protected void transitionToVerifying(ContractNegotiation negotiation) {
+        negotiation.transitionVerifying();
+        update(negotiation);
+    }
+
+    protected void transitionToVerified(ContractNegotiation negotiation) {
+        negotiation.transitionVerified();
+        update(negotiation);
+        observable.invokeForEach(l -> l.verified(negotiation));
+    }
+
+    private StatusResult<ContractNegotiation> loadNegotiation(String negotiationId) {
+        var negotiation = store.findById(negotiationId);
+        if (negotiation == null) {
+            return StatusResult.failure(FATAL_ERROR, "Contract negotiation with id '%s' not found".formatted(negotiationId));
+        }
+        return StatusResult.success(negotiation);
+    }
+
+    protected <T> StatusResult<T> dispatch(
+            ProcessRemoteMessage.Builder<?, ?> messageBuilder,
+            ContractNegotiation negotiation, Class<T> responseType) {
+        messageBuilder.counterPartyAddress(negotiation.getCounterPartyAddress())
+                .counterPartyId(negotiation.getCounterPartyId())
+                .protocol(negotiation.getProtocol())
+                .processId(Optional.ofNullable(negotiation.getCorrelationId()).orElse(negotiation.getId()));
+
+        if (negotiation.getType() == ContractNegotiation.Type.CONSUMER) {
+            messageBuilder.consumerPid(negotiation.getId()).providerPid(negotiation.getCorrelationId());
+        } else {
+            messageBuilder.providerPid(negotiation.getId()).consumerPid(negotiation.getCorrelationId());
+        }
+
+        if (negotiation.lastSentProtocolMessage() != null) {
+            messageBuilder.id(negotiation.lastSentProtocolMessage());
+        }
+
+        var message = messageBuilder.build();
+
+        negotiation.lastSentProtocolMessage(message.getId());
+
+        try {
+            return dispatcherRegistry.dispatch(negotiation.getParticipantContextId(), responseType, message).get();
+        } catch (Exception e) {
+            return StatusResult.failure(FATAL_ERROR, "Failed to dispatch message: %s".formatted(e.getMessage()));
+        }
+    }
+
+    protected void transitionToRequesting(ContractNegotiation negotiation) {
+        negotiation.transitionRequesting();
+        update(negotiation);
+    }
+    
+    protected void update(ContractNegotiation entity) {
+        store.save(entity);
+        monitor.debug(() -> "[%s] %s %s is now in state %s".formatted(entity.getType(), entity.getClass().getSimpleName(),
+                entity.getId(), entity.stateAsString()));
+    }
+
+    protected <T extends ProcessTaskPayload, B extends ProcessTaskPayload.Builder<T, B>> B baseBuilder(B builder, ContractNegotiation negotiation) {
+        return builder.processId(negotiation.getId())
+                .processState(negotiation.stateAsString())
+                .processType(negotiation.getType().name());
+    }
+
+    private record Handler(Function<ContractNegotiation, StatusResult<Void>> function, ContractNegotiation.Type type) {
+
+    }
+
+    public static class Builder {
+        private final ContractNegotiationTaskExecutorImpl manager;
+
+        private Builder() {
+            manager = new ContractNegotiationTaskExecutorImpl();
+        }
+
+        public static Builder newInstance() {
+            return new Builder();
+        }
+
+        public Builder taskService(TaskService taskStore) {
+            this.manager.taskService = taskStore;
+            return this;
+        }
+
+        public Builder clock(Clock clock) {
+            this.manager.clock = clock;
+            return this;
+        }
+
+        public Builder identityResolver(ParticipantIdentityResolver identityResolver) {
+            this.manager.identityResolver = identityResolver;
+            return this;
+        }
+
+        public Builder webhookResolver(ParticipantWebhookResolver webhookResolver) {
+            this.manager.webhookResolver = webhookResolver;
+            return this;
+        }
+
+        public Builder dispatcherRegistry(RemoteMessageDispatcherRegistry dispatcherRegistry) {
+            this.manager.dispatcherRegistry = dispatcherRegistry;
+            return this;
+        }
+
+        public Builder store(ContractNegotiationStore store) {
+            this.manager.store = store;
+            return this;
+        }
+
+        public Builder transactionContext(TransactionContext transactionContext) {
+            this.manager.transactionContext = transactionContext;
+            return this;
+        }
+
+        public Builder pendingGuard(ContractNegotiationPendingGuard pendingGuard) {
+            this.manager.pendingGuard = pendingGuard;
+            return this;
+        }
+
+        public Builder observable(ContractNegotiationObservable observable) {
+            this.manager.observable = observable;
+            return this;
+        }
+
+        public Builder monitor(Monitor monitor) {
+            this.manager.monitor = monitor;
+            return this;
+        }
+
+        public ContractNegotiationTaskExecutor build() {
+            java.util.Objects.requireNonNull(manager.taskService, "taskStore must not be null");
+            java.util.Objects.requireNonNull(manager.clock, "clock must not be null");
+            java.util.Objects.requireNonNull(manager.identityResolver, "identityResolver must not be null");
+            java.util.Objects.requireNonNull(manager.webhookResolver, "webhookResolver must not be null");
+            java.util.Objects.requireNonNull(manager.dispatcherRegistry, "dispatcherRegistry must not be null");
+            java.util.Objects.requireNonNull(manager.store, "store must not be null");
+            java.util.Objects.requireNonNull(manager.transactionContext, "transactionContext must not be null");
+            java.util.Objects.requireNonNull(manager.pendingGuard, "pendingGuard must not be null");
+            java.util.Objects.requireNonNull(manager.observable, "observable must not be null");
+            java.util.Objects.requireNonNull(manager.monitor, "monitor must not be null");
+
+            return manager;
+        }
+    }
+
+
+}

--- a/core/negotiation-task-executor/src/main/java/org/eclipse/edc/virtual/controlplane/contract/negotiation/task/ContractTaskExecutorExtension.java
+++ b/core/negotiation-task-executor/src/main/java/org/eclipse/edc/virtual/controlplane/contract/negotiation/task/ContractTaskExecutorExtension.java
@@ -1,0 +1,85 @@
+/*
+ *  Copyright (c) 2026 Metaform Systems, Inc.
+ *
+ *  This program and the accompanying materials are made available under the
+ *  terms of the Apache License, Version 2.0 which is available at
+ *  https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Contributors:
+ *       Metaform Systems, Inc. - initial API and implementation
+ *
+ */
+
+package org.eclipse.edc.virtual.controlplane.contract.negotiation.task;
+
+import org.eclipse.edc.connector.controlplane.contract.spi.negotiation.ContractNegotiationPendingGuard;
+import org.eclipse.edc.connector.controlplane.contract.spi.negotiation.observe.ContractNegotiationObservable;
+import org.eclipse.edc.connector.controlplane.contract.spi.negotiation.store.ContractNegotiationStore;
+import org.eclipse.edc.participantcontext.spi.identity.ParticipantIdentityResolver;
+import org.eclipse.edc.runtime.metamodel.annotation.Extension;
+import org.eclipse.edc.runtime.metamodel.annotation.Inject;
+import org.eclipse.edc.runtime.metamodel.annotation.Provider;
+import org.eclipse.edc.spi.message.RemoteMessageDispatcherRegistry;
+import org.eclipse.edc.spi.monitor.Monitor;
+import org.eclipse.edc.spi.system.ServiceExtension;
+import org.eclipse.edc.transaction.spi.TransactionContext;
+import org.eclipse.edc.virtual.controlplane.contract.spi.negotiation.ContractNegotiationTaskExecutor;
+import org.eclipse.edc.virtual.controlplane.participantcontext.spi.ParticipantWebhookResolver;
+import org.eclipse.edc.virtual.controlplane.tasks.TaskService;
+
+import java.time.Clock;
+
+import static org.eclipse.edc.virtual.controlplane.contract.negotiation.task.ContractTaskExecutorExtension.NAME;
+
+@Extension(NAME)
+public class ContractTaskExecutorExtension implements ServiceExtension {
+
+    public static final String NAME = "EDC-V Contract Task Executor Extension";
+    @Inject
+    private ContractNegotiationStore contractNegotiationStore;
+
+    @Inject
+    private TransactionContext transactionContext;
+
+    @Inject
+    private ContractNegotiationPendingGuard pendingGuard;
+
+    @Inject
+    private Monitor monitor;
+
+    @Inject
+    private ParticipantWebhookResolver webhookResolver;
+
+    @Inject
+    private ParticipantIdentityResolver identityResolver;
+
+    @Inject
+    private RemoteMessageDispatcherRegistry dispatcherRegistry;
+
+    @Inject
+    private ContractNegotiationObservable observable;
+
+    @Inject
+    private TaskService taskService;
+
+    @Inject
+    private Clock clock;
+
+    @Provider
+    public ContractNegotiationTaskExecutor contractNegotiationTaskExecutor() {
+        return ContractNegotiationTaskExecutorImpl.Builder.newInstance()
+                .taskService(taskService)
+                .clock(clock)
+                .identityResolver(identityResolver)
+                .webhookResolver(webhookResolver)
+                .dispatcherRegistry(dispatcherRegistry)
+                .store(contractNegotiationStore)
+                .transactionContext(transactionContext)
+                .pendingGuard(pendingGuard)
+                .observable(observable)
+                .monitor(monitor)
+                .build();
+    }
+}

--- a/core/negotiation-task-executor/src/main/resources/META-INF/services/org.eclipse.edc.spi.system.ServiceExtension
+++ b/core/negotiation-task-executor/src/main/resources/META-INF/services/org.eclipse.edc.spi.system.ServiceExtension
@@ -1,0 +1,14 @@
+#
+#  Copyright (c) 2026 Metaform Systems, Inc.
+#
+#  This program and the accompanying materials are made available under the
+#  terms of the Apache License, Version 2.0 which is available at
+#  https://www.apache.org/licenses/LICENSE-2.0
+#
+#  SPDX-License-Identifier: Apache-2.0
+#
+#  Contributors:
+#       Metaform Systems, Inc. - initial API and implementation
+#
+#
+org.eclipse.edc.virtual.controlplane.contract.negotiation.task.ContractTaskExecutorExtension

--- a/core/negotiation-task-executor/src/test/java/org/eclipse/edc/virtual/controlplane/contract/negotiation/task/ContractNegotiationTaskExecutorImplTest.java
+++ b/core/negotiation-task-executor/src/test/java/org/eclipse/edc/virtual/controlplane/contract/negotiation/task/ContractNegotiationTaskExecutorImplTest.java
@@ -1,0 +1,294 @@
+/*
+ *  Copyright (c) 2026 Metaform Systems, Inc.
+ *
+ *  This program and the accompanying materials are made available under the
+ *  terms of the Apache License, Version 2.0 which is available at
+ *  https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Contributors:
+ *       Metaform Systems, Inc. - initial API and implementation
+ *
+ */
+
+package org.eclipse.edc.virtual.controlplane.contract.negotiation.task;
+
+import org.eclipse.edc.connector.controlplane.contract.spi.negotiation.ContractNegotiationPendingGuard;
+import org.eclipse.edc.connector.controlplane.contract.spi.negotiation.observe.ContractNegotiationObservable;
+import org.eclipse.edc.connector.controlplane.contract.spi.negotiation.store.ContractNegotiationStore;
+import org.eclipse.edc.connector.controlplane.contract.spi.types.agreement.ContractAgreement;
+import org.eclipse.edc.connector.controlplane.contract.spi.types.negotiation.ContractNegotiation;
+import org.eclipse.edc.connector.controlplane.contract.spi.types.negotiation.ContractNegotiationStates;
+import org.eclipse.edc.connector.controlplane.contract.spi.types.offer.ContractOffer;
+import org.eclipse.edc.connector.controlplane.contract.spi.types.protocol.ContractNegotiationAck;
+import org.eclipse.edc.participantcontext.spi.identity.ParticipantIdentityResolver;
+import org.eclipse.edc.policy.model.Policy;
+import org.eclipse.edc.spi.message.RemoteMessageDispatcherRegistry;
+import org.eclipse.edc.spi.monitor.Monitor;
+import org.eclipse.edc.spi.response.StatusResult;
+import org.eclipse.edc.transaction.spi.NoopTransactionContext;
+import org.eclipse.edc.transaction.spi.TransactionContext;
+import org.eclipse.edc.virtual.controlplane.contract.spi.negotiation.ContractNegotiationTaskExecutor;
+import org.eclipse.edc.virtual.controlplane.contract.spi.negotiation.tasks.AgreeNegotiation;
+import org.eclipse.edc.virtual.controlplane.contract.spi.negotiation.tasks.ContractNegotiationTaskPayload;
+import org.eclipse.edc.virtual.controlplane.contract.spi.negotiation.tasks.FinalizeNegotiation;
+import org.eclipse.edc.virtual.controlplane.contract.spi.negotiation.tasks.RequestNegotiation;
+import org.eclipse.edc.virtual.controlplane.contract.spi.negotiation.tasks.SendAgreement;
+import org.eclipse.edc.virtual.controlplane.contract.spi.negotiation.tasks.SendFinalizeNegotiation;
+import org.eclipse.edc.virtual.controlplane.contract.spi.negotiation.tasks.SendRequestNegotiation;
+import org.eclipse.edc.virtual.controlplane.contract.spi.negotiation.tasks.SendVerificationNegotiation;
+import org.eclipse.edc.virtual.controlplane.contract.spi.negotiation.tasks.VerifyNegotiation;
+import org.eclipse.edc.virtual.controlplane.participantcontext.spi.ParticipantWebhookResolver;
+import org.eclipse.edc.virtual.controlplane.tasks.ProcessTaskPayload;
+import org.eclipse.edc.virtual.controlplane.tasks.TaskService;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtensionContext;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.ArgumentsProvider;
+import org.junit.jupiter.params.provider.ArgumentsSource;
+import org.mockito.ArgumentCaptor;
+
+import java.time.Clock;
+import java.util.stream.Stream;
+
+import static java.util.concurrent.CompletableFuture.completedFuture;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.eclipse.edc.connector.controlplane.contract.spi.types.negotiation.ContractNegotiation.Type.CONSUMER;
+import static org.eclipse.edc.connector.controlplane.contract.spi.types.negotiation.ContractNegotiation.Type.PROVIDER;
+import static org.eclipse.edc.connector.controlplane.contract.spi.types.negotiation.ContractNegotiationStates.AGREED;
+import static org.eclipse.edc.connector.controlplane.contract.spi.types.negotiation.ContractNegotiationStates.AGREEING;
+import static org.eclipse.edc.connector.controlplane.contract.spi.types.negotiation.ContractNegotiationStates.FINALIZED;
+import static org.eclipse.edc.connector.controlplane.contract.spi.types.negotiation.ContractNegotiationStates.FINALIZING;
+import static org.eclipse.edc.connector.controlplane.contract.spi.types.negotiation.ContractNegotiationStates.INITIAL;
+import static org.eclipse.edc.connector.controlplane.contract.spi.types.negotiation.ContractNegotiationStates.REQUESTED;
+import static org.eclipse.edc.connector.controlplane.contract.spi.types.negotiation.ContractNegotiationStates.REQUESTING;
+import static org.eclipse.edc.connector.controlplane.contract.spi.types.negotiation.ContractNegotiationStates.VERIFIED;
+import static org.eclipse.edc.connector.controlplane.contract.spi.types.negotiation.ContractNegotiationStates.VERIFYING;
+import static org.junit.jupiter.params.provider.Arguments.arguments;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+class ContractNegotiationTaskExecutorImplTest {
+
+    private final Clock clock = Clock.systemUTC();
+    private final Monitor monitor = mock();
+    private final ContractNegotiationStore negotiationStore = mock();
+    private final TaskService taskService = mock();
+    private final RemoteMessageDispatcherRegistry dispatcherRegistry = mock();
+    private final ParticipantIdentityResolver identityResolver = mock();
+    private final ParticipantWebhookResolver webhookResolver = mock();
+    private final ContractNegotiationObservable observable = mock();
+    private final ContractNegotiationPendingGuard pendingGuard = mock();
+    private final TransactionContext transactionContext = new NoopTransactionContext();
+    private final String protocolWebhookUrl = "http://protocol.webhook/url";
+    private ContractNegotiationTaskExecutor executor;
+
+    @BeforeEach
+    void setUp() {
+
+
+        when(pendingGuard.test(any())).thenReturn(false);
+
+        executor = ContractNegotiationTaskExecutorImpl.Builder.newInstance()
+                .store(negotiationStore)
+                .taskService(taskService)
+                .dispatcherRegistry(dispatcherRegistry)
+                .identityResolver(identityResolver)
+                .webhookResolver(webhookResolver)
+                .observable(observable)
+                .pendingGuard(pendingGuard)
+                .transactionContext(transactionContext)
+                .monitor(monitor)
+                .clock(clock)
+                .build();
+    }
+
+    @ParameterizedTest
+    @ArgumentsSource(StateTransitionProvider.class)
+    void handle(ContractNegotiationTaskPayload payload, ContractNegotiationStates expectedState) {
+
+        var negotiation = createContractNegotiation(payload.getProcessId(), ContractNegotiationStates.valueOf(payload.getProcessState()),
+                ContractNegotiation.Type.valueOf(payload.getProcessType()));
+
+        when(identityResolver.getParticipantId(any(), any())).thenReturn("participant-123");
+        when(dispatcherRegistry.dispatch(any(), any(), any())).thenReturn(completedFuture(StatusResult.success(ContractNegotiationAck.Builder.newInstance().build())));
+        when(webhookResolver.getWebhook(any(), any())).thenReturn(() -> protocolWebhookUrl);
+        when(negotiationStore.findById(payload.getProcessId())).thenReturn(negotiation);
+
+
+        var result = executor.handle(payload);
+
+        assertThat(result.succeeded()).isTrue();
+
+        var captor = ArgumentCaptor.forClass(ContractNegotiation.class);
+        verify(negotiationStore).save(captor.capture());
+        var savedNegotiation = captor.getValue();
+        assertThat(savedNegotiation.stateAsString()).isEqualTo(expectedState.name());
+    }
+
+    @Test
+    void handle_shouldSkipWhenNegotiationNotFound() {
+        var task = RequestNegotiation.Builder.newInstance()
+                .processId("negotiation-123")
+                .processState(INITIAL.name())
+                .processType(CONSUMER.name())
+                .build();
+
+        when(negotiationStore.findById("negotiation-123")).thenReturn(null);
+
+        var result = executor.handle(task);
+
+        assertThat(result.failed()).isTrue();
+        assertThat(result.getFailureDetail()).contains("not found");
+    }
+
+    @Test
+    void handle_shouldSkipWhenNegotiationIsInFinalState() {
+        var negotiation = createContractNegotiation("negotiation-123", ContractNegotiationStates.TERMINATED);
+
+        var task = RequestNegotiation.Builder.newInstance()
+                .processId("negotiation-123")
+                .processState(INITIAL.name())
+                .processType(CONSUMER.name())
+                .build();
+
+        when(negotiationStore.findById("negotiation-123")).thenReturn(negotiation);
+
+        var result = executor.handle(task);
+
+        assertThat(result.succeeded()).isTrue();
+        verify(taskService, never()).create(any());
+    }
+
+    @Test
+    void handle_shouldSkipWhenStateDoesNotMatch() {
+        var negotiation = createContractNegotiation("negotiation-123", REQUESTING);
+
+        var task = RequestNegotiation.Builder.newInstance()
+                .processId("negotiation-123")
+                .processState(INITIAL.name())
+                .processType(CONSUMER.name())
+                .build();
+
+        when(negotiationStore.findById("negotiation-123")).thenReturn(negotiation);
+
+        var result = executor.handle(task);
+
+        assertThat(result.succeeded()).isTrue();
+        verify(taskService, never()).create(any());
+    }
+
+    @Test
+    void handle_shouldSkipWhenPendingGuardMatches() {
+        var negotiation = createContractNegotiation("negotiation-123", INITIAL);
+
+        var task = RequestNegotiation.Builder.newInstance()
+                .processId("negotiation-123")
+                .processState(INITIAL.name())
+                .processType(CONSUMER.name())
+                .build();
+
+        when(negotiationStore.findById("negotiation-123")).thenReturn(negotiation);
+        when(pendingGuard.test(negotiation)).thenReturn(true);
+
+        var result = executor.handle(task);
+
+        assertThat(result.succeeded()).isTrue();
+        verify(taskService, never()).create(any());
+    }
+
+    @Test
+    void handle_shouldSkipWhenNegotiationTypeDoesNotMatch() {
+        var negotiation = createContractNegotiation("negotiation-123", INITIAL, PROVIDER);
+
+        var task = RequestNegotiation.Builder.newInstance()
+                .processId("negotiation-123")
+                .processState(INITIAL.name())
+                .processType(CONSUMER.name())
+                .build();
+
+        when(negotiationStore.findById("negotiation-123")).thenReturn(negotiation);
+
+        var result = executor.handle(task);
+
+        assertThat(result.succeeded()).isTrue();
+    }
+
+    @Test
+    void handle_shouldTransitionToTerminatedOnFatalError() {
+        var negotiation = createContractNegotiation("negotiation-123", REQUESTING);
+
+
+        var task = RequestNegotiation.Builder.newInstance()
+                .processId("negotiation-123")
+                .processState(REQUESTING.name())
+                .processType(CONSUMER.name())
+                .build();
+
+        when(negotiationStore.findById("negotiation-123")).thenReturn(negotiation);
+        when(webhookResolver.getWebhook("participant-123", "DSP")).thenReturn(null);
+
+        var result = executor.handle(task);
+
+        assertThat(result.succeeded()).isTrue();
+        verify(negotiationStore).save(any());
+    }
+
+    private ContractNegotiation createContractNegotiation(String id, ContractNegotiationStates state) {
+        return createContractNegotiation(id, state, CONSUMER);
+    }
+
+    private ContractNegotiation createContractNegotiation(String id, ContractNegotiationStates state, ContractNegotiation.Type type) {
+        return ContractNegotiation.Builder.newInstance()
+                .id(id)
+                .type(type)
+                .state(state.code())
+                .participantContextId("participant-123")
+                .protocol("DSP")
+                .counterPartyAddress("http://counter-party")
+                .counterPartyId("counter-party-id")
+                .contractOffer(ContractOffer.Builder.newInstance()
+                        .id("offer-123")
+                        .assetId("asset-123")
+                        .policy(Policy.Builder.newInstance().build())
+                        .build())
+                .contractAgreement(ContractAgreement.Builder.newInstance()
+                        .agreementId("agreement-123")
+                        .assetId("asset-123")
+                        .policy(Policy.Builder.newInstance().build())
+                        .consumerId("consumer-123")
+                        .providerId("provider-123")
+                        .build())
+                .build();
+    }
+
+    public static class StateTransitionProvider implements ArgumentsProvider {
+
+        protected <T extends ProcessTaskPayload, B extends ProcessTaskPayload.Builder<T, B>> B baseBuilder(B builder, String id, ContractNegotiationStates state, ContractNegotiation.Type type) {
+            return builder.processId(id)
+                    .processState(state.name())
+                    .processType(type.name());
+        }
+
+        @Override
+        public Stream<? extends Arguments> provideArguments(ExtensionContext context) {
+
+            return Stream.of(
+                    arguments(baseBuilder(RequestNegotiation.Builder.newInstance(), "id", INITIAL, CONSUMER).build(), REQUESTING),
+                    arguments(baseBuilder(SendRequestNegotiation.Builder.newInstance(), "id", REQUESTING, CONSUMER).build(), REQUESTED),
+                    arguments(baseBuilder(VerifyNegotiation.Builder.newInstance(), "id", AGREED, CONSUMER).build(), VERIFYING),
+                    arguments(baseBuilder(SendVerificationNegotiation.Builder.newInstance(), "id", VERIFYING, CONSUMER).build(), VERIFIED),
+                    arguments(baseBuilder(AgreeNegotiation.Builder.newInstance(), "id", REQUESTED, PROVIDER).build(), AGREEING),
+                    arguments(baseBuilder(SendAgreement.Builder.newInstance(), "id", AGREEING, PROVIDER).build(), AGREED),
+                    arguments(baseBuilder(FinalizeNegotiation.Builder.newInstance(), "id", VERIFIED, PROVIDER).build(), FINALIZING),
+                    arguments(baseBuilder(SendFinalizeNegotiation.Builder.newInstance(), "id", FINALIZING, PROVIDER).build(), FINALIZED)
+            );
+        }
+    }
+}

--- a/core/transfer-process-manager/src/main/java/org/eclipse/edc/virtual/controlplane/transfer/process/TransferManagerExtension.java
+++ b/core/transfer-process-manager/src/main/java/org/eclipse/edc/virtual/controlplane/transfer/process/TransferManagerExtension.java
@@ -99,4 +99,5 @@ public class TransferManagerExtension implements ServiceExtension {
                 .policyArchive(policyArchive)
                 .build();
     }
+
 }

--- a/core/transfer-process-manager/src/main/java/org/eclipse/edc/virtual/controlplane/transfer/process/VirtualTransferProcessManager.java
+++ b/core/transfer-process-manager/src/main/java/org/eclipse/edc/virtual/controlplane/transfer/process/VirtualTransferProcessManager.java
@@ -99,9 +99,8 @@ public class VirtualTransferProcessManager implements TransferProcessManager {
 
     protected void update(TransferProcess entity) {
         store.save(entity);
-        monitor.debug(() -> "[%s] %s %s is now in state %s"
-                .formatted(this.getClass().getSimpleName(), entity.getClass().getSimpleName(),
-                        entity.getId(), entity.stateAsString()));
+        monitor.debug(() -> "[%s] %s %s is now in state %s".formatted(entity.getType(), entity.getClass().getSimpleName(),
+                entity.getId(), entity.stateAsString()));
     }
 
     @Override

--- a/core/transfer-process-task-executor/build.gradle.kts
+++ b/core/transfer-process-task-executor/build.gradle.kts
@@ -1,0 +1,30 @@
+/*
+ *  Copyright (c) 2026 Metaform Systems, Inc.
+ *
+ *  This program and the accompanying materials are made available under the
+ *  terms of the Apache License, Version 2.0 which is available at
+ *  https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Contributors:
+ *       Metaform Systems, Inc. - initial API and implementation
+ *
+ */
+
+plugins {
+    `java-library`
+}
+
+dependencies {
+    api(project(":spi:v-core-spi"))
+    api(project(":spi:v-task-spi"))
+    api(libs.edc.spi.core)
+    api(libs.edc.spi.transaction)
+    api(libs.edc.spi.protocol)
+    api(libs.edc.spi.transfer)
+    api(libs.edc.spi.policy)
+    implementation(libs.opentelemetry.instrumentation.annotations)
+    testImplementation(libs.edc.junit)
+}
+

--- a/core/transfer-process-task-executor/src/main/java/org/eclipse/edc/virtual/controlplane/transfer/process/task/TransferProcessTaskExecutorImpl.java
+++ b/core/transfer-process-task-executor/src/main/java/org/eclipse/edc/virtual/controlplane/transfer/process/task/TransferProcessTaskExecutorImpl.java
@@ -1,0 +1,534 @@
+/*
+ *  Copyright (c) 2026 Metaform Systems, Inc.
+ *
+ *  This program and the accompanying materials are made available under the
+ *  terms of the Apache License, Version 2.0 which is available at
+ *  https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Contributors:
+ *       Metaform Systems, Inc. - initial API and implementation
+ *
+ */
+
+package org.eclipse.edc.virtual.controlplane.transfer.process.task;
+
+import org.eclipse.edc.connector.controlplane.asset.spi.index.DataAddressResolver;
+import org.eclipse.edc.connector.controlplane.policy.spi.store.PolicyArchive;
+import org.eclipse.edc.connector.controlplane.transfer.spi.TransferProcessPendingGuard;
+import org.eclipse.edc.connector.controlplane.transfer.spi.flow.DataFlowController;
+import org.eclipse.edc.connector.controlplane.transfer.spi.observe.TransferProcessObservable;
+import org.eclipse.edc.connector.controlplane.transfer.spi.observe.TransferProcessStartedData;
+import org.eclipse.edc.connector.controlplane.transfer.spi.store.TransferProcessStore;
+import org.eclipse.edc.connector.controlplane.transfer.spi.types.TransferProcess;
+import org.eclipse.edc.connector.controlplane.transfer.spi.types.TransferProcessStates;
+import org.eclipse.edc.connector.controlplane.transfer.spi.types.protocol.TransferCompletionMessage;
+import org.eclipse.edc.connector.controlplane.transfer.spi.types.protocol.TransferProcessAck;
+import org.eclipse.edc.connector.controlplane.transfer.spi.types.protocol.TransferRemoteMessage;
+import org.eclipse.edc.connector.controlplane.transfer.spi.types.protocol.TransferRequestMessage;
+import org.eclipse.edc.connector.controlplane.transfer.spi.types.protocol.TransferStartMessage;
+import org.eclipse.edc.connector.controlplane.transfer.spi.types.protocol.TransferSuspensionMessage;
+import org.eclipse.edc.connector.controlplane.transfer.spi.types.protocol.TransferTerminationMessage;
+import org.eclipse.edc.spi.message.RemoteMessageDispatcherRegistry;
+import org.eclipse.edc.spi.monitor.Monitor;
+import org.eclipse.edc.spi.response.StatusResult;
+import org.eclipse.edc.spi.security.Vault;
+import org.eclipse.edc.spi.types.domain.DataAddress;
+import org.eclipse.edc.transaction.spi.TransactionContext;
+import org.eclipse.edc.virtual.controlplane.participantcontext.spi.ParticipantWebhookResolver;
+import org.eclipse.edc.virtual.controlplane.tasks.ProcessTaskPayload;
+import org.eclipse.edc.virtual.controlplane.tasks.Task;
+import org.eclipse.edc.virtual.controlplane.tasks.TaskService;
+import org.eclipse.edc.virtual.controlplane.transfer.spi.TransferProcessTaskExecutor;
+import org.eclipse.edc.virtual.controlplane.transfer.spi.tasks.CompleteDataFlow;
+import org.eclipse.edc.virtual.controlplane.transfer.spi.tasks.PrepareTransfer;
+import org.eclipse.edc.virtual.controlplane.transfer.spi.tasks.ResumeDataFlow;
+import org.eclipse.edc.virtual.controlplane.transfer.spi.tasks.SendTransferRequest;
+import org.eclipse.edc.virtual.controlplane.transfer.spi.tasks.SignalDataflowStarted;
+import org.eclipse.edc.virtual.controlplane.transfer.spi.tasks.StartDataflow;
+import org.eclipse.edc.virtual.controlplane.transfer.spi.tasks.SuspendDataFlow;
+import org.eclipse.edc.virtual.controlplane.transfer.spi.tasks.TerminateDataFlow;
+import org.eclipse.edc.virtual.controlplane.transfer.spi.tasks.TransferProcessTaskPayload;
+
+import java.time.Clock;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Optional;
+import java.util.function.Function;
+
+import static org.eclipse.edc.connector.controlplane.transfer.spi.types.TransferProcess.Type.CONSUMER;
+import static org.eclipse.edc.connector.controlplane.transfer.spi.types.TransferProcess.Type.PROVIDER;
+import static org.eclipse.edc.connector.controlplane.transfer.spi.types.TransferProcessStates.REQUESTED;
+import static org.eclipse.edc.connector.controlplane.transfer.spi.types.TransferProcessStates.from;
+import static org.eclipse.edc.spi.response.ResponseStatus.FATAL_ERROR;
+import static org.eclipse.edc.spi.types.domain.DataAddress.EDC_DATA_ADDRESS_SECRET;
+
+public class TransferProcessTaskExecutorImpl implements TransferProcessTaskExecutor {
+
+    private final Map<Class<? extends TransferProcessTaskPayload>, Handler> handlers = new HashMap<>();
+    private TransferProcessStore store;
+    private TaskService taskService;
+    private TransactionContext transactionContext;
+    private DataFlowController dataFlowController;
+    private RemoteMessageDispatcherRegistry dispatcherRegistry;
+    private ParticipantWebhookResolver webhookResolver;
+    private Vault vault;
+    private DataAddressResolver addressResolver;
+    private TransferProcessObservable observable;
+    private PolicyArchive policyArchive;
+    private TransferProcessPendingGuard pendingGuard;
+    private Monitor monitor;
+    private Clock clock = Clock.systemUTC();
+
+    private TransferProcessTaskExecutorImpl() {
+        registerStateHandlers();
+    }
+
+    private void registerStateHandlers() {
+        handlers.put(PrepareTransfer.class, new Handler(this::handlePrepareTransfer, null));
+        handlers.put(SendTransferRequest.class, new Handler(this::handleSendRequest, CONSUMER));
+        handlers.put(StartDataflow.class, new Handler(this::handleStartDataflow, PROVIDER));
+        handlers.put(SignalDataflowStarted.class, new Handler(this::handleSignalStartedDataflow, CONSUMER));
+        handlers.put(SuspendDataFlow.class, new Handler(this::handleSuspendDataflow, null));
+        handlers.put(ResumeDataFlow.class, new Handler(this::handleResumeDataflow, null));
+        handlers.put(TerminateDataFlow.class, new Handler(this::handleTerminateDataflow, null));
+        handlers.put(CompleteDataFlow.class, new Handler(this::handleCompleteDataflow, null));
+    }
+
+    @Override
+    public StatusResult<Void> handle(TransferProcessTaskPayload task) {
+        return handleTask(task);
+    }
+
+    private void storeTask(TransferProcessTaskPayload payload) {
+
+        var task = Task.Builder.newInstance().at(clock.millis())
+                .payload(payload)
+                .build();
+        taskService.create(task);
+    }
+
+    private StatusResult<Void> handleTask(TransferProcessTaskPayload task) {
+        var expectedState = TransferProcessStates.valueOf(task.getProcessState());
+        var transferId = task.getProcessId();
+        return transactionContext.execute(() -> {
+            var transferResult = loadTransferProcess(transferId);
+            if (transferResult.failed()) {
+                return StatusResult.failure(FATAL_ERROR, transferResult.getFailureDetail());
+            }
+
+            var negotiation = transferResult.getContent();
+            if (TransferProcessStates.isFinal(negotiation.getState())) {
+                monitor.debug("Skipping transfer process with id '%s' is in final state '%s'".formatted(transferId, from(negotiation.getState())));
+                return StatusResult.success();
+            }
+
+            if (negotiation.getState() != expectedState.code()) {
+                monitor.warning("Skipping transfer process with id '%s' is in state '%s', expected '%s'".formatted(transferId, from(negotiation.getState()), expectedState));
+                return StatusResult.success();
+            }
+
+            var handler = handlers.get(task.getClass());
+            if (handler == null) {
+                monitor.debug("No handler for task '%s' in transfer process with id '%s'".formatted(task.getClass().getSimpleName(), transferId));
+                return StatusResult.success();
+            }
+
+            if (handler.type != null && handler.type != negotiation.getType()) {
+                var msg = "Expected type '%s' for state '%s', but got '%s' for transfer process %s".formatted(handler.type, expectedState, negotiation.getType(), transferId);
+                monitor.severe(msg);
+                return StatusResult.failure(FATAL_ERROR, msg);
+            }
+
+            if (pendingGuard.test(negotiation)) {
+                monitor.debug("Skipping '%s' for transfer process with id '%s' due matched guard".formatted(expectedState, transferId));
+                return StatusResult.success();
+            }
+
+            return handler.function.apply(negotiation);
+        });
+
+    }
+
+    private StatusResult<Void> handlePrepareTransfer(TransferProcess process) {
+        var contractId = process.getContractId();
+        var policy = policyArchive.findPolicyForContract(contractId);
+
+        if (policy == null) {
+            transitionToTerminating(process, "Policy not found for contract: " + contractId);
+            return StatusResult.failure(FATAL_ERROR, "Policy not found for contract: " + contractId);
+        }
+
+        if (process.getType() == CONSUMER) {
+
+            var provisioning = dataFlowController.prepare(process, policy);
+
+            if (provisioning.failed()) {
+                // with the upcoming data-plane signaling data-plane will be mandatory also on consumer side
+                // so in this case the transfer will be terminated straight away
+                transitionToRequesting(process);
+            } else {
+                var response = provisioning.getContent();
+                process.setDataPlaneId(response.getDataPlaneId());
+                if (response.isProvisioning()) {
+                    process.transitionProvisioningRequested();
+                } else {
+                    process.updateDestination(response.getDataAddress());
+                    transitionToRequesting(process);
+                }
+            }
+
+        } else {
+            var assetId = process.getAssetId();
+            var dataAddress = addressResolver.resolveForAsset(assetId);
+            if (dataAddress == null) {
+                transitionToStarting(process);
+                return StatusResult.success();
+            }
+            // default the content address to the asset address; this may be overridden during provisioning
+            process.setContentDataAddress(dataAddress);
+
+            transitionToStarting(process);
+        }
+
+        return StatusResult.success();
+    }
+
+    private StatusResult<Void> handleStartDataflow(TransferProcess process) {
+        var policy = policyArchive.findPolicyForContract(process.getContractId());
+
+        var result = dataFlowController.start(process, policy);
+
+        if (result.failed()) {
+            transitionToTerminating(process, result.getFailureDetail());
+            return StatusResult.failure(FATAL_ERROR, result.getFailureDetail());
+        }
+        var dataFlowResponse = result.getContent();
+        var messageBuilder = TransferStartMessage.Builder.newInstance().dataAddress(dataFlowResponse.getDataAddress());
+        process.setDataPlaneId(dataFlowResponse.getDataPlaneId());
+        return dispatch(messageBuilder, process, Object.class)
+                .onSuccess(c -> transitionToStarted(process))
+                .mapEmpty();
+    }
+
+    private StatusResult<Void> handleSignalStartedDataflow(TransferProcess process) {
+        return dataFlowController.started(process)
+                .onSuccess(v -> transitionToStarted(process));
+    }
+
+    private StatusResult<Void> handleSuspendDataflow(TransferProcess process) {
+        if (process.getType() == PROVIDER) {
+            var result = dataFlowController.suspend(process);
+            if (result.failed()) {
+                transitionToTerminating(process, "Failed to suspend transfer process: " + result.getFailureDetail());
+                return StatusResult.failure(FATAL_ERROR, result.getFailureDetail());
+            }
+        }
+        if (process.suspensionWasRequestedByCounterParty()) {
+            transitionToSuspended(process);
+            return StatusResult.success();
+        } else {
+            return dispatch(TransferSuspensionMessage.Builder.newInstance().reason(process.getErrorDetail()), process, Object.class)
+                    .onSuccess(c -> transitionToSuspended(process))
+                    .mapEmpty();
+        }
+    }
+
+    private StatusResult<Void> handleResumeDataflow(TransferProcess process) {
+        if (process.getType() == CONSUMER) {
+            return handleConsumerResumeDataflow(process);
+        } else {
+            return handleStartDataflow(process);
+        }
+    }
+
+    private StatusResult<Void> handleConsumerResumeDataflow(TransferProcess process) {
+        var messageBuilder = TransferStartMessage.Builder.newInstance();
+
+        return dispatch(messageBuilder, process, Object.class)
+                .onSuccess(c -> transitionToResumed(process))
+                .mapEmpty();
+    }
+
+    private StatusResult<Void> handleTerminateDataflow(TransferProcess process) {
+        if (process.getType() == CONSUMER && process.getState() < REQUESTED.code()) {
+            transitionToTerminated(process);
+            return StatusResult.success();
+        }
+        var result = dataFlowController.terminate(process);
+
+        if (result.failed()) {
+            transitionToTerminated(process, "Failed to terminate transfer process: " + result.getFailureDetail());
+            return StatusResult.failure(FATAL_ERROR, result.getFailureDetail());
+        }
+
+        if (process.terminationWasRequestedByCounterParty()) {
+            transitionToTerminated(process);
+            return StatusResult.success();
+        }
+        return dispatch(TransferTerminationMessage.Builder.newInstance().reason(process.getErrorDetail()), process, Object.class)
+                .onSuccess(c -> transitionToTerminated(process))
+                .mapEmpty();
+    }
+
+    private StatusResult<Void> handleCompleteDataflow(TransferProcess process) {
+        if (process.completionWasRequestedByCounterParty()) {
+            var result = dataFlowController.terminate(process);
+            if (result.failed()) {
+                transitionToTerminated(process, "Failed to terminate transfer process: " + result.getFailureDetail());
+                return StatusResult.failure(FATAL_ERROR, result.getFailureDetail());
+            }
+            transitionToCompleted(process);
+            return StatusResult.success();
+        } else {
+            return dispatch(TransferCompletionMessage.Builder.newInstance(), process, Object.class)
+                    .onSuccess(c -> transitionToCompleted(process))
+                    .mapEmpty();
+        }
+    }
+
+    private StatusResult<Void> handleSendRequest(TransferProcess process) {
+        var originalDestination = process.getDataDestination();
+        var callbackAddress = webhookResolver.getWebhook(process.getParticipantContextId(), process.getProtocol());
+        var agreementId = policyArchive.getAgreementIdForContract(process.getContractId());
+
+        if (callbackAddress != null) {
+            var dataDestination = Optional.ofNullable(originalDestination)
+                    .map(DataAddress::getKeyName)
+                    .map(vault::resolveSecret)
+                    .map(secret -> DataAddress.Builder.newInstance().properties(originalDestination.getProperties()).property(EDC_DATA_ADDRESS_SECRET, secret).build())
+                    .orElse(originalDestination);
+
+            var messageBuilder = TransferRequestMessage.Builder.newInstance()
+                    .callbackAddress(callbackAddress.url())
+                    .dataDestination(dataDestination)
+                    .transferType(process.getTransferType())
+                    .contractId(agreementId);
+
+            return dispatch(messageBuilder, process, TransferProcessAck.class)
+                    .onSuccess(ack -> transitionToRequested(process, ack))
+                    .mapEmpty();
+
+        } else {
+            transitionToTerminated(process, "No callback address found for protocol: " + process.getProtocol());
+            return StatusResult.failure(FATAL_ERROR, "No callback address found for protocol: " + process.getProtocol());
+        }
+    }
+
+    private StatusResult<TransferProcess> loadTransferProcess(String transferProcessId) {
+        var transferProcess = store.findById(transferProcessId);
+        if (transferProcess == null) {
+            return StatusResult.failure(FATAL_ERROR, "Transfer process with id '%s' not found".formatted(transferProcessId));
+        }
+        return StatusResult.success(transferProcess);
+    }
+
+    protected void update(TransferProcess entity) {
+        store.save(entity);
+        monitor.debug(() -> "[%s] %s %s is now in state %s"
+                .formatted(entity.getType(), entity.getClass().getSimpleName(),
+                        entity.getId(), entity.stateAsString()));
+    }
+
+    private void transitionToTerminated(TransferProcess process, String message) {
+        process.setErrorDetail(message);
+        monitor.warning(message);
+        transitionToTerminated(process);
+    }
+
+    private void transitionToRequesting(TransferProcess process) {
+        process.transitionRequesting();
+        update(process);
+
+        var task = baseBuilder(SendTransferRequest.Builder.newInstance(), process).build();
+        storeTask(task);
+    }
+
+    private void transitionToTerminated(TransferProcess process) {
+        process.transitionTerminated();
+        update(process);
+        observable.invokeForEach(l -> l.terminated(process));
+    }
+
+    private void transitionToTerminating(TransferProcess process, String message, Throwable... errors) {
+        monitor.warning(message, errors);
+        process.transitionTerminating(message);
+        update(process);
+    }
+
+    private void transitionToStarting(TransferProcess transferProcess) {
+        transferProcess.transitionStarting();
+        update(transferProcess);
+
+        var task = baseBuilder(StartDataflow.Builder.newInstance(), transferProcess).build();
+        storeTask(task);
+    }
+
+    private void transitionToStarted(TransferProcess transferProcess) {
+        transferProcess.transitionStarted();
+        update(transferProcess);
+        observable.invokeForEach(l -> l.started(transferProcess, TransferProcessStartedData.Builder.newInstance().build()));
+    }
+
+    private void transitionToCompleted(TransferProcess transferProcess) {
+        transferProcess.transitionCompleted();
+        update(transferProcess);
+        observable.invokeForEach(l -> l.completed(transferProcess));
+    }
+
+    private void transitionToSuspended(TransferProcess process) {
+        process.transitionSuspended();
+        update(process);
+        observable.invokeForEach(l -> l.suspended(process));
+    }
+
+    private void transitionToRequested(TransferProcess transferProcess, TransferProcessAck ack) {
+        transferProcess.transitionRequested();
+        transferProcess.setCorrelationId(ack.getProviderPid());
+        update(transferProcess);
+        observable.invokeForEach(l -> l.requested(transferProcess));
+    }
+
+    private void transitionToResumed(TransferProcess process) {
+        process.transitionResumed();
+        update(process);
+    }
+
+    private <T> StatusResult<T> dispatch(TransferRemoteMessage.Builder<?, ?> messageBuilder,
+                                         TransferProcess process, Class<T> responseType) {
+
+        var contractPolicy = policyArchive.findPolicyForContract(process.getContractId());
+
+        messageBuilder.protocol(process.getProtocol())
+                .counterPartyAddress(process.getCounterPartyAddress())
+                .processId(Optional.ofNullable(process.getCorrelationId()).orElse(process.getId()))
+                .policy(contractPolicy);
+
+        if (process.lastSentProtocolMessage() != null) {
+            messageBuilder.id(process.lastSentProtocolMessage());
+        }
+
+        if (process.getType() == PROVIDER) {
+            messageBuilder.consumerPid(process.getCorrelationId())
+                    .providerPid(process.getId())
+                    .counterPartyId(contractPolicy.getAssignee());
+        } else {
+            messageBuilder.consumerPid(process.getId())
+                    .providerPid(process.getCorrelationId())
+                    .counterPartyId(contractPolicy.getAssigner());
+        }
+
+        var message = messageBuilder.build();
+
+        process.lastSentProtocolMessage(message.getId());
+
+        try {
+            return dispatcherRegistry.dispatch(process.getParticipantContextId(), responseType, message).get();
+        } catch (Exception e) {
+            return StatusResult.failure(FATAL_ERROR, "Failed to dispatch message: %s".formatted(e.getMessage()));
+        }
+    }
+
+    protected <T extends ProcessTaskPayload, B extends ProcessTaskPayload.Builder<T, B>> B baseBuilder(B builder, TransferProcess transferProcess) {
+        return builder.processId(transferProcess.getId())
+                .processState(transferProcess.stateAsString())
+                .processType(transferProcess.getType().name());
+    }
+
+    private record Handler(Function<TransferProcess, StatusResult<Void>> function, TransferProcess.Type type) {
+
+    }
+
+    public static class Builder {
+
+        private final TransferProcessTaskExecutorImpl manager;
+
+        private Builder() {
+            manager = new TransferProcessTaskExecutorImpl();
+        }
+
+        public static Builder newInstance() {
+            return new Builder();
+        }
+
+        public TransferProcessTaskExecutor build() {
+            Objects.requireNonNull(manager.dataFlowController, "dataFlowController cannot be null");
+            Objects.requireNonNull(manager.dispatcherRegistry, "dispatcherRegistry cannot be null");
+            Objects.requireNonNull(manager.observable, "observable cannot be null");
+            Objects.requireNonNull(manager.policyArchive, "policyArchive cannot be null");
+            Objects.requireNonNull(manager.addressResolver, "addressResolver cannot be null");
+            Objects.requireNonNull(manager.store, "store");
+            Objects.requireNonNull(manager.taskService, "taskService");
+            Objects.requireNonNull(manager.monitor, "monitor");
+            Objects.requireNonNull(manager.transactionContext, "transactionContext cannot be null");
+            return manager;
+        }
+
+        public Builder dataFlowController(DataFlowController dataFlowController) {
+            manager.dataFlowController = dataFlowController;
+            return this;
+        }
+
+        public Builder dispatcherRegistry(RemoteMessageDispatcherRegistry registry) {
+            manager.dispatcherRegistry = registry;
+            return this;
+        }
+
+        public Builder vault(Vault vault) {
+            manager.vault = vault;
+            return this;
+        }
+
+        public Builder store(TransferProcessStore store) {
+            manager.store = store;
+            return this;
+        }
+
+        public Builder taskService(TaskService taskService) {
+            manager.taskService = taskService;
+            return this;
+        }
+
+        public Builder transactionContext(TransactionContext transactionContext) {
+            manager.transactionContext = transactionContext;
+            return this;
+        }
+
+        public Builder monitor(Monitor monitor) {
+            manager.monitor = monitor;
+            return this;
+        }
+
+        public Builder observable(TransferProcessObservable observable) {
+            manager.observable = observable;
+            return this;
+        }
+
+        public Builder policyArchive(PolicyArchive policyArchive) {
+            manager.policyArchive = policyArchive;
+            return this;
+        }
+
+        public Builder addressResolver(DataAddressResolver addressResolver) {
+            manager.addressResolver = addressResolver;
+            return this;
+        }
+
+        public Builder webhookResolver(ParticipantWebhookResolver webhookResolver) {
+            manager.webhookResolver = webhookResolver;
+            return this;
+        }
+
+        public Builder pendingGuard(TransferProcessPendingGuard pendingGuard) {
+            manager.pendingGuard = pendingGuard;
+            return this;
+        }
+
+        public Builder clock(Clock clock) {
+            manager.clock = clock;
+            return this;
+        }
+    }
+}

--- a/core/transfer-process-task-executor/src/main/java/org/eclipse/edc/virtual/controlplane/transfer/process/task/TransferTaskExecutorExtension.java
+++ b/core/transfer-process-task-executor/src/main/java/org/eclipse/edc/virtual/controlplane/transfer/process/task/TransferTaskExecutorExtension.java
@@ -1,0 +1,122 @@
+/*
+ *  Copyright (c) 2026 Metaform Systems, Inc.
+ *
+ *  This program and the accompanying materials are made available under the
+ *  terms of the Apache License, Version 2.0 which is available at
+ *  https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Contributors:
+ *       Metaform Systems, Inc. - initial API and implementation
+ *
+ */
+
+package org.eclipse.edc.virtual.controlplane.transfer.process.task;
+
+import org.eclipse.edc.connector.controlplane.asset.spi.index.DataAddressResolver;
+import org.eclipse.edc.connector.controlplane.policy.spi.store.PolicyArchive;
+import org.eclipse.edc.connector.controlplane.transfer.spi.TransferProcessPendingGuard;
+import org.eclipse.edc.connector.controlplane.transfer.spi.flow.DataFlowController;
+import org.eclipse.edc.connector.controlplane.transfer.spi.observe.TransferProcessObservable;
+import org.eclipse.edc.connector.controlplane.transfer.spi.store.TransferProcessStore;
+import org.eclipse.edc.runtime.metamodel.annotation.Extension;
+import org.eclipse.edc.runtime.metamodel.annotation.Inject;
+import org.eclipse.edc.runtime.metamodel.annotation.Provider;
+import org.eclipse.edc.spi.command.CommandHandlerRegistry;
+import org.eclipse.edc.spi.message.RemoteMessageDispatcherRegistry;
+import org.eclipse.edc.spi.monitor.Monitor;
+import org.eclipse.edc.spi.security.Vault;
+import org.eclipse.edc.spi.system.ServiceExtension;
+import org.eclipse.edc.spi.types.TypeManager;
+import org.eclipse.edc.transaction.spi.TransactionContext;
+import org.eclipse.edc.virtual.controlplane.participantcontext.spi.ParticipantWebhookResolver;
+import org.eclipse.edc.virtual.controlplane.tasks.TaskService;
+import org.eclipse.edc.virtual.controlplane.transfer.process.task.command.CompleteTransferCommandHandler;
+import org.eclipse.edc.virtual.controlplane.transfer.process.task.command.ResumeTransferCommandHandler;
+import org.eclipse.edc.virtual.controlplane.transfer.process.task.command.SuspendTransferCommandHandler;
+import org.eclipse.edc.virtual.controlplane.transfer.process.task.command.TerminateTransferCommandHandler;
+import org.eclipse.edc.virtual.controlplane.transfer.spi.TransferProcessTaskExecutor;
+
+import java.time.Clock;
+
+import static org.eclipse.edc.virtual.controlplane.transfer.process.task.TransferTaskExecutorExtension.NAME;
+
+
+@Extension(NAME)
+public class TransferTaskExecutorExtension implements ServiceExtension {
+
+    public static final String NAME = "EDC-V Transfer Task Executor Extension";
+    @Inject
+    private TransferProcessStore store;
+
+    @Inject
+    private TransactionContext transactionContext;
+
+    @Inject
+    private TransferProcessPendingGuard pendingGuard;
+
+    @Inject
+    private Monitor monitor;
+
+    @Inject
+    private ParticipantWebhookResolver webhookResolver;
+
+    @Inject
+    private RemoteMessageDispatcherRegistry dispatcherRegistry;
+
+    @Inject
+    private TransferProcessObservable observable;
+
+    @Inject
+    private PolicyArchive policyArchive;
+
+    @Inject
+    private DataFlowController dataFlowController;
+
+    @Inject
+    private DataAddressResolver dataAddressResolver;
+
+    @Inject
+    private Vault vault;
+
+    @Inject
+    private Clock clock;
+
+    @Inject
+    private TaskService taskService;
+
+    @Inject
+    private CommandHandlerRegistry commandHandlerRegistry;
+
+    @Inject
+    private TypeManager typeManager;
+
+    // temporary workaround to register command handlers for overriding the default ones
+    @Override
+    public void prepare() {
+        commandHandlerRegistry.register(new SuspendTransferCommandHandler(store, taskService, clock));
+        commandHandlerRegistry.register(new ResumeTransferCommandHandler(store, taskService, clock));
+        commandHandlerRegistry.register(new TerminateTransferCommandHandler(store, taskService, clock));
+        commandHandlerRegistry.register(new CompleteTransferCommandHandler(store, taskService, clock));
+    }
+
+    @Provider
+    public TransferProcessTaskExecutor transferProcessTaskExecutor() {
+        return TransferProcessTaskExecutorImpl.Builder.newInstance()
+                .store(store)
+                .transactionContext(transactionContext)
+                .dataFlowController(dataFlowController)
+                .dispatcherRegistry(dispatcherRegistry)
+                .webhookResolver(webhookResolver)
+                .vault(vault)
+                .addressResolver(dataAddressResolver)
+                .monitor(monitor)
+                .pendingGuard(pendingGuard)
+                .observable(observable)
+                .policyArchive(policyArchive)
+                .taskService(taskService)
+                .clock(clock)
+                .build();
+    }
+}

--- a/core/transfer-process-task-executor/src/main/java/org/eclipse/edc/virtual/controlplane/transfer/process/task/command/CompleteTransferCommandHandler.java
+++ b/core/transfer-process-task-executor/src/main/java/org/eclipse/edc/virtual/controlplane/transfer/process/task/command/CompleteTransferCommandHandler.java
@@ -1,0 +1,71 @@
+/*
+ *  Copyright (c) 2026 Metaform Systems, Inc.
+ *
+ *  This program and the accompanying materials are made available under the
+ *  terms of the Apache License, Version 2.0 which is available at
+ *  https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Contributors:
+ *       Metaform Systems, Inc. - initial API and implementation
+ *
+ */
+
+package org.eclipse.edc.virtual.controlplane.transfer.process.task.command;
+
+import org.eclipse.edc.connector.controlplane.transfer.spi.store.TransferProcessStore;
+import org.eclipse.edc.connector.controlplane.transfer.spi.types.TransferProcess;
+import org.eclipse.edc.connector.controlplane.transfer.spi.types.TransferProcessStates;
+import org.eclipse.edc.connector.controlplane.transfer.spi.types.command.CompleteTransferCommand;
+import org.eclipse.edc.spi.command.EntityCommandHandler;
+import org.eclipse.edc.virtual.controlplane.tasks.Task;
+import org.eclipse.edc.virtual.controlplane.tasks.TaskService;
+import org.eclipse.edc.virtual.controlplane.transfer.spi.tasks.CompleteDataFlow;
+
+import java.time.Clock;
+
+/**
+ * Completes a transfer process and sends it to the {@link TransferProcessStates#COMPLETED} state.
+ */
+public class CompleteTransferCommandHandler extends EntityCommandHandler<CompleteTransferCommand, TransferProcess> {
+
+    private final TaskService taskService;
+    private final Clock clock;
+
+    public CompleteTransferCommandHandler(TransferProcessStore store, TaskService taskService, Clock clock) {
+        super(store);
+        this.taskService = taskService;
+        this.clock = clock;
+    }
+
+    @Override
+    public Class<CompleteTransferCommand> getType() {
+        return CompleteTransferCommand.class;
+    }
+
+    @Override
+    protected boolean modify(TransferProcess process, CompleteTransferCommand command) {
+        if (process.canBeCompleted()) {
+            process.transitionCompleting();
+            return true;
+        }
+        return false;
+    }
+
+    @Override
+    public void postActions(TransferProcess entity, CompleteTransferCommand command) {
+
+        var payload = CompleteDataFlow.Builder.newInstance().processId(entity.getId())
+                .processState(entity.stateAsString())
+                .processType(entity.getType().name())
+                .build();
+
+        var task = Task.Builder.newInstance().at(clock.millis())
+                .payload(payload)
+                .build();
+
+        taskService.create(task);
+    }
+
+}

--- a/core/transfer-process-task-executor/src/main/java/org/eclipse/edc/virtual/controlplane/transfer/process/task/command/ResumeTransferCommandHandler.java
+++ b/core/transfer-process-task-executor/src/main/java/org/eclipse/edc/virtual/controlplane/transfer/process/task/command/ResumeTransferCommandHandler.java
@@ -1,0 +1,75 @@
+/*
+ *  Copyright (c) 2026 Metaform Systems, Inc.
+ *
+ *  This program and the accompanying materials are made available under the
+ *  terms of the Apache License, Version 2.0 which is available at
+ *  https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Contributors:
+ *       Metaform Systems, Inc. - initial API and implementation
+ *
+ */
+
+package org.eclipse.edc.virtual.controlplane.transfer.process.task.command;
+
+
+import org.eclipse.edc.connector.controlplane.transfer.spi.store.TransferProcessStore;
+import org.eclipse.edc.connector.controlplane.transfer.spi.types.TransferProcess;
+import org.eclipse.edc.connector.controlplane.transfer.spi.types.TransferProcessStates;
+import org.eclipse.edc.connector.controlplane.transfer.spi.types.command.ResumeTransferCommand;
+import org.eclipse.edc.spi.command.EntityCommandHandler;
+import org.eclipse.edc.virtual.controlplane.tasks.Task;
+import org.eclipse.edc.virtual.controlplane.tasks.TaskService;
+import org.eclipse.edc.virtual.controlplane.transfer.spi.tasks.ResumeDataFlow;
+
+import java.time.Clock;
+
+import static org.eclipse.edc.connector.controlplane.transfer.spi.types.TransferProcessStates.SUSPENDED;
+
+/**
+ * Resumes a SUSPENDED transfer process and puts it in the {@link TransferProcessStates#STARTING} state.
+ */
+public class ResumeTransferCommandHandler extends EntityCommandHandler<ResumeTransferCommand, TransferProcess> {
+
+    private final TaskService taskService;
+    private final Clock clock;
+
+    public ResumeTransferCommandHandler(TransferProcessStore store, TaskService taskService, Clock clock) {
+        super(store);
+        this.taskService = taskService;
+        this.clock = clock;
+    }
+
+    @Override
+    public Class<ResumeTransferCommand> getType() {
+        return ResumeTransferCommand.class;
+    }
+
+    @Override
+    protected boolean modify(TransferProcess process, ResumeTransferCommand command) {
+        if (process.currentStateIsOneOf(SUSPENDED)) {
+            process.transitionResuming();
+            return true;
+        }
+
+        return false;
+    }
+
+    @Override
+    public void postActions(TransferProcess entity, ResumeTransferCommand command) {
+
+        var payload = ResumeDataFlow.Builder.newInstance().processId(entity.getId())
+                .processState(entity.stateAsString())
+                .processType(entity.getType().name())
+                .build();
+
+        var task = Task.Builder.newInstance().at(clock.millis())
+                .payload(payload)
+                .build();
+
+
+        taskService.create(task);
+    }
+}

--- a/core/transfer-process-task-executor/src/main/java/org/eclipse/edc/virtual/controlplane/transfer/process/task/command/SuspendTransferCommandHandler.java
+++ b/core/transfer-process-task-executor/src/main/java/org/eclipse/edc/virtual/controlplane/transfer/process/task/command/SuspendTransferCommandHandler.java
@@ -1,0 +1,71 @@
+/*
+ *  Copyright (c) 2026 Metaform Systems, Inc.
+ *
+ *  This program and the accompanying materials are made available under the
+ *  terms of the Apache License, Version 2.0 which is available at
+ *  https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Contributors:
+ *       Metaform Systems, Inc. - initial API and implementation
+ *
+ */
+
+package org.eclipse.edc.virtual.controlplane.transfer.process.task.command;
+
+import org.eclipse.edc.connector.controlplane.transfer.spi.store.TransferProcessStore;
+import org.eclipse.edc.connector.controlplane.transfer.spi.types.TransferProcess;
+import org.eclipse.edc.connector.controlplane.transfer.spi.types.TransferProcessStates;
+import org.eclipse.edc.connector.controlplane.transfer.spi.types.command.SuspendTransferCommand;
+import org.eclipse.edc.spi.command.EntityCommandHandler;
+import org.eclipse.edc.virtual.controlplane.tasks.Task;
+import org.eclipse.edc.virtual.controlplane.tasks.TaskService;
+import org.eclipse.edc.virtual.controlplane.transfer.spi.tasks.SuspendDataFlow;
+
+import java.time.Clock;
+
+/**
+ * Terminates a transfer process and puts it in the {@link TransferProcessStates#SUSPENDING} state.
+ */
+public class SuspendTransferCommandHandler extends EntityCommandHandler<SuspendTransferCommand, TransferProcess> {
+
+    private final TaskService taskService;
+    private final Clock clock;
+
+    public SuspendTransferCommandHandler(TransferProcessStore store, TaskService taskService, Clock clock) {
+        super(store);
+        this.taskService = taskService;
+        this.clock = clock;
+    }
+
+    @Override
+    public Class<SuspendTransferCommand> getType() {
+        return SuspendTransferCommand.class;
+    }
+
+    @Override
+    protected boolean modify(TransferProcess process, SuspendTransferCommand command) {
+        if (process.canBeSuspended()) {
+            process.transitionSuspending(command.getReason());
+            return true;
+        }
+
+        return false;
+    }
+
+    @Override
+    public void postActions(TransferProcess entity, SuspendTransferCommand command) {
+
+        var payload = SuspendDataFlow.Builder.newInstance().processId(entity.getId())
+                .processState(entity.stateAsString())
+                .processType(entity.getType().name())
+                .build();
+
+        var task = Task.Builder.newInstance().at(clock.millis())
+                .payload(payload)
+                .build();
+
+        taskService.create(task);
+    }
+}

--- a/core/transfer-process-task-executor/src/main/java/org/eclipse/edc/virtual/controlplane/transfer/process/task/command/TerminateTransferCommandHandler.java
+++ b/core/transfer-process-task-executor/src/main/java/org/eclipse/edc/virtual/controlplane/transfer/process/task/command/TerminateTransferCommandHandler.java
@@ -1,0 +1,72 @@
+/*
+ *  Copyright (c) 2026 Metaform Systems, Inc.
+ *
+ *  This program and the accompanying materials are made available under the
+ *  terms of the Apache License, Version 2.0 which is available at
+ *  https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Contributors:
+ *       Metaform Systems, Inc. - initial API and implementation
+ *
+ */
+
+package org.eclipse.edc.virtual.controlplane.transfer.process.task.command;
+
+import org.eclipse.edc.connector.controlplane.transfer.spi.store.TransferProcessStore;
+import org.eclipse.edc.connector.controlplane.transfer.spi.types.TransferProcess;
+import org.eclipse.edc.connector.controlplane.transfer.spi.types.TransferProcessStates;
+import org.eclipse.edc.connector.controlplane.transfer.spi.types.command.TerminateTransferCommand;
+import org.eclipse.edc.spi.command.EntityCommandHandler;
+import org.eclipse.edc.virtual.controlplane.tasks.Task;
+import org.eclipse.edc.virtual.controlplane.tasks.TaskService;
+import org.eclipse.edc.virtual.controlplane.transfer.spi.tasks.TerminateDataFlow;
+
+import java.time.Clock;
+
+/**
+ * Terminates a transfer process and puts it in the {@link TransferProcessStates#TERMINATING} state.
+ */
+public class TerminateTransferCommandHandler extends EntityCommandHandler<TerminateTransferCommand, TransferProcess> {
+
+    private final TaskService taskService;
+    private final Clock clock;
+
+    public TerminateTransferCommandHandler(TransferProcessStore store, TaskService taskService, Clock clock) {
+        super(store);
+        this.taskService = taskService;
+        this.clock = clock;
+    }
+
+    @Override
+    public Class<TerminateTransferCommand> getType() {
+        return TerminateTransferCommand.class;
+    }
+
+    @Override
+    protected boolean modify(TransferProcess process, TerminateTransferCommand command) {
+        if (process.canBeTerminated()) {
+            process.transitionTerminating(command.getReason());
+            return true;
+        }
+
+        return false;
+    }
+
+    @Override
+    public void postActions(TransferProcess entity, TerminateTransferCommand command) {
+
+        var payload = TerminateDataFlow.Builder.newInstance().processId(entity.getId())
+                .processState(entity.stateAsString())
+                .processType(entity.getType().name())
+                .build();
+
+        var task = Task.Builder.newInstance().at(clock.millis())
+                .payload(payload)
+                .build();
+
+        taskService.create(task);
+    }
+
+}

--- a/core/transfer-process-task-executor/src/main/resources/META-INF/services/org.eclipse.edc.spi.system.ServiceExtension
+++ b/core/transfer-process-task-executor/src/main/resources/META-INF/services/org.eclipse.edc.spi.system.ServiceExtension
@@ -1,0 +1,14 @@
+#
+#  Copyright (c) 2026 Metaform Systems, Inc.
+#
+#  This program and the accompanying materials are made available under the
+#  terms of the Apache License, Version 2.0 which is available at
+#  https://www.apache.org/licenses/LICENSE-2.0
+#
+#  SPDX-License-Identifier: Apache-2.0
+#
+#  Contributors:
+#       Metaform Systems, Inc. - initial API and implementation
+#
+#
+org.eclipse.edc.virtual.controlplane.transfer.process.task.TransferTaskExecutorExtension

--- a/core/transfer-process-task-executor/src/test/java/org/eclipse/edc/virtual/controlplane/transfer/process/task/TransferProcessTaskExecutorImplTest.java
+++ b/core/transfer-process-task-executor/src/test/java/org/eclipse/edc/virtual/controlplane/transfer/process/task/TransferProcessTaskExecutorImplTest.java
@@ -1,0 +1,318 @@
+/*
+ *  Copyright (c) 2026 Metaform Systems, Inc.
+ *
+ *  This program and the accompanying materials are made available under the
+ *  terms of the Apache License, Version 2.0 which is available at
+ *  https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Contributors:
+ *       Metaform Systems, Inc. - initial API and implementation
+ *
+ */
+
+package org.eclipse.edc.virtual.controlplane.transfer.process.task;
+
+import org.eclipse.edc.connector.controlplane.asset.spi.index.DataAddressResolver;
+import org.eclipse.edc.connector.controlplane.policy.spi.store.PolicyArchive;
+import org.eclipse.edc.connector.controlplane.transfer.spi.TransferProcessPendingGuard;
+import org.eclipse.edc.connector.controlplane.transfer.spi.flow.DataFlowController;
+import org.eclipse.edc.connector.controlplane.transfer.spi.observe.TransferProcessObservable;
+import org.eclipse.edc.connector.controlplane.transfer.spi.store.TransferProcessStore;
+import org.eclipse.edc.connector.controlplane.transfer.spi.types.DataFlowResponse;
+import org.eclipse.edc.connector.controlplane.transfer.spi.types.TransferProcess;
+import org.eclipse.edc.connector.controlplane.transfer.spi.types.TransferProcessStates;
+import org.eclipse.edc.connector.controlplane.transfer.spi.types.protocol.TransferProcessAck;
+import org.eclipse.edc.junit.assertions.AbstractResultAssert;
+import org.eclipse.edc.policy.model.Policy;
+import org.eclipse.edc.spi.message.RemoteMessageDispatcherRegistry;
+import org.eclipse.edc.spi.monitor.Monitor;
+import org.eclipse.edc.spi.response.StatusResult;
+import org.eclipse.edc.spi.security.Vault;
+import org.eclipse.edc.spi.types.domain.DataAddress;
+import org.eclipse.edc.transaction.spi.NoopTransactionContext;
+import org.eclipse.edc.transaction.spi.TransactionContext;
+import org.eclipse.edc.virtual.controlplane.participantcontext.spi.ParticipantWebhookResolver;
+import org.eclipse.edc.virtual.controlplane.tasks.ProcessTaskPayload;
+import org.eclipse.edc.virtual.controlplane.tasks.TaskService;
+import org.eclipse.edc.virtual.controlplane.transfer.spi.TransferProcessTaskExecutor;
+import org.eclipse.edc.virtual.controlplane.transfer.spi.tasks.CompleteDataFlow;
+import org.eclipse.edc.virtual.controlplane.transfer.spi.tasks.PrepareTransfer;
+import org.eclipse.edc.virtual.controlplane.transfer.spi.tasks.ResumeDataFlow;
+import org.eclipse.edc.virtual.controlplane.transfer.spi.tasks.SendTransferRequest;
+import org.eclipse.edc.virtual.controlplane.transfer.spi.tasks.SignalDataflowStarted;
+import org.eclipse.edc.virtual.controlplane.transfer.spi.tasks.StartDataflow;
+import org.eclipse.edc.virtual.controlplane.transfer.spi.tasks.SuspendDataFlow;
+import org.eclipse.edc.virtual.controlplane.transfer.spi.tasks.TerminateDataFlow;
+import org.eclipse.edc.virtual.controlplane.transfer.spi.tasks.TransferProcessTaskPayload;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtensionContext;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.ArgumentsProvider;
+import org.junit.jupiter.params.provider.ArgumentsSource;
+import org.mockito.ArgumentCaptor;
+
+import java.time.Clock;
+import java.util.UUID;
+import java.util.stream.Stream;
+
+import static java.util.concurrent.CompletableFuture.completedFuture;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.eclipse.edc.connector.controlplane.transfer.spi.types.TransferProcess.Type.CONSUMER;
+import static org.eclipse.edc.connector.controlplane.transfer.spi.types.TransferProcess.Type.PROVIDER;
+import static org.eclipse.edc.connector.controlplane.transfer.spi.types.TransferProcessStates.COMPLETED;
+import static org.eclipse.edc.connector.controlplane.transfer.spi.types.TransferProcessStates.COMPLETING;
+import static org.eclipse.edc.connector.controlplane.transfer.spi.types.TransferProcessStates.INITIAL;
+import static org.eclipse.edc.connector.controlplane.transfer.spi.types.TransferProcessStates.REQUESTED;
+import static org.eclipse.edc.connector.controlplane.transfer.spi.types.TransferProcessStates.REQUESTING;
+import static org.eclipse.edc.connector.controlplane.transfer.spi.types.TransferProcessStates.RESUMED;
+import static org.eclipse.edc.connector.controlplane.transfer.spi.types.TransferProcessStates.RESUMING;
+import static org.eclipse.edc.connector.controlplane.transfer.spi.types.TransferProcessStates.STARTED;
+import static org.eclipse.edc.connector.controlplane.transfer.spi.types.TransferProcessStates.STARTING;
+import static org.eclipse.edc.connector.controlplane.transfer.spi.types.TransferProcessStates.SUSPENDED;
+import static org.eclipse.edc.connector.controlplane.transfer.spi.types.TransferProcessStates.SUSPENDING;
+import static org.eclipse.edc.connector.controlplane.transfer.spi.types.TransferProcessStates.TERMINATED;
+import static org.eclipse.edc.connector.controlplane.transfer.spi.types.TransferProcessStates.TERMINATING;
+import static org.junit.jupiter.params.provider.Arguments.arguments;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+class TransferProcessTaskExecutorImplTest {
+
+    private final TransferProcessObservable observable = mock();
+    private final DataFlowController dataFlowController = mock();
+    private final TransferProcessStore transferStore = mock();
+    private final RemoteMessageDispatcherRegistry dispatcherRegistry = mock();
+    private final ParticipantWebhookResolver webhookResolver = mock();
+    private final DataAddressResolver addressResolver = mock();
+    private final PolicyArchive policyArchive = mock();
+    private final TransferProcessPendingGuard pendingGuard = mock();
+    private final TransactionContext transactionContext = new NoopTransactionContext();
+    private final Monitor monitor = mock();
+    private final Vault vault = mock();
+    private final Clock clock = Clock.systemUTC();
+    private final TaskService taskService = mock();
+    private final String protocolWebhookUrl = "http://protocol.webhook/url";
+    private TransferProcessTaskExecutor executor;
+
+    @BeforeEach
+    void setUp() {
+
+        when(pendingGuard.test(any())).thenReturn(false);
+
+        executor = TransferProcessTaskExecutorImpl.Builder.newInstance()
+                .store(transferStore)
+                .dataFlowController(dataFlowController)
+                .dispatcherRegistry(dispatcherRegistry)
+                .webhookResolver(webhookResolver)
+                .addressResolver(addressResolver)
+                .policyArchive(policyArchive)
+                .observable(observable)
+                .pendingGuard(pendingGuard)
+                .transactionContext(transactionContext)
+                .monitor(monitor)
+                .vault(vault)
+                .clock(clock)
+                .taskService(taskService)
+                .build();
+    }
+
+
+    @ParameterizedTest
+    @ArgumentsSource(StateTransitionProvider.class)
+    void handle(TransferProcessTaskPayload payload, TransferProcessStates expectedState) {
+
+        var contractId = "contractId";
+
+
+        when(dataFlowController.started(any())).thenReturn(StatusResult.success());
+        when(dataFlowController.prepare(any(), any())).thenReturn(StatusResult.success(DataFlowResponse.Builder.newInstance().build()));
+        when(dataFlowController.start(any(), any())).thenReturn(StatusResult.success(DataFlowResponse.Builder.newInstance().build()));
+        when(dataFlowController.terminate(any())).thenReturn(StatusResult.success());
+        when(dataFlowController.suspend(any())).thenReturn(StatusResult.success());
+        when(addressResolver.resolveForAsset(any())).thenReturn(DataAddress.Builder.newInstance().type("type").build());
+
+        when(dispatcherRegistry.dispatch(any(), any(), any())).thenReturn(completedFuture(StatusResult.success(TransferProcessAck.Builder.newInstance().build())));
+        when(webhookResolver.getWebhook(any(), any())).thenReturn(() -> protocolWebhookUrl);
+        var transferProcess = TransferProcess.Builder.newInstance()
+                .id(payload.getProcessId())
+                .type(TransferProcess.Type.valueOf(payload.getProcessType()))
+                .state(TransferProcessStates.valueOf(payload.getProcessState()).code())
+                .contractId(contractId)
+                .build();
+
+        when(transferStore.findById(payload.getProcessId())).thenReturn(transferProcess);
+        when(policyArchive.findPolicyForContract(any())).thenReturn(Policy.Builder.newInstance().build());
+
+
+        var result = executor.handle(payload);
+
+        AbstractResultAssert.assertThat(result).isSucceeded();
+
+        var captor = ArgumentCaptor.forClass(TransferProcess.class);
+        verify(transferStore).save(captor.capture());
+
+        var updatedProcess = captor.getValue();
+
+        assertThat(updatedProcess.getState()).isEqualTo(expectedState.code());
+
+    }
+
+    @Test
+    void handle_shouldSkipWhenTransferProcessNotFound() {
+        var task = PrepareTransfer.Builder.newInstance()
+                .processId("transfer-123")
+                .processState(TransferProcessStates.INITIAL.name())
+                .processType(TransferProcess.Type.CONSUMER.name())
+                .build();
+
+        when(transferStore.findById("transfer-123")).thenReturn(null);
+
+        var result = executor.handle(task);
+
+        assertThat(result.failed()).isTrue();
+        assertThat(result.getFailureDetail()).contains("not found");
+    }
+
+    @Test
+    void handle_shouldSkipWhenTransferProcessIsInFinalState() {
+        var transferProcess = createTransferProcess("transfer-123", TransferProcessStates.COMPLETED);
+
+        var task = PrepareTransfer.Builder.newInstance()
+                .processId("transfer-123")
+                .processState(TransferProcessStates.INITIAL.name())
+                .processType(TransferProcess.Type.CONSUMER.name())
+                .build();
+
+        when(transferStore.findById("transfer-123")).thenReturn(transferProcess);
+
+        var result = executor.handle(task);
+
+        assertThat(result.succeeded()).isTrue();
+    }
+
+    @Test
+    void handle_shouldSkipWhenStateDoesNotMatch() {
+        var transferProcess = createTransferProcess("transfer-123", TransferProcessStates.PROVISIONING_REQUESTED);
+
+        var task = PrepareTransfer.Builder.newInstance()
+                .processId("transfer-123")
+                .processState(TransferProcessStates.INITIAL.name())
+                .processType(TransferProcess.Type.CONSUMER.name())
+                .build();
+
+        when(transferStore.findById("transfer-123")).thenReturn(transferProcess);
+
+        var result = executor.handle(task);
+
+        assertThat(result.succeeded()).isTrue();
+    }
+
+    @Test
+    void handle_shouldSkipWhenPendingGuardMatches() {
+        var transferProcess = createTransferProcess("transfer-123", TransferProcessStates.INITIAL);
+
+        var task = PrepareTransfer.Builder.newInstance()
+                .processId("transfer-123")
+                .processState(TransferProcessStates.INITIAL.name())
+                .processType(TransferProcess.Type.CONSUMER.name())
+                .build();
+
+        when(transferStore.findById("transfer-123")).thenReturn(transferProcess);
+        when(pendingGuard.test(transferProcess)).thenReturn(true);
+
+        var result = executor.handle(task);
+
+        assertThat(result.succeeded()).isTrue();
+    }
+
+    @Test
+    void handle_shouldFailWhenProcessTypeDoesNotMatch() {
+        var transferProcess = createTransferProcess("transfer-123", TransferProcessStates.INITIAL);
+
+        var task = PrepareTransfer.Builder.newInstance()
+                .processId("transfer-123")
+                .processState(TransferProcessStates.INITIAL.name())
+                .processType(TransferProcess.Type.CONSUMER.name())
+                .build();
+
+        when(transferStore.findById("transfer-123")).thenReturn(transferProcess);
+
+        var result = executor.handle(task);
+
+        assertThat(result.failed()).isTrue();
+    }
+
+    @Test
+    void handle_shouldTransitionWhenHandlerSucceeds() {
+        var transferProcess = createTransferProcess("transfer-123", TransferProcessStates.INITIAL);
+
+        var task = PrepareTransfer.Builder.newInstance()
+                .processId("transfer-123")
+                .processState(TransferProcessStates.INITIAL.name())
+                .processType(TransferProcess.Type.CONSUMER.name())
+                .build();
+
+        when(policyArchive.findPolicyForContract(anyString())).thenReturn(Policy.Builder.newInstance().build());
+        when(transferStore.findById("transfer-123")).thenReturn(transferProcess);
+        when(dataFlowController.prepare(any(), any())).thenReturn(StatusResult.fatalError("test"));
+
+        var result = executor.handle(task);
+
+        assertThat(result.succeeded()).isTrue();
+        verify(transferStore).save(any());
+    }
+
+    private TransferProcess createTransferProcess(String id, TransferProcessStates state) {
+        var transferProcess = mock(TransferProcess.class);
+        when(transferProcess.getId()).thenReturn(id);
+        when(transferProcess.getState()).thenReturn(state.code());
+        when(transferProcess.stateAsString()).thenReturn(state.name());
+        when(transferProcess.getType()).thenReturn(TransferProcess.Type.CONSUMER);
+        when(transferProcess.getParticipantContextId()).thenReturn("participant-123");
+        when(transferProcess.getProtocol()).thenReturn("DSP");
+        when(transferProcess.getCounterPartyAddress()).thenReturn("http://counter-party");
+        when(transferProcess.getContractId()).thenReturn("contract-123");
+        when(transferProcess.getAssetId()).thenReturn("asset-123");
+
+        return transferProcess;
+    }
+
+    public static class StateTransitionProvider implements ArgumentsProvider {
+
+        protected <T extends ProcessTaskPayload, B extends ProcessTaskPayload.Builder<T, B>> B baseBuilder(B builder, String id, TransferProcessStates state, TransferProcess.Type type) {
+            return builder.processId(id)
+                    .processState(state.name())
+                    .processType(type.name());
+        }
+
+        @Override
+        public Stream<? extends Arguments> provideArguments(ExtensionContext context) {
+
+            var id = UUID.randomUUID().toString();
+            return Stream.of(
+                    arguments(baseBuilder(PrepareTransfer.Builder.newInstance(), id, INITIAL, CONSUMER).build(), REQUESTING),
+                    arguments(baseBuilder(SendTransferRequest.Builder.newInstance(), id, REQUESTING, CONSUMER).build(), REQUESTED),
+                    arguments(baseBuilder(SignalDataflowStarted.Builder.newInstance(), id, REQUESTED, CONSUMER).build(), STARTED),
+                    arguments(baseBuilder(SuspendDataFlow.Builder.newInstance(), id, SUSPENDING, CONSUMER).build(), SUSPENDED),
+                    arguments(baseBuilder(ResumeDataFlow.Builder.newInstance(), id, RESUMING, CONSUMER).build(), RESUMED),
+                    arguments(baseBuilder(TerminateDataFlow.Builder.newInstance(), id, TERMINATING, CONSUMER).build(), TERMINATED),
+                    arguments(baseBuilder(CompleteDataFlow.Builder.newInstance(), id, COMPLETING, CONSUMER).build(), COMPLETED),
+
+                    arguments(baseBuilder(PrepareTransfer.Builder.newInstance(), id, INITIAL, PROVIDER).build(), STARTING),
+                    arguments(baseBuilder(StartDataflow.Builder.newInstance(), id, STARTING, PROVIDER).build(), STARTED),
+                    arguments(baseBuilder(SuspendDataFlow.Builder.newInstance(), id, SUSPENDING, PROVIDER).build(), SUSPENDED),
+                    arguments(baseBuilder(ResumeDataFlow.Builder.newInstance(), id, RESUMING, PROVIDER).build(), STARTED),
+                    arguments(baseBuilder(TerminateDataFlow.Builder.newInstance(), id, TERMINATING, PROVIDER).build(), TERMINATED),
+                    arguments(baseBuilder(CompleteDataFlow.Builder.newInstance(), id, COMPLETING, PROVIDER).build(), COMPLETED)
+            );
+
+        }
+    }
+}

--- a/core/v-task-core/build.gradle.kts
+++ b/core/v-task-core/build.gradle.kts
@@ -1,0 +1,29 @@
+/*
+ *  Copyright (c) 2026 Metaform Systems, Inc.
+ *
+ *  This program and the accompanying materials are made available under the
+ *  terms of the Apache License, Version 2.0 which is available at
+ *  https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Contributors:
+ *       Metaform Systems, Inc. - initial API and implementation
+ *
+ */
+
+plugins {
+    `java-library`
+}
+
+dependencies {
+    api(project(":spi:v-core-spi"))
+    api(project(":spi:v-task-spi"))
+    api(libs.edc.spi.core)
+    api(libs.edc.spi.transaction)
+    implementation(libs.edc.lib.store)
+    testImplementation(libs.edc.lib.query)
+    testImplementation(testFixtures(project(":spi:v-task-spi")))
+
+}
+

--- a/core/v-task-core/src/main/java/org/eclipse/edc/virtual/controlplane/tasks/TaskObservableImpl.java
+++ b/core/v-task-core/src/main/java/org/eclipse/edc/virtual/controlplane/tasks/TaskObservableImpl.java
@@ -1,0 +1,21 @@
+/*
+ *  Copyright (c) 2026 Metaform Systems, Inc.
+ *
+ *  This program and the accompanying materials are made available under the
+ *  terms of the Apache License, Version 2.0 which is available at
+ *  https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Contributors:
+ *       Metaform Systems, Inc. - initial API and implementation
+ *
+ */
+
+package org.eclipse.edc.virtual.controlplane.tasks;
+
+import org.eclipse.edc.spi.observe.ObservableImpl;
+
+public class TaskObservableImpl extends ObservableImpl<TaskListener> implements TaskObservable {
+
+}

--- a/core/v-task-core/src/main/java/org/eclipse/edc/virtual/controlplane/tasks/TaskServiceImpl.java
+++ b/core/v-task-core/src/main/java/org/eclipse/edc/virtual/controlplane/tasks/TaskServiceImpl.java
@@ -1,0 +1,58 @@
+/*
+ *  Copyright (c) 2026 Metaform Systems, Inc.
+ *
+ *  This program and the accompanying materials are made available under the
+ *  terms of the Apache License, Version 2.0 which is available at
+ *  https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Contributors:
+ *       Metaform Systems, Inc. - initial API and implementation
+ *
+ */
+
+package org.eclipse.edc.virtual.controlplane.tasks;
+
+import org.eclipse.edc.spi.query.QuerySpec;
+import org.eclipse.edc.transaction.spi.TransactionContext;
+import org.eclipse.edc.virtual.controlplane.tasks.store.TaskStore;
+
+import java.util.List;
+
+public class TaskServiceImpl implements TaskService {
+
+    private final TaskStore taskStore;
+    private final TaskObservable taskObservable;
+    private final TransactionContext transactionContext;
+
+
+    public TaskServiceImpl(TaskStore taskStore, TaskObservable taskObservable, TransactionContext transactionContext) {
+        this.taskStore = taskStore;
+        this.taskObservable = taskObservable;
+        this.transactionContext = transactionContext;
+    }
+
+    @Override
+    public void create(Task task) {
+        transactionContext.execute(() -> {
+            taskStore.create(task);
+            taskObservable.invokeForEach(l -> l.created(task));
+        });
+    }
+
+    @Override
+    public List<Task> fetchLatestTask(QuerySpec query) {
+        return transactionContext.execute(() -> taskStore.fetchForUpdate(query));
+    }
+
+    @Override
+    public void delete(String id) {
+        transactionContext.execute(() -> taskStore.delete(id));
+    }
+
+    @Override
+    public Task findById(String id) {
+        return transactionContext.execute(() -> taskStore.findById(id));
+    }
+}

--- a/core/v-task-core/src/main/java/org/eclipse/edc/virtual/controlplane/tasks/TaskTypes.java
+++ b/core/v-task-core/src/main/java/org/eclipse/edc/virtual/controlplane/tasks/TaskTypes.java
@@ -1,0 +1,55 @@
+/*
+ *  Copyright (c) 2026 Metaform Systems, Inc.
+ *
+ *  This program and the accompanying materials are made available under the
+ *  terms of the Apache License, Version 2.0 which is available at
+ *  https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Contributors:
+ *       Metaform Systems, Inc. - initial API and implementation
+ *
+ */
+
+package org.eclipse.edc.virtual.controlplane.tasks;
+
+import org.eclipse.edc.virtual.controlplane.contract.spi.negotiation.tasks.AgreeNegotiation;
+import org.eclipse.edc.virtual.controlplane.contract.spi.negotiation.tasks.FinalizeNegotiation;
+import org.eclipse.edc.virtual.controlplane.contract.spi.negotiation.tasks.RequestNegotiation;
+import org.eclipse.edc.virtual.controlplane.contract.spi.negotiation.tasks.SendAgreement;
+import org.eclipse.edc.virtual.controlplane.contract.spi.negotiation.tasks.SendFinalizeNegotiation;
+import org.eclipse.edc.virtual.controlplane.contract.spi.negotiation.tasks.SendRequestNegotiation;
+import org.eclipse.edc.virtual.controlplane.contract.spi.negotiation.tasks.SendVerificationNegotiation;
+import org.eclipse.edc.virtual.controlplane.contract.spi.negotiation.tasks.VerifyNegotiation;
+import org.eclipse.edc.virtual.controlplane.transfer.spi.tasks.CompleteDataFlow;
+import org.eclipse.edc.virtual.controlplane.transfer.spi.tasks.PrepareTransfer;
+import org.eclipse.edc.virtual.controlplane.transfer.spi.tasks.ResumeDataFlow;
+import org.eclipse.edc.virtual.controlplane.transfer.spi.tasks.SendTransferRequest;
+import org.eclipse.edc.virtual.controlplane.transfer.spi.tasks.SignalDataflowStarted;
+import org.eclipse.edc.virtual.controlplane.transfer.spi.tasks.StartDataflow;
+import org.eclipse.edc.virtual.controlplane.transfer.spi.tasks.SuspendDataFlow;
+import org.eclipse.edc.virtual.controlplane.transfer.spi.tasks.TerminateDataFlow;
+
+import java.util.List;
+
+public class TaskTypes {
+
+    public static final List<Class<?>> TYPES = List.of(
+            RequestNegotiation.class,
+            SendRequestNegotiation.class,
+            AgreeNegotiation.class,
+            SendAgreement.class,
+            VerifyNegotiation.class,
+            SendVerificationNegotiation.class,
+            FinalizeNegotiation.class,
+            SendFinalizeNegotiation.class,
+            PrepareTransfer.class,
+            SendTransferRequest.class,
+            StartDataflow.class,
+            SignalDataflowStarted.class,
+            SuspendDataFlow.class,
+            ResumeDataFlow.class,
+            TerminateDataFlow.class,
+            CompleteDataFlow.class);
+}

--- a/core/v-task-core/src/main/java/org/eclipse/edc/virtual/controlplane/tasks/TasksServicesExtension.java
+++ b/core/v-task-core/src/main/java/org/eclipse/edc/virtual/controlplane/tasks/TasksServicesExtension.java
@@ -1,0 +1,68 @@
+/*
+ *  Copyright (c) 2026 Metaform Systems, Inc.
+ *
+ *  This program and the accompanying materials are made available under the
+ *  terms of the Apache License, Version 2.0 which is available at
+ *  https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Contributors:
+ *       Metaform Systems, Inc. - initial API and implementation
+ *
+ */
+
+package org.eclipse.edc.virtual.controlplane.tasks;
+
+import org.eclipse.edc.runtime.metamodel.annotation.Extension;
+import org.eclipse.edc.runtime.metamodel.annotation.Inject;
+import org.eclipse.edc.runtime.metamodel.annotation.Provider;
+import org.eclipse.edc.spi.monitor.Monitor;
+import org.eclipse.edc.spi.system.ServiceExtension;
+import org.eclipse.edc.spi.system.ServiceExtensionContext;
+import org.eclipse.edc.spi.types.TypeManager;
+import org.eclipse.edc.transaction.spi.TransactionContext;
+import org.eclipse.edc.virtual.controlplane.tasks.store.TaskStore;
+
+import static org.eclipse.edc.virtual.controlplane.tasks.TaskTypes.TYPES;
+import static org.eclipse.edc.virtual.controlplane.tasks.TasksServicesExtension.NAME;
+
+@Extension(NAME)
+public class TasksServicesExtension implements ServiceExtension {
+
+    public static final String NAME = "EDC-V Tasks Core Services";
+
+    @Inject
+    private TaskStore taskStore;
+
+    @Inject
+    private TransactionContext transactionContext;
+
+    @Inject
+    private Monitor monitor;
+
+    @Inject
+    private TypeManager typeManager;
+
+    private TaskObservable observable;
+
+
+    @Override
+    public void initialize(ServiceExtensionContext context) {
+        TYPES.forEach(typeManager::registerTypes);
+    }
+
+    @Provider
+    public TaskService taskService() {
+        return new TaskServiceImpl(taskStore, taskObservable(), transactionContext);
+    }
+
+    @Provider
+    public TaskObservable taskObservable() {
+        if (observable == null) {
+            observable = new TaskObservableImpl();
+        }
+        return observable;
+    }
+
+}

--- a/core/v-task-core/src/main/java/org/eclipse/edc/virtual/controlplane/tasks/defaults/InMemoryTaskStore.java
+++ b/core/v-task-core/src/main/java/org/eclipse/edc/virtual/controlplane/tasks/defaults/InMemoryTaskStore.java
@@ -1,0 +1,64 @@
+/*
+ *  Copyright (c) 2026 Metaform Systems, Inc.
+ *
+ *  This program and the accompanying materials are made available under the
+ *  terms of the Apache License, Version 2.0 which is available at
+ *  https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Contributors:
+ *       Metaform Systems, Inc. - initial API and implementation
+ *
+ */
+
+package org.eclipse.edc.virtual.controlplane.tasks.defaults;
+
+import org.eclipse.edc.spi.query.CriterionOperatorRegistry;
+import org.eclipse.edc.spi.query.QueryResolver;
+import org.eclipse.edc.spi.query.QuerySpec;
+import org.eclipse.edc.store.ReflectionBasedQueryResolver;
+import org.eclipse.edc.virtual.controlplane.tasks.Task;
+import org.eclipse.edc.virtual.controlplane.tasks.store.TaskStore;
+
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.stream.Collectors;
+
+public class InMemoryTaskStore implements TaskStore {
+
+    private final Map<String, Task> tasks = new ConcurrentHashMap<>();
+    private final QueryResolver<Task> queryResolver;
+
+    public InMemoryTaskStore(CriterionOperatorRegistry criterionOperatorRegistry) {
+        this.queryResolver = new ReflectionBasedQueryResolver<>(Task.class, criterionOperatorRegistry);
+    }
+
+    @Override
+    public void create(Task task) {
+        tasks.put(task.getId(), task);
+    }
+
+    @Override
+    public List<Task> fetchForUpdate(QuerySpec querySpec) {
+        return queryResolver.query(tasks.values().stream().map(t -> t), querySpec)
+                .map(t -> (Task) t)
+                .collect(Collectors.toList());
+    }
+
+    @Override
+    public void delete(String id) {
+        tasks.remove(id);
+    }
+
+    @Override
+    public void update(Task task) {
+        tasks.put(task.getId(), task);
+    }
+
+    @Override
+    public Task findById(String id) {
+        return tasks.get(id);
+    }
+}

--- a/core/v-task-core/src/main/java/org/eclipse/edc/virtual/controlplane/tasks/defaults/TasksDefaultServicesExtension.java
+++ b/core/v-task-core/src/main/java/org/eclipse/edc/virtual/controlplane/tasks/defaults/TasksDefaultServicesExtension.java
@@ -1,0 +1,38 @@
+/*
+ *  Copyright (c) 2026 Metaform Systems, Inc.
+ *
+ *  This program and the accompanying materials are made available under the
+ *  terms of the Apache License, Version 2.0 which is available at
+ *  https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Contributors:
+ *       Metaform Systems, Inc. - initial API and implementation
+ *
+ */
+
+package org.eclipse.edc.virtual.controlplane.tasks.defaults;
+
+import org.eclipse.edc.runtime.metamodel.annotation.Extension;
+import org.eclipse.edc.runtime.metamodel.annotation.Inject;
+import org.eclipse.edc.runtime.metamodel.annotation.Provider;
+import org.eclipse.edc.spi.query.CriterionOperatorRegistry;
+import org.eclipse.edc.spi.system.ServiceExtension;
+import org.eclipse.edc.virtual.controlplane.tasks.store.TaskStore;
+
+import static org.eclipse.edc.virtual.controlplane.tasks.TasksServicesExtension.NAME;
+
+@Extension(NAME)
+public class TasksDefaultServicesExtension implements ServiceExtension {
+
+    public static final String NAME = "EDC-V Tasks Default Services";
+    @Inject
+    private CriterionOperatorRegistry criterionOperatorRegistry;
+
+    @Provider(isDefault = true)
+    public TaskStore taskStore() {
+        return new InMemoryTaskStore(criterionOperatorRegistry);
+    }
+
+}

--- a/core/v-task-core/src/main/resources/META-INF/services/org.eclipse.edc.spi.system.ServiceExtension
+++ b/core/v-task-core/src/main/resources/META-INF/services/org.eclipse.edc.spi.system.ServiceExtension
@@ -1,0 +1,15 @@
+#
+#  Copyright (c) 2026 Metaform Systems, Inc.
+#
+#  This program and the accompanying materials are made available under the
+#  terms of the Apache License, Version 2.0 which is available at
+#  https://www.apache.org/licenses/LICENSE-2.0
+#
+#  SPDX-License-Identifier: Apache-2.0
+#
+#  Contributors:
+#       Metaform Systems, Inc. - initial API and implementation
+#
+#
+org.eclipse.edc.virtual.controlplane.tasks.TasksServicesExtension
+org.eclipse.edc.virtual.controlplane.tasks.defaults.TasksDefaultServicesExtension

--- a/core/v-task-core/src/test/java/org/eclipse/edc/virtual/controlplane/tasks/TaskServiceImplTest.java
+++ b/core/v-task-core/src/test/java/org/eclipse/edc/virtual/controlplane/tasks/TaskServiceImplTest.java
@@ -1,0 +1,231 @@
+/*
+ *  Copyright (c) 2026 Metaform Systems, Inc.
+ *
+ *  This program and the accompanying materials are made available under the
+ *  terms of the Apache License, Version 2.0 which is available at
+ *  https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Contributors:
+ *       Metaform Systems, Inc. - initial API and implementation
+ *
+ */
+
+package org.eclipse.edc.virtual.controlplane.tasks;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.databind.annotation.JsonPOJOBuilder;
+import org.eclipse.edc.spi.query.QuerySpec;
+import org.eclipse.edc.transaction.spi.NoopTransactionContext;
+import org.eclipse.edc.transaction.spi.TransactionContext;
+import org.eclipse.edc.virtual.controlplane.tasks.store.TaskStore;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+class TaskServiceImplTest {
+
+    private final TaskStore taskStore = mock();
+    private final TaskObservableImpl taskObservable = new TaskObservableImpl();
+    private final TaskListener taskListener = mock();
+    private final TransactionContext transactionContext = new NoopTransactionContext();
+    private TaskServiceImpl service;
+
+    @BeforeEach
+    void setUp() {
+        service = new TaskServiceImpl(taskStore, taskObservable, transactionContext);
+        taskObservable.registerListener(taskListener);
+    }
+
+    @Test
+    void create_shouldPersistTask() {
+        var payload = TestPayload.Builder.newInstance()
+                .processId("process-1")
+                .processState("INITIAL")
+                .processType("CONSUMER")
+                .build();
+        var task = Task.Builder.newInstance()
+                .at(System.currentTimeMillis())
+                .payload(payload)
+                .build();
+
+        service.create(task);
+
+
+        verify(taskStore).create(task);
+    }
+
+    @Test
+    void create_shouldInvokeTaskListeners() {
+        var payload = TestPayload.Builder.newInstance()
+                .processId("process-1")
+                .processState("INITIAL")
+                .processType("CONSUMER")
+                .build();
+        var task = Task.Builder.newInstance()
+                .at(System.currentTimeMillis())
+                .payload(payload)
+                .build();
+
+
+        service.create(task);
+
+        verify(taskListener).created(any());
+    }
+
+    @Test
+    void fetchLatestTask_shouldRetrieveTasks() {
+        var payload1 = TestPayload.Builder.newInstance()
+                .processId("process-1")
+                .processState("INITIAL")
+                .processType("CONSUMER")
+                .build();
+        var task1 = Task.Builder.newInstance()
+                .at(System.currentTimeMillis())
+                .payload(payload1)
+                .build();
+
+        var payload2 = TestPayload.Builder.newInstance()
+                .processId("process-2")
+                .processState("INITIAL")
+                .processType("CONSUMER")
+                .build();
+        var task2 = Task.Builder.newInstance()
+                .at(System.currentTimeMillis())
+                .payload(payload2)
+                .build();
+
+        when(taskStore.fetchForUpdate(any(QuerySpec.class)))
+                .thenReturn(List.of(task1, task2));
+
+        var results = service.fetchLatestTask(QuerySpec.none());
+
+        assertThat(results).hasSize(2);
+        verify(taskStore).fetchForUpdate(any(QuerySpec.class));
+    }
+
+    @Test
+    void fetchLatestTask_shouldReturnEmptyWhenNoTasksAvailable() {
+        when(taskStore.fetchForUpdate(any(QuerySpec.class)))
+                .thenReturn(List.of());
+
+        var results = service.fetchLatestTask(QuerySpec.none());
+
+        assertThat(results).isEmpty();
+        verify(taskStore).fetchForUpdate(any(QuerySpec.class));
+    }
+
+    @Test
+    void delete_shouldRemoveTask() {
+        var taskId = "task-123";
+
+        service.delete(taskId);
+
+        verify(taskStore).delete(taskId);
+    }
+
+    @Test
+    void findById_shouldReturnTask() {
+        var taskId = "task-123";
+        var payload = TestPayload.Builder.newInstance()
+                .processId("process-1")
+                .processState("INITIAL")
+                .processType("CONSUMER")
+                .build();
+        var task = Task.Builder.newInstance()
+                .id(taskId)
+                .at(System.currentTimeMillis())
+                .payload(payload)
+                .build();
+
+        when(taskStore.findById(taskId)).thenReturn((Task) task);
+
+        var result = service.findById(taskId);
+
+        assertThat(result).isNotNull();
+        assertThat(result.getId()).isEqualTo(taskId);
+        verify(taskStore).findById(taskId);
+    }
+
+    @Test
+    void findById_shouldReturnNullWhenTaskNotFound() {
+        when(taskStore.findById("nonexistent-id")).thenReturn(null);
+
+        var result = service.findById("nonexistent-id");
+
+        assertThat(result).isNull();
+        verify(taskStore).findById("nonexistent-id");
+    }
+
+    @Test
+    void create_shouldAllowMultipleTasksForSameProcess() {
+        var payload1 = TestPayload.Builder.newInstance()
+                .processId("process-1")
+                .processState("INITIAL")
+                .processType("CONSUMER")
+                .build();
+        var task1 = Task.Builder.newInstance()
+                .at(System.currentTimeMillis())
+                .payload(payload1)
+                .build();
+
+        var payload2 = TestPayload.Builder.newInstance()
+                .processId("process-1")
+                .processState("UPDATED")
+                .processType("CONSUMER")
+                .build();
+        var task2 = Task.Builder.newInstance()
+                .at(System.currentTimeMillis())
+                .payload(payload2)
+                .build();
+
+        when(taskStore.fetchForUpdate(any(QuerySpec.class)))
+                .thenReturn(List.of(task1, task2));
+
+        var results = service.fetchLatestTask(QuerySpec.none());
+
+        assertThat(results).hasSize(2);
+        verify(taskStore).fetchForUpdate(any(QuerySpec.class));
+    }
+
+
+    /**
+     * Test payload implementation for TaskService tests
+     */
+    public static class TestPayload extends ProcessTaskPayload {
+
+        private TestPayload() {
+        }
+
+        @Override
+        public String name() {
+            return "test.payload";
+        }
+
+        @JsonPOJOBuilder(withPrefix = "")
+        public static class Builder extends ProcessTaskPayload.Builder<TestPayload, Builder> {
+
+            private Builder() {
+                super(new TestPayload());
+            }
+
+            @JsonCreator
+            public static Builder newInstance() {
+                return new TestPayload.Builder();
+            }
+
+            @Override
+            public Builder self() {
+                return this;
+            }
+        }
+    }
+}

--- a/core/v-task-core/src/test/java/org/eclipse/edc/virtual/controlplane/tasks/defaults/InMemoryTaskStoreTest.java
+++ b/core/v-task-core/src/test/java/org/eclipse/edc/virtual/controlplane/tasks/defaults/InMemoryTaskStoreTest.java
@@ -1,0 +1,29 @@
+/*
+ *  Copyright (c) 2026 Metaform Systems, Inc.
+ *
+ *  This program and the accompanying materials are made available under the
+ *  terms of the Apache License, Version 2.0 which is available at
+ *  https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Contributors:
+ *       Metaform Systems, Inc. - initial API and implementation
+ *
+ */
+
+package org.eclipse.edc.virtual.controlplane.tasks.defaults;
+
+import org.eclipse.edc.query.CriterionOperatorRegistryImpl;
+import org.eclipse.edc.virtual.controlplane.tasks.store.TaskStore;
+import org.eclipse.edc.virtual.controlplane.tasks.store.TaskStoreTestBase;
+
+class InMemoryTaskStoreTest extends TaskStoreTestBase {
+
+    private final InMemoryTaskStore store = new InMemoryTaskStore(CriterionOperatorRegistryImpl.ofDefaults());
+    
+    @Override
+    protected TaskStore getStore() {
+        return store;
+    }
+}

--- a/docs/assets/deployment_scenario1_single_node_polling.drawio
+++ b/docs/assets/deployment_scenario1_single_node_polling.drawio
@@ -1,0 +1,54 @@
+<mxfile host="65bd71144e">
+    <diagram id="scenario1-single-node-polling" name="Page-1">
+        <mxGraphModel dx="800" dy="600" grid="1" gridSize="10" guides="1" tooltips="1" connect="1" arrows="1" fold="1" page="1" pageScale="1" pageWidth="600" pageHeight="500" math="0" shadow="0">
+            <root>
+                <mxCell id="0"/>
+                <mxCell id="1" parent="0"/>
+                <!-- Control Plane container -->
+                <mxCell id="container" value="Control Plane" style="rounded=0;whiteSpace=wrap;html=1;verticalAlign=top;fontSize=14;fillColor=#f5f5f5;fontColor=#333333;strokeColor=#666666;fontStyle=1" vertex="1" parent="1">
+                    <mxGeometry x="60" y="20" width="280" height="420" as="geometry"/>
+                </mxCell>
+                <!-- State Machines -->
+                <mxCell id="sm" value="State Machines&lt;br&gt;(Negotiation, Transfer)" style="rounded=1;whiteSpace=wrap;html=1;fillColor=#dae8fc;strokeColor=#6c8ebf;fontSize=11;" vertex="1" parent="1">
+                    <mxGeometry x="90" y="60" width="220" height="45" as="geometry"/>
+                </mxCell>
+                <!-- TaskStateListeners -->
+                <mxCell id="tsl" value="TaskStateListeners&lt;br&gt;(Listen to state changes)" style="rounded=1;whiteSpace=wrap;html=1;fillColor=#d5e8d4;strokeColor=#82b366;fontSize=11;" vertex="1" parent="1">
+                    <mxGeometry x="90" y="130" width="220" height="45" as="geometry"/>
+                </mxCell>
+                <!-- TaskService.create() -->
+                <mxCell id="ts" value="TaskService.create()" style="rounded=1;whiteSpace=wrap;html=1;fillColor=#d5e8d4;strokeColor=#82b366;fontSize=11;" vertex="1" parent="1">
+                    <mxGeometry x="90" y="200" width="220" height="40" as="geometry"/>
+                </mxCell>
+                <!-- InMemoryTaskStore -->
+                <mxCell id="store" value="InMemoryTaskStore&lt;br&gt;(Tasks in RAM)" style="rounded=1;whiteSpace=wrap;html=1;fillColor=#fff2cc;strokeColor=#d6b656;fontSize=11;" vertex="1" parent="1">
+                    <mxGeometry x="90" y="265" width="220" height="45" as="geometry"/>
+                </mxCell>
+                <!-- TaskPollExecutor -->
+                <mxCell id="poll" value="TaskPollExecutor&lt;br&gt;(Poll every x ms)" style="rounded=1;whiteSpace=wrap;html=1;fillColor=#e1d5e7;strokeColor=#9673a6;fontSize=11;" vertex="1" parent="1">
+                    <mxGeometry x="90" y="335" width="220" height="45" as="geometry"/>
+                </mxCell>
+                <!-- TaskExecutors -->
+                <mxCell id="exec" value="TaskExecutors&lt;br&gt;(Process tasks)" style="rounded=1;whiteSpace=wrap;html=1;fillColor=#f8cecc;strokeColor=#b85450;fontSize=11;" vertex="1" parent="1">
+                    <mxGeometry x="90" y="405" width="220" height="45" as="geometry"/>
+                </mxCell>
+                <!-- Arrows -->
+                <mxCell id="e1" style="edgeStyle=orthogonalEdgeStyle;rounded=0;orthogonalLoop=1;jettySize=auto;html=1;strokeColor=#666666;strokeWidth=1.5;" edge="1" parent="1" source="sm" target="tsl">
+                    <mxGeometry relative="1" as="geometry"/>
+                </mxCell>
+                <mxCell id="e2" style="edgeStyle=orthogonalEdgeStyle;rounded=0;orthogonalLoop=1;jettySize=auto;html=1;strokeColor=#666666;strokeWidth=1.5;" edge="1" parent="1" source="tsl" target="ts">
+                    <mxGeometry relative="1" as="geometry"/>
+                </mxCell>
+                <mxCell id="e3" style="edgeStyle=orthogonalEdgeStyle;rounded=0;orthogonalLoop=1;jettySize=auto;html=1;strokeColor=#666666;strokeWidth=1.5;" edge="1" parent="1" source="ts" target="store">
+                    <mxGeometry relative="1" as="geometry"/>
+                </mxCell>
+                <mxCell id="e4" style="edgeStyle=orthogonalEdgeStyle;rounded=0;orthogonalLoop=1;jettySize=auto;html=1;strokeColor=#666666;strokeWidth=1.5;" edge="1" parent="1" source="store" target="poll">
+                    <mxGeometry relative="1" as="geometry"/>
+                </mxCell>
+                <mxCell id="e5" style="edgeStyle=orthogonalEdgeStyle;rounded=0;orthogonalLoop=1;jettySize=auto;html=1;strokeColor=#666666;strokeWidth=1.5;" edge="1" parent="1" source="poll" target="exec">
+                    <mxGeometry relative="1" as="geometry"/>
+                </mxCell>
+            </root>
+        </mxGraphModel>
+    </diagram>
+</mxfile>

--- a/docs/assets/deployment_scenario1_single_node_polling.svg
+++ b/docs/assets/deployment_scenario1_single_node_polling.svg
@@ -1,0 +1,56 @@
+<svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" version="1.1" width="341px" height="461px" viewBox="-0.5 -0.5 341 461" style="background: transparent; background-color: transparent;" content="&lt;mxfile host=&quot;65bd71144e&quot;&gt;&lt;diagram id=&quot;scenario1-single-node-polling&quot; name=&quot;Page-1&quot;&gt;&lt;mxGraphModel&gt;&lt;root&gt;&lt;mxCell id=&quot;0&quot;/&gt;&lt;mxCell id=&quot;1&quot; parent=&quot;0&quot;/&gt;&lt;/root&gt;&lt;/mxGraphModel&gt;&lt;/diagram&gt;&lt;/mxfile&gt;">
+    <defs>
+        <marker id="arrowhead" markerWidth="10" markerHeight="7" refX="9" refY="3.5" orient="auto">
+            <polygon points="0 0, 10 3.5, 0 7" fill="#666666"/>
+        </marker>
+    </defs>
+    <g>
+        <!-- Control Plane container -->
+        <rect x="0" y="0" width="340" height="460" fill="#f5f5f5" stroke="#666666" stroke-width="1.5"/>
+        <text x="170" y="25" font-family="Helvetica, Arial, sans-serif" font-size="14" font-weight="bold" text-anchor="middle" fill="#333333">Control Plane</text>
+
+        <!-- State Machines -->
+        <rect x="30" y="45" width="280" height="50" rx="8" ry="8" fill="#dae8fc" stroke="#6c8ebf" stroke-width="1.5"/>
+        <text x="170" y="65" font-family="Helvetica, Arial, sans-serif" font-size="11" text-anchor="middle" fill="#000000">State Machines</text>
+        <text x="170" y="82" font-family="Helvetica, Arial, sans-serif" font-size="10" text-anchor="middle" fill="#000000">(Negotiation, Transfer)</text>
+
+        <!-- Arrow -->
+        <path d="M 170 95 L 170 115" stroke="#666666" stroke-width="1.5" fill="none" marker-end="url(#arrowhead)"/>
+
+        <!-- TaskStateListeners -->
+        <rect x="30" y="115" width="280" height="50" rx="8" ry="8" fill="#d5e8d4" stroke="#82b366" stroke-width="1.5"/>
+        <text x="170" y="135" font-family="Helvetica, Arial, sans-serif" font-size="11" text-anchor="middle" fill="#000000">TaskStateListeners</text>
+        <text x="170" y="152" font-family="Helvetica, Arial, sans-serif" font-size="10" text-anchor="middle" fill="#000000">(Listen to state changes)</text>
+
+        <!-- Arrow -->
+        <path d="M 170 165 L 170 185" stroke="#666666" stroke-width="1.5" fill="none" marker-end="url(#arrowhead)"/>
+
+        <!-- TaskService.create() -->
+        <rect x="30" y="185" width="280" height="40" rx="8" ry="8" fill="#d5e8d4" stroke="#82b366" stroke-width="1.5"/>
+        <text x="170" y="210" font-family="Helvetica, Arial, sans-serif" font-size="11" text-anchor="middle" fill="#000000">TaskService.create()</text>
+
+        <!-- Arrow -->
+        <path d="M 170 225 L 170 245" stroke="#666666" stroke-width="1.5" fill="none" marker-end="url(#arrowhead)"/>
+
+        <!-- InMemoryTaskStore -->
+        <rect x="30" y="245" width="280" height="50" rx="8" ry="8" fill="#fff2cc" stroke="#d6b656" stroke-width="1.5"/>
+        <text x="170" y="265" font-family="Helvetica, Arial, sans-serif" font-size="11" text-anchor="middle" fill="#000000">InMemoryTaskStore</text>
+        <text x="170" y="282" font-family="Helvetica, Arial, sans-serif" font-size="10" text-anchor="middle" fill="#000000">(Tasks in RAM)</text>
+
+        <!-- Arrow -->
+        <path d="M 170 295 L 170 315" stroke="#666666" stroke-width="1.5" fill="none" marker-end="url(#arrowhead)"/>
+
+        <!-- TaskPollExecutor -->
+        <rect x="30" y="315" width="280" height="50" rx="8" ry="8" fill="#e1d5e7" stroke="#9673a6" stroke-width="1.5"/>
+        <text x="170" y="335" font-family="Helvetica, Arial, sans-serif" font-size="11" text-anchor="middle" fill="#000000">TaskPollExecutor</text>
+        <text x="170" y="352" font-family="Helvetica, Arial, sans-serif" font-size="10" text-anchor="middle" fill="#000000">(Poll every x ms)</text>
+
+        <!-- Arrow -->
+        <path d="M 170 365 L 170 385" stroke="#666666" stroke-width="1.5" fill="none" marker-end="url(#arrowhead)"/>
+
+        <!-- TaskExecutors -->
+        <rect x="30" y="385" width="280" height="50" rx="8" ry="8" fill="#f8cecc" stroke="#b85450" stroke-width="1.5"/>
+        <text x="170" y="405" font-family="Helvetica, Arial, sans-serif" font-size="11" text-anchor="middle" fill="#000000">TaskExecutors</text>
+        <text x="170" y="422" font-family="Helvetica, Arial, sans-serif" font-size="10" text-anchor="middle" fill="#000000">(Process tasks)</text>
+    </g>
+</svg>

--- a/docs/assets/deployment_scenario2_multi_node_skip_locked.drawio
+++ b/docs/assets/deployment_scenario2_multi_node_skip_locked.drawio
@@ -1,0 +1,45 @@
+<mxfile host="65bd71144e">
+    <diagram id="scenario2-multi-node-skip-locked" name="Page-1">
+        <mxGraphModel dx="1000" dy="700" grid="1" gridSize="10" guides="1" tooltips="1" connect="1" arrows="1" fold="1" page="1" pageScale="1" pageWidth="800" pageHeight="600" math="0" shadow="0">
+            <root>
+                <mxCell id="0"/>
+                <mxCell id="1" parent="0"/>
+                <!-- Control Plane 1 -->
+                <mxCell id="cp1" value="Control Plane 1" style="rounded=0;whiteSpace=wrap;html=1;verticalAlign=top;fontSize=12;fillColor=#f5f5f5;fontColor=#333333;strokeColor=#666666;fontStyle=1" vertex="1" parent="1">
+                    <mxGeometry x="20" y="20" width="200" height="100" as="geometry"/>
+                </mxCell>
+                <mxCell id="cp1-inner" value="State Machines&lt;br&gt;TaskStateListeners&lt;br&gt;TaskService" style="rounded=1;whiteSpace=wrap;html=1;fillColor=#dae8fc;strokeColor=#6c8ebf;fontSize=10;" vertex="1" parent="1">
+                    <mxGeometry x="35" y="50" width="170" height="60" as="geometry"/>
+                </mxCell>
+                <!-- Control Plane N -->
+                <mxCell id="cpn" value="Control Plane N" style="rounded=0;whiteSpace=wrap;html=1;verticalAlign=top;fontSize=12;fillColor=#f5f5f5;fontColor=#333333;strokeColor=#666666;fontStyle=1" vertex="1" parent="1">
+                    <mxGeometry x="20" y="140" width="200" height="100" as="geometry"/>
+                </mxCell>
+                <mxCell id="cpn-inner" value="State Machines&lt;br&gt;TaskStateListeners&lt;br&gt;TaskService" style="rounded=1;whiteSpace=wrap;html=1;fillColor=#dae8fc;strokeColor=#6c8ebf;fontSize=10;" vertex="1" parent="1">
+                    <mxGeometry x="35" y="170" width="170" height="60" as="geometry"/>
+                </mxCell>
+                <!-- TaskPollExecutor 1 -->
+                <mxCell id="poll1" value="TaskPollExecutor 1&lt;br&gt;(Poll every x ms)&lt;br&gt;(SKIP LOCKED)" style="rounded=1;whiteSpace=wrap;html=1;fillColor=#e1d5e7;strokeColor=#9673a6;fontSize=10;" vertex="1" parent="1">
+                    <mxGeometry x="260" y="20" width="150" height="60" as="geometry"/>
+                </mxCell>
+                <!-- Worker boxes -->
+                <mxCell id="w2" value="TaskPoll 2&lt;br&gt;(Worker)" style="rounded=1;whiteSpace=wrap;html=1;fillColor=#f8cecc;strokeColor=#b85450;fontSize=10;" vertex="1" parent="1">
+                    <mxGeometry x="260" y="100" width="90" height="50" as="geometry"/>
+                </mxCell>
+                <mxCell id="w3" value="TaskPoll 3&lt;br&gt;(Worker)" style="rounded=1;whiteSpace=wrap;html=1;fillColor=#f8cecc;strokeColor=#b85450;fontSize=10;" vertex="1" parent="1">
+                    <mxGeometry x="360" y="100" width="90" height="50" as="geometry"/>
+                </mxCell>
+                <mxCell id="wn" value="TaskPoll N&lt;br&gt;(Worker)" style="rounded=1;whiteSpace=wrap;html=1;fillColor=#f8cecc;strokeColor=#b85450;fontSize=10;" vertex="1" parent="1">
+                    <mxGeometry x="260" y="165" width="90" height="50" as="geometry"/>
+                </mxCell>
+                <mxCell id="wm" value="TaskPoll M&lt;br&gt;(Worker)" style="rounded=1;whiteSpace=wrap;html=1;fillColor=#f8cecc;strokeColor=#b85450;fontSize=10;" vertex="1" parent="1">
+                    <mxGeometry x="360" y="165" width="90" height="50" as="geometry"/>
+                </mxCell>
+                <!-- PostgreSQL -->
+                <mxCell id="pg" value="PostgreSQL (Shared)&lt;br&gt;(edc_tasks)&lt;br&gt;(WITH SKIP LOCKED)&lt;br&gt;(Persistent)" style="shape=cylinder3;whiteSpace=wrap;html=1;boundedLbl=1;backgroundOutline=1;size=10;fillColor=#fff2cc;strokeColor=#d6b656;fontSize=10;" vertex="1" parent="1">
+                    <mxGeometry x="150" y="270" width="160" height="90" as="geometry"/>
+                </mxCell>
+            </root>
+        </mxGraphModel>
+    </diagram>
+</mxfile>

--- a/docs/assets/deployment_scenario2_multi_node_skip_locked.svg
+++ b/docs/assets/deployment_scenario2_multi_node_skip_locked.svg
@@ -1,0 +1,72 @@
+<svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" version="1.1" width="461px" height="381px" viewBox="-0.5 -0.5 461 381" style="background: transparent; background-color: transparent;" content="&lt;mxfile host=&quot;65bd71144e&quot;&gt;&lt;diagram id=&quot;scenario2-multi-node-skip-locked&quot; name=&quot;Page-1&quot;&gt;&lt;mxGraphModel&gt;&lt;root&gt;&lt;mxCell id=&quot;0&quot;/&gt;&lt;mxCell id=&quot;1&quot; parent=&quot;0&quot;/&gt;&lt;/root&gt;&lt;/mxGraphModel&gt;&lt;/diagram&gt;&lt;/mxfile&gt;">
+    <defs>
+        <marker id="arrowhead" markerWidth="10" markerHeight="7" refX="9" refY="3.5" orient="auto">
+            <polygon points="0 0, 10 3.5, 0 7" fill="#666666"/>
+        </marker>
+    </defs>
+    <g>
+        <!-- Control Plane 1 -->
+        <rect x="0" y="0" width="180" height="90" fill="#f5f5f5" stroke="#666666" stroke-width="1.5"/>
+        <text x="90" y="18" font-family="Helvetica, Arial, sans-serif" font-size="11" font-weight="bold" text-anchor="middle" fill="#333333">Control Plane 1</text>
+        <rect x="10" y="28" width="160" height="55" rx="6" ry="6" fill="#dae8fc" stroke="#6c8ebf" stroke-width="1.5"/>
+        <text x="90" y="46" font-family="Helvetica, Arial, sans-serif" font-size="10" text-anchor="middle" fill="#000000">State Machines</text>
+        <text x="90" y="59" font-family="Helvetica, Arial, sans-serif" font-size="10" text-anchor="middle" fill="#000000">TaskStateListeners</text>
+        <text x="90" y="72" font-family="Helvetica, Arial, sans-serif" font-size="10" text-anchor="middle" fill="#000000">TaskService</text>
+
+        <!-- Control Plane N -->
+        <rect x="0" y="105" width="180" height="90" fill="#f5f5f5" stroke="#666666" stroke-width="1.5"/>
+        <text x="90" y="123" font-family="Helvetica, Arial, sans-serif" font-size="11" font-weight="bold" text-anchor="middle" fill="#333333">Control Plane N</text>
+        <rect x="10" y="133" width="160" height="55" rx="6" ry="6" fill="#dae8fc" stroke="#6c8ebf" stroke-width="1.5"/>
+        <text x="90" y="151" font-family="Helvetica, Arial, sans-serif" font-size="10" text-anchor="middle" fill="#000000">State Machines</text>
+        <text x="90" y="164" font-family="Helvetica, Arial, sans-serif" font-size="10" text-anchor="middle" fill="#000000">TaskStateListeners</text>
+        <text x="90" y="177" font-family="Helvetica, Arial, sans-serif" font-size="10" text-anchor="middle" fill="#000000">TaskService</text>
+
+        <!-- Arrows from Control Planes -->
+        <path d="M 180 55 L 200 55 L 200 35 L 220 35" stroke="#666666" stroke-width="1.5" fill="none" marker-end="url(#arrowhead)"/>
+        <path d="M 180 160 L 200 160 L 200 35 L 220 35" stroke="#666666" stroke-width="1.5" fill="none"/>
+
+        <!-- TaskPollExecutor 1 -->
+        <rect x="220" y="0" width="150" height="65" rx="6" ry="6" fill="#e1d5e7" stroke="#9673a6" stroke-width="1.5"/>
+        <text x="295" y="18" font-family="Helvetica, Arial, sans-serif" font-size="10" text-anchor="middle" fill="#000000">TaskPollExecutor 1</text>
+        <text x="295" y="33" font-family="Helvetica, Arial, sans-serif" font-size="9" text-anchor="middle" fill="#000000">(Poll every x ms)</text>
+        <text x="295" y="48" font-family="Helvetica, Arial, sans-serif" font-size="9" text-anchor="middle" fill="#000000">(SKIP LOCKED)</text>
+
+        <!-- Arrows from TaskPollExecutor 1 to workers -->
+        <path d="M 260 65 L 260 80" stroke="#666666" stroke-width="1.5" fill="none" marker-end="url(#arrowhead)"/>
+        <path d="M 295 65 L 295 75 L 355 75 L 355 80" stroke="#666666" stroke-width="1.5" fill="none" marker-end="url(#arrowhead)"/>
+
+        <!-- Worker 2 -->
+        <rect x="220" y="80" width="90" height="50" rx="6" ry="6" fill="#f8cecc" stroke="#b85450" stroke-width="1.5"/>
+        <text x="265" y="100" font-family="Helvetica, Arial, sans-serif" font-size="10" text-anchor="middle" fill="#000000">TaskPoll 2</text>
+        <text x="265" y="115" font-family="Helvetica, Arial, sans-serif" font-size="9" text-anchor="middle" fill="#000000">(Worker)</text>
+
+        <!-- Worker 3 -->
+        <rect x="320" y="80" width="90" height="50" rx="6" ry="6" fill="#f8cecc" stroke="#b85450" stroke-width="1.5"/>
+        <text x="365" y="100" font-family="Helvetica, Arial, sans-serif" font-size="10" text-anchor="middle" fill="#000000">TaskPoll 3</text>
+        <text x="365" y="115" font-family="Helvetica, Arial, sans-serif" font-size="9" text-anchor="middle" fill="#000000">(Worker)</text>
+
+        <!-- Worker N -->
+        <rect x="220" y="145" width="90" height="50" rx="6" ry="6" fill="#f8cecc" stroke="#b85450" stroke-width="1.5"/>
+        <text x="265" y="165" font-family="Helvetica, Arial, sans-serif" font-size="10" text-anchor="middle" fill="#000000">TaskPoll N</text>
+        <text x="265" y="180" font-family="Helvetica, Arial, sans-serif" font-size="9" text-anchor="middle" fill="#000000">(Worker)</text>
+
+        <!-- Worker M -->
+        <rect x="320" y="145" width="90" height="50" rx="6" ry="6" fill="#f8cecc" stroke="#b85450" stroke-width="1.5"/>
+        <text x="365" y="165" font-family="Helvetica, Arial, sans-serif" font-size="10" text-anchor="middle" fill="#000000">TaskPoll M</text>
+        <text x="365" y="180" font-family="Helvetica, Arial, sans-serif" font-size="9" text-anchor="middle" fill="#000000">(Worker)</text>
+
+        <!-- Arrows from workers to PostgreSQL -->
+        <path d="M 265 130 L 265 210 L 230 210 L 230 250" stroke="#666666" stroke-width="1.5" fill="none" marker-end="url(#arrowhead)"/>
+        <path d="M 365 130 L 365 210 L 230 210" stroke="#666666" stroke-width="1.5" fill="none"/>
+        <path d="M 265 195 L 265 210" stroke="#666666" stroke-width="1.5" fill="none"/>
+        <path d="M 365 195 L 365 210" stroke="#666666" stroke-width="1.5" fill="none"/>
+
+        <!-- PostgreSQL cylinder -->
+        <path d="M 130 270 Q 130 250 230 250 Q 330 250 330 270 L 330 350 Q 330 370 230 370 Q 130 370 130 350 Z" fill="#fff2cc" stroke="#d6b656" stroke-width="1.5"/>
+        <ellipse cx="230" cy="270" rx="100" ry="20" fill="#fff2cc" stroke="#d6b656" stroke-width="1.5"/>
+        <text x="230" y="300" font-family="Helvetica, Arial, sans-serif" font-size="10" text-anchor="middle" fill="#000000">PostgreSQL (Shared)</text>
+        <text x="230" y="315" font-family="Helvetica, Arial, sans-serif" font-size="9" text-anchor="middle" fill="#000000">(edc_tasks)</text>
+        <text x="230" y="330" font-family="Helvetica, Arial, sans-serif" font-size="9" text-anchor="middle" fill="#000000">(WITH SKIP LOCKED)</text>
+        <text x="230" y="345" font-family="Helvetica, Arial, sans-serif" font-size="9" text-anchor="middle" fill="#000000">(Persistent)</text>
+    </g>
+</svg>

--- a/docs/assets/deployment_scenario2_single_node_sql.drawio
+++ b/docs/assets/deployment_scenario2_single_node_sql.drawio
@@ -1,0 +1,47 @@
+<mxfile host="65bd71144e">
+    <diagram id="scenario2-single-node-sql" name="Page-1">
+        <mxGraphModel dx="800" dy="600" grid="1" gridSize="10" guides="1" tooltips="1" connect="1" arrows="1" fold="1" page="1" pageScale="1" pageWidth="600" pageHeight="500" math="0" shadow="0">
+            <root>
+                <mxCell id="0"/>
+                <mxCell id="1" parent="0"/>
+                <!-- Control Plane container -->
+                <mxCell id="container" value="Control Plane" style="rounded=0;whiteSpace=wrap;html=1;verticalAlign=top;fontSize=14;fillColor=#f5f5f5;fontColor=#333333;strokeColor=#666666;fontStyle=1" vertex="1" parent="1">
+                    <mxGeometry x="60" y="20" width="280" height="300" as="geometry"/>
+                </mxCell>
+                <!-- State Machines + TaskStateListeners + TaskService -->
+                <mxCell id="sm" value="State Machines&lt;br&gt;TaskStateListeners&lt;br&gt;TaskService" style="rounded=1;whiteSpace=wrap;html=1;fillColor=#dae8fc;strokeColor=#6c8ebf;fontSize=11;" vertex="1" parent="1">
+                    <mxGeometry x="90" y="60" width="220" height="60" as="geometry"/>
+                </mxCell>
+                <!-- SqlTaskStore -->
+                <mxCell id="store" value="SqlTaskStore" style="rounded=1;whiteSpace=wrap;html=1;fillColor=#fff2cc;strokeColor=#d6b656;fontSize=11;" vertex="1" parent="1">
+                    <mxGeometry x="90" y="145" width="220" height="40" as="geometry"/>
+                </mxCell>
+                <!-- TaskPollExecutor -->
+                <mxCell id="poll" value="TaskPollExecutor&lt;br&gt;(Poll every x ms)" style="rounded=1;whiteSpace=wrap;html=1;fillColor=#e1d5e7;strokeColor=#9673a6;fontSize=11;" vertex="1" parent="1">
+                    <mxGeometry x="90" y="210" width="220" height="45" as="geometry"/>
+                </mxCell>
+                <!-- TaskExecutors -->
+                <mxCell id="exec" value="TaskExecutors" style="rounded=1;whiteSpace=wrap;html=1;fillColor=#f8cecc;strokeColor=#b85450;fontSize=11;" vertex="1" parent="1">
+                    <mxGeometry x="90" y="280" width="220" height="35" as="geometry"/>
+                </mxCell>
+                <!-- PostgreSQL -->
+                <mxCell id="pg" value="PostgreSQL&lt;br&gt;(edc_tasks)&lt;br&gt;(Persistent)" style="shape=cylinder3;whiteSpace=wrap;html=1;boundedLbl=1;backgroundOutline=1;size=10;fillColor=#f5f5f5;strokeColor=#666666;fontSize=11;" vertex="1" parent="1">
+                    <mxGeometry x="145" y="380" width="110" height="80" as="geometry"/>
+                </mxCell>
+                <!-- Arrows -->
+                <mxCell id="e1" style="edgeStyle=orthogonalEdgeStyle;rounded=0;orthogonalLoop=1;jettySize=auto;html=1;strokeColor=#666666;strokeWidth=1.5;" edge="1" parent="1" source="sm" target="store">
+                    <mxGeometry relative="1" as="geometry"/>
+                </mxCell>
+                <mxCell id="e2" style="edgeStyle=orthogonalEdgeStyle;rounded=0;orthogonalLoop=1;jettySize=auto;html=1;strokeColor=#666666;strokeWidth=1.5;" edge="1" parent="1" source="store" target="poll">
+                    <mxGeometry relative="1" as="geometry"/>
+                </mxCell>
+                <mxCell id="e3" style="edgeStyle=orthogonalEdgeStyle;rounded=0;orthogonalLoop=1;jettySize=auto;html=1;strokeColor=#666666;strokeWidth=1.5;" edge="1" parent="1" source="poll" target="exec">
+                    <mxGeometry relative="1" as="geometry"/>
+                </mxCell>
+                <mxCell id="e4" style="edgeStyle=orthogonalEdgeStyle;rounded=0;orthogonalLoop=1;jettySize=auto;html=1;strokeColor=#666666;strokeWidth=1.5;" edge="1" parent="1" source="container" target="pg">
+                    <mxGeometry relative="1" as="geometry"/>
+                </mxCell>
+            </root>
+        </mxGraphModel>
+    </diagram>
+</mxfile>

--- a/docs/assets/deployment_scenario2_single_node_sql.svg
+++ b/docs/assets/deployment_scenario2_single_node_sql.svg
@@ -1,0 +1,50 @@
+<svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" version="1.1" width="341px" height="461px" viewBox="-0.5 -0.5 341 461" style="background: transparent; background-color: transparent;" content="&lt;mxfile host=&quot;65bd71144e&quot;&gt;&lt;diagram id=&quot;scenario2-single-node-sql&quot; name=&quot;Page-1&quot;&gt;&lt;mxGraphModel&gt;&lt;root&gt;&lt;mxCell id=&quot;0&quot;/&gt;&lt;mxCell id=&quot;1&quot; parent=&quot;0&quot;/&gt;&lt;/root&gt;&lt;/mxGraphModel&gt;&lt;/diagram&gt;&lt;/mxfile&gt;">
+    <defs>
+        <marker id="arrowhead" markerWidth="10" markerHeight="7" refX="9" refY="3.5" orient="auto">
+            <polygon points="0 0, 10 3.5, 0 7" fill="#666666"/>
+        </marker>
+    </defs>
+    <g>
+        <!-- Control Plane container -->
+        <rect x="0" y="0" width="340" height="310" fill="#f5f5f5" stroke="#666666" stroke-width="1.5"/>
+        <text x="170" y="25" font-family="Helvetica, Arial, sans-serif" font-size="14" font-weight="bold" text-anchor="middle" fill="#333333">Control Plane</text>
+
+        <!-- State Machines + TaskStateListeners + TaskService -->
+        <rect x="30" y="45" width="280" height="65" rx="8" ry="8" fill="#dae8fc" stroke="#6c8ebf" stroke-width="1.5"/>
+        <text x="170" y="65" font-family="Helvetica, Arial, sans-serif" font-size="11" text-anchor="middle" fill="#000000">State Machines</text>
+        <text x="170" y="80" font-family="Helvetica, Arial, sans-serif" font-size="11" text-anchor="middle" fill="#000000">TaskStateListeners</text>
+        <text x="170" y="95" font-family="Helvetica, Arial, sans-serif" font-size="11" text-anchor="middle" fill="#000000">TaskService</text>
+
+        <!-- Arrow -->
+        <path d="M 170 110 L 170 130" stroke="#666666" stroke-width="1.5" fill="none" marker-end="url(#arrowhead)"/>
+
+        <!-- SqlTaskStore -->
+        <rect x="30" y="130" width="280" height="40" rx="8" ry="8" fill="#fff2cc" stroke="#d6b656" stroke-width="1.5"/>
+        <text x="170" y="155" font-family="Helvetica, Arial, sans-serif" font-size="11" text-anchor="middle" fill="#000000">SqlTaskStore</text>
+
+        <!-- Arrow -->
+        <path d="M 170 170 L 170 190" stroke="#666666" stroke-width="1.5" fill="none" marker-end="url(#arrowhead)"/>
+
+        <!-- TaskPollExecutor -->
+        <rect x="30" y="190" width="280" height="50" rx="8" ry="8" fill="#e1d5e7" stroke="#9673a6" stroke-width="1.5"/>
+        <text x="170" y="210" font-family="Helvetica, Arial, sans-serif" font-size="11" text-anchor="middle" fill="#000000">TaskPollExecutor</text>
+        <text x="170" y="227" font-family="Helvetica, Arial, sans-serif" font-size="10" text-anchor="middle" fill="#000000">(Poll every x ms)</text>
+
+        <!-- Arrow -->
+        <path d="M 170 240 L 170 260" stroke="#666666" stroke-width="1.5" fill="none" marker-end="url(#arrowhead)"/>
+
+        <!-- TaskExecutors -->
+        <rect x="30" y="260" width="280" height="35" rx="8" ry="8" fill="#f8cecc" stroke="#b85450" stroke-width="1.5"/>
+        <text x="170" y="283" font-family="Helvetica, Arial, sans-serif" font-size="11" text-anchor="middle" fill="#000000">TaskExecutors</text>
+
+        <!-- Arrow to PostgreSQL -->
+        <path d="M 170 310 L 170 350" stroke="#666666" stroke-width="1.5" fill="none" marker-end="url(#arrowhead)"/>
+
+        <!-- PostgreSQL cylinder -->
+        <path d="M 95 365 Q 95 350 170 350 Q 245 350 245 365 L 245 430 Q 245 445 170 445 Q 95 445 95 430 Z" fill="#f5f5f5" stroke="#666666" stroke-width="1.5"/>
+        <ellipse cx="170" cy="365" rx="75" ry="15" fill="#f5f5f5" stroke="#666666" stroke-width="1.5"/>
+        <text x="170" y="390" font-family="Helvetica, Arial, sans-serif" font-size="11" text-anchor="middle" fill="#000000">PostgreSQL</text>
+        <text x="170" y="405" font-family="Helvetica, Arial, sans-serif" font-size="10" text-anchor="middle" fill="#000000">(edc_tasks)</text>
+        <text x="170" y="420" font-family="Helvetica, Arial, sans-serif" font-size="10" text-anchor="middle" fill="#000000">(Persistent)</text>
+    </g>
+</svg>

--- a/docs/assets/deployment_scenario3_multi_node_nats_sql.drawio
+++ b/docs/assets/deployment_scenario3_multi_node_nats_sql.drawio
@@ -1,0 +1,45 @@
+<mxfile host="65bd71144e">
+    <diagram id="scenario3-multi-node-nats-sql" name="Page-1">
+        <mxGraphModel dx="1000" dy="800" grid="1" gridSize="10" guides="1" tooltips="1" connect="1" arrows="1" fold="1" page="1" pageScale="1" pageWidth="900" pageHeight="700" math="0" shadow="0">
+            <root>
+                <mxCell id="0"/>
+                <mxCell id="1" parent="0"/>
+                <!-- Control Plane 1 -->
+                <mxCell id="cp1" value="Control Plane 1&lt;br&gt;(Task Publishers)" style="rounded=0;whiteSpace=wrap;html=1;verticalAlign=top;fontSize=11;fillColor=#f5f5f5;fontColor=#333333;strokeColor=#666666;fontStyle=1" vertex="1" parent="1">
+                    <mxGeometry x="20" y="20" width="180" height="110" as="geometry"/>
+                </mxCell>
+                <mxCell id="cp1-inner" value="State Machines&lt;br&gt;TaskStateListeners&lt;br&gt;NatsTaskPublisher" style="rounded=1;whiteSpace=wrap;html=1;fillColor=#dae8fc;strokeColor=#6c8ebf;fontSize=10;" vertex="1" parent="1">
+                    <mxGeometry x="30" y="60" width="160" height="60" as="geometry"/>
+                </mxCell>
+                <!-- Control Plane N -->
+                <mxCell id="cpn" value="Control Plane N&lt;br&gt;(Task Publishers)" style="rounded=0;whiteSpace=wrap;html=1;verticalAlign=top;fontSize=11;fillColor=#f5f5f5;fontColor=#333333;strokeColor=#666666;fontStyle=1" vertex="1" parent="1">
+                    <mxGeometry x="20" y="150" width="180" height="110" as="geometry"/>
+                </mxCell>
+                <mxCell id="cpn-inner" value="State Machines&lt;br&gt;TaskStateListeners&lt;br&gt;NatsTaskPublisher" style="rounded=1;whiteSpace=wrap;html=1;fillColor=#dae8fc;strokeColor=#6c8ebf;fontSize=10;" vertex="1" parent="1">
+                    <mxGeometry x="30" y="190" width="160" height="60" as="geometry"/>
+                </mxCell>
+                <!-- NATS JetStream -->
+                <mxCell id="nats" value="NATS JetStream&lt;br&gt;(Streams)&lt;br&gt;├─ cn-stream&lt;br&gt;└─ tp-stream" style="rounded=1;whiteSpace=wrap;html=1;fillColor=#fff2cc;strokeColor=#d6b656;fontSize=10;fontStyle=1;align=center;" vertex="1" parent="1">
+                    <mxGeometry x="240" y="100" width="140" height="80" as="geometry"/>
+                </mxCell>
+                <!-- Workers -->
+                <mxCell id="w1" value="Wkr 1&lt;br&gt;CN Sub" style="rounded=1;whiteSpace=wrap;html=1;fillColor=#f8cecc;strokeColor=#b85450;fontSize=10;" vertex="1" parent="1">
+                    <mxGeometry x="420" y="40" width="70" height="50" as="geometry"/>
+                </mxCell>
+                <mxCell id="w2" value="Wkr 2&lt;br&gt;CN Sub" style="rounded=1;whiteSpace=wrap;html=1;fillColor=#f8cecc;strokeColor=#b85450;fontSize=10;" vertex="1" parent="1">
+                    <mxGeometry x="500" y="40" width="70" height="50" as="geometry"/>
+                </mxCell>
+                <mxCell id="w3" value="Wkr 3&lt;br&gt;TP Sub" style="rounded=1;whiteSpace=wrap;html=1;fillColor=#d5e8d4;strokeColor=#82b366;fontSize=10;" vertex="1" parent="1">
+                    <mxGeometry x="420" y="100" width="70" height="50" as="geometry"/>
+                </mxCell>
+                <mxCell id="wn" value="Wkr N&lt;br&gt;TP Sub" style="rounded=1;whiteSpace=wrap;html=1;fillColor=#d5e8d4;strokeColor=#82b366;fontSize=10;" vertex="1" parent="1">
+                    <mxGeometry x="500" y="100" width="70" height="50" as="geometry"/>
+                </mxCell>
+                <!-- PostgreSQL -->
+                <mxCell id="pg" value="PostgreSQL&lt;br&gt;(Shared TaskDB)&lt;br&gt;(State DBs)" style="shape=cylinder3;whiteSpace=wrap;html=1;boundedLbl=1;backgroundOutline=1;size=10;fillColor=#f5f5f5;strokeColor=#666666;fontSize=10;" vertex="1" parent="1">
+                    <mxGeometry x="310" y="220" width="130" height="70" as="geometry"/>
+                </mxCell>
+            </root>
+        </mxGraphModel>
+    </diagram>
+</mxfile>

--- a/docs/assets/deployment_scenario3_multi_node_nats_sql.svg
+++ b/docs/assets/deployment_scenario3_multi_node_nats_sql.svg
@@ -1,0 +1,78 @@
+<svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" version="1.1" width="581px" height="321px" viewBox="-0.5 -0.5 581 321" style="background: transparent; background-color: transparent;" content="&lt;mxfile host=&quot;65bd71144e&quot;&gt;&lt;diagram id=&quot;scenario3-multi-node-nats-sql&quot; name=&quot;Page-1&quot;&gt;&lt;mxGraphModel&gt;&lt;root&gt;&lt;mxCell id=&quot;0&quot;/&gt;&lt;mxCell id=&quot;1&quot; parent=&quot;0&quot;/&gt;&lt;/root&gt;&lt;/mxGraphModel&gt;&lt;/diagram&gt;&lt;/mxfile&gt;">
+    <defs>
+        <marker id="arrowhead" markerWidth="10" markerHeight="7" refX="9" refY="3.5" orient="auto">
+            <polygon points="0 0, 10 3.5, 0 7" fill="#666666"/>
+        </marker>
+    </defs>
+    <g>
+        <!-- Control Plane 1 -->
+        <rect x="0" y="0" width="180" height="100" fill="#f5f5f5" stroke="#666666" stroke-width="1.5"/>
+        <text x="90" y="15" font-family="Helvetica, Arial, sans-serif" font-size="10" font-weight="bold" text-anchor="middle" fill="#333333">Control Plane 1</text>
+        <text x="90" y="28" font-family="Helvetica, Arial, sans-serif" font-size="9" text-anchor="middle" fill="#333333">(Task Publishers)</text>
+        <rect x="10" y="38" width="160" height="55" rx="6" ry="6" fill="#dae8fc" stroke="#6c8ebf" stroke-width="1.5"/>
+        <text x="90" y="53" font-family="Helvetica, Arial, sans-serif" font-size="9" text-anchor="middle" fill="#000000">State Machines</text>
+        <text x="90" y="66" font-family="Helvetica, Arial, sans-serif" font-size="9" text-anchor="middle" fill="#000000">TaskStateListeners</text>
+        <text x="90" y="79" font-family="Helvetica, Arial, sans-serif" font-size="9" text-anchor="middle" fill="#000000">NatsTaskPublisher</text>
+
+        <!-- Control Plane N -->
+        <rect x="0" y="115" width="180" height="100" fill="#f5f5f5" stroke="#666666" stroke-width="1.5"/>
+        <text x="90" y="130" font-family="Helvetica, Arial, sans-serif" font-size="10" font-weight="bold" text-anchor="middle" fill="#333333">Control Plane N</text>
+        <text x="90" y="143" font-family="Helvetica, Arial, sans-serif" font-size="9" text-anchor="middle" fill="#333333">(Task Publishers)</text>
+        <rect x="10" y="153" width="160" height="55" rx="6" ry="6" fill="#dae8fc" stroke="#6c8ebf" stroke-width="1.5"/>
+        <text x="90" y="168" font-family="Helvetica, Arial, sans-serif" font-size="9" text-anchor="middle" fill="#000000">State Machines</text>
+        <text x="90" y="181" font-family="Helvetica, Arial, sans-serif" font-size="9" text-anchor="middle" fill="#000000">TaskStateListeners</text>
+        <text x="90" y="194" font-family="Helvetica, Arial, sans-serif" font-size="9" text-anchor="middle" fill="#000000">NatsTaskPublisher</text>
+
+        <!-- Arrows from Control Planes to NATS -->
+        <path d="M 180 65 L 210 65 L 210 115 L 230 115" stroke="#666666" stroke-width="1.5" fill="none" marker-end="url(#arrowhead)"/>
+        <path d="M 180 180 L 210 180 L 210 115" stroke="#666666" stroke-width="1.5" fill="none"/>
+
+        <!-- NATS JetStream -->
+        <rect x="230" y="75" width="150" height="90" rx="8" ry="8" fill="#fff2cc" stroke="#d6b656" stroke-width="1.5"/>
+        <text x="305" y="95" font-family="Helvetica, Arial, sans-serif" font-size="10" font-weight="bold" text-anchor="middle" fill="#000000">NATS JetStream</text>
+        <text x="305" y="110" font-family="Helvetica, Arial, sans-serif" font-size="9" text-anchor="middle" fill="#000000">(Streams)</text>
+        <text x="305" y="128" font-family="Helvetica, Arial, sans-serif" font-size="9" text-anchor="middle" fill="#000000">cn-stream</text>
+        <text x="305" y="143" font-family="Helvetica, Arial, sans-serif" font-size="9" text-anchor="middle" fill="#000000">tp-stream</text>
+
+        <!-- Arrows from NATS to Workers -->
+        <path d="M 380 100 L 395 100 L 395 50 L 410 50" stroke="#666666" stroke-width="1.5" fill="none" marker-end="url(#arrowhead)"/>
+        <path d="M 380 100 L 395 100 L 395 50 L 485 50 L 485 50 L 485 50" stroke="#666666" stroke-width="1.5" fill="none"/>
+        <path d="M 485 50 L 500 50" stroke="#666666" stroke-width="1.5" fill="none" marker-end="url(#arrowhead)"/>
+        <path d="M 380 140 L 395 140 L 395 115 L 410 115" stroke="#666666" stroke-width="1.5" fill="none" marker-end="url(#arrowhead)"/>
+        <path d="M 380 140 L 395 140 L 395 115 L 500 115" stroke="#666666" stroke-width="1.5" fill="none" marker-end="url(#arrowhead)"/>
+
+        <!-- Worker 1 (CN) -->
+        <rect x="410" y="25" width="70" height="50" rx="6" ry="6" fill="#f8cecc" stroke="#b85450" stroke-width="1.5"/>
+        <text x="445" y="45" font-family="Helvetica, Arial, sans-serif" font-size="10" text-anchor="middle" fill="#000000">Wkr 1</text>
+        <text x="445" y="60" font-family="Helvetica, Arial, sans-serif" font-size="9" text-anchor="middle" fill="#000000">CN Sub</text>
+
+        <!-- Worker 2 (CN) -->
+        <rect x="500" y="25" width="70" height="50" rx="6" ry="6" fill="#f8cecc" stroke="#b85450" stroke-width="1.5"/>
+        <text x="535" y="45" font-family="Helvetica, Arial, sans-serif" font-size="10" text-anchor="middle" fill="#000000">Wkr 2</text>
+        <text x="535" y="60" font-family="Helvetica, Arial, sans-serif" font-size="9" text-anchor="middle" fill="#000000">CN Sub</text>
+
+        <!-- Worker 3 (TP) -->
+        <rect x="410" y="90" width="70" height="50" rx="6" ry="6" fill="#d5e8d4" stroke="#82b366" stroke-width="1.5"/>
+        <text x="445" y="110" font-family="Helvetica, Arial, sans-serif" font-size="10" text-anchor="middle" fill="#000000">Wkr 3</text>
+        <text x="445" y="125" font-family="Helvetica, Arial, sans-serif" font-size="9" text-anchor="middle" fill="#000000">TP Sub</text>
+
+        <!-- Worker N (TP) -->
+        <rect x="500" y="90" width="70" height="50" rx="6" ry="6" fill="#d5e8d4" stroke="#82b366" stroke-width="1.5"/>
+        <text x="535" y="110" font-family="Helvetica, Arial, sans-serif" font-size="10" text-anchor="middle" fill="#000000">Wkr N</text>
+        <text x="535" y="125" font-family="Helvetica, Arial, sans-serif" font-size="9" text-anchor="middle" fill="#000000">TP Sub</text>
+
+        <!-- Arrows from Workers to PostgreSQL -->
+        <path d="M 445 75 L 445 170 L 360 170 L 360 220" stroke="#666666" stroke-width="1.5" fill="none"/>
+        <path d="M 535 75 L 535 170 L 360 170" stroke="#666666" stroke-width="1.5" fill="none"/>
+        <path d="M 445 140 L 445 170" stroke="#666666" stroke-width="1.5" fill="none"/>
+        <path d="M 535 140 L 535 170" stroke="#666666" stroke-width="1.5" fill="none"/>
+        <path d="M 360 170 L 360 220" stroke="#666666" stroke-width="1.5" fill="none" marker-end="url(#arrowhead)"/>
+
+        <!-- PostgreSQL cylinder -->
+        <path d="M 260 240 Q 260 220 360 220 Q 460 220 460 240 L 460 295 Q 460 315 360 315 Q 260 315 260 295 Z" fill="#f5f5f5" stroke="#666666" stroke-width="1.5"/>
+        <ellipse cx="360" cy="240" rx="100" ry="20" fill="#f5f5f5" stroke="#666666" stroke-width="1.5"/>
+        <text x="360" y="265" font-family="Helvetica, Arial, sans-serif" font-size="10" text-anchor="middle" fill="#000000">PostgreSQL</text>
+        <text x="360" y="280" font-family="Helvetica, Arial, sans-serif" font-size="9" text-anchor="middle" fill="#000000">(Shared TaskDB)</text>
+        <text x="360" y="295" font-family="Helvetica, Arial, sans-serif" font-size="9" text-anchor="middle" fill="#000000">(State DBs)</text>
+    </g>
+</svg>

--- a/docs/assets/nats_multi_worker.drawio
+++ b/docs/assets/nats_multi_worker.drawio
@@ -1,0 +1,85 @@
+<mxfile host="65bd71144e">
+    <diagram id="nats-multi-worker" name="Page-1">
+        <mxGraphModel dx="1000" dy="600" grid="1" gridSize="10" guides="1" tooltips="1" connect="1" arrows="1" fold="1" page="1" pageScale="1" pageWidth="850" pageHeight="450" math="0" shadow="0">
+            <root>
+                <mxCell id="0"/>
+                <mxCell id="1" parent="0"/>
+                <!-- Control Plane 1 -->
+                <mxCell id="cp1" value="Control Plane 1" style="rounded=1;whiteSpace=wrap;html=1;fillColor=#dae8fc;strokeColor=#6c8ebf;fontSize=12;" vertex="1" parent="1">
+                    <mxGeometry x="120" y="30" width="140" height="50" as="geometry"/>
+                </mxCell>
+                <!-- Control Plane 2 -->
+                <mxCell id="cp2" value="Control Plane 2" style="rounded=1;whiteSpace=wrap;html=1;fillColor=#dae8fc;strokeColor=#6c8ebf;fontSize=12;" vertex="1" parent="1">
+                    <mxGeometry x="340" y="30" width="140" height="50" as="geometry"/>
+                </mxCell>
+                <!-- NatsTaskPublisher -->
+                <mxCell id="publisher" value="NatsTaskPublisher&lt;br&gt;(TaskListener)" style="rounded=1;whiteSpace=wrap;html=1;fillColor=#d5e8d4;strokeColor=#82b366;fontSize=12;" vertex="1" parent="1">
+                    <mxGeometry x="210" y="130" width="180" height="50" as="geometry"/>
+                </mxCell>
+                <!-- NATS JetStream -->
+                <mxCell id="nats" value="NATS JetStream" style="rounded=1;whiteSpace=wrap;html=1;fillColor=#fff2cc;strokeColor=#d6b656;fontSize=12;fontStyle=1" vertex="1" parent="1">
+                    <mxGeometry x="210" y="230" width="180" height="50" as="geometry"/>
+                </mxCell>
+                <!-- Worker 1 -->
+                <mxCell id="w1" value="Worker 1" style="rounded=1;whiteSpace=wrap;html=1;fillColor=#f8cecc;strokeColor=#b85450;fontSize=11;" vertex="1" parent="1">
+                    <mxGeometry x="20" y="330" width="90" height="40" as="geometry"/>
+                </mxCell>
+                <!-- Worker 2 -->
+                <mxCell id="w2" value="Worker 2" style="rounded=1;whiteSpace=wrap;html=1;fillColor=#f8cecc;strokeColor=#b85450;fontSize=11;" vertex="1" parent="1">
+                    <mxGeometry x="130" y="330" width="90" height="40" as="geometry"/>
+                </mxCell>
+                <!-- Worker 3 -->
+                <mxCell id="w3" value="Worker 3" style="rounded=1;whiteSpace=wrap;html=1;fillColor=#f8cecc;strokeColor=#b85450;fontSize=11;" vertex="1" parent="1">
+                    <mxGeometry x="240" y="330" width="90" height="40" as="geometry"/>
+                </mxCell>
+                <!-- ... -->
+                <mxCell id="dots" value="..." style="text;html=1;strokeColor=none;fillColor=none;align=center;verticalAlign=middle;whiteSpace=wrap;rounded=0;fontSize=14;fontStyle=1" vertex="1" parent="1">
+                    <mxGeometry x="350" y="330" width="40" height="40" as="geometry"/>
+                </mxCell>
+                <!-- Worker N -->
+                <mxCell id="wn" value="Worker N" style="rounded=1;whiteSpace=wrap;html=1;fillColor=#f8cecc;strokeColor=#b85450;fontSize=11;" vertex="1" parent="1">
+                    <mxGeometry x="410" y="330" width="90" height="40" as="geometry"/>
+                </mxCell>
+                <!-- TaskExecutor label -->
+                <mxCell id="executor" value="TaskExecutor (same for all)" style="text;html=1;strokeColor=none;fillColor=none;align=center;verticalAlign=middle;whiteSpace=wrap;rounded=0;fontSize=12;fontStyle=2" vertex="1" parent="1">
+                    <mxGeometry x="160" y="390" width="200" height="30" as="geometry"/>
+                </mxCell>
+                <!-- Arrow: CP1 to Publisher -->
+                <mxCell id="e1" style="edgeStyle=orthogonalEdgeStyle;rounded=0;orthogonalLoop=1;jettySize=auto;html=1;strokeColor=#666666;strokeWidth=2;" edge="1" parent="1" source="cp1" target="publisher">
+                    <mxGeometry relative="1" as="geometry"/>
+                </mxCell>
+                <!-- Arrow: CP2 to Publisher -->
+                <mxCell id="e2" style="edgeStyle=orthogonalEdgeStyle;rounded=0;orthogonalLoop=1;jettySize=auto;html=1;strokeColor=#666666;strokeWidth=2;" edge="1" parent="1" source="cp2" target="publisher">
+                    <mxGeometry relative="1" as="geometry"/>
+                </mxCell>
+                <!-- Arrow: Publisher to NATS -->
+                <mxCell id="e3" style="edgeStyle=orthogonalEdgeStyle;rounded=0;orthogonalLoop=1;jettySize=auto;html=1;strokeColor=#666666;strokeWidth=2;" edge="1" parent="1" source="publisher" target="nats">
+                    <mxGeometry relative="1" as="geometry"/>
+                </mxCell>
+                <!-- Arrow: NATS to Worker 1 -->
+                <mxCell id="e4" style="edgeStyle=orthogonalEdgeStyle;rounded=0;orthogonalLoop=1;jettySize=auto;html=1;strokeColor=#666666;strokeWidth=2;" edge="1" parent="1" source="nats" target="w1">
+                    <mxGeometry relative="1" as="geometry"/>
+                </mxCell>
+                <!-- Arrow: NATS to Worker 2 -->
+                <mxCell id="e5" style="edgeStyle=orthogonalEdgeStyle;rounded=0;orthogonalLoop=1;jettySize=auto;html=1;strokeColor=#666666;strokeWidth=2;" edge="1" parent="1" source="nats" target="w2">
+                    <mxGeometry relative="1" as="geometry"/>
+                </mxCell>
+                <!-- Arrow: NATS to Worker 3 -->
+                <mxCell id="e6" style="edgeStyle=orthogonalEdgeStyle;rounded=0;orthogonalLoop=1;jettySize=auto;html=1;strokeColor=#666666;strokeWidth=2;" edge="1" parent="1" source="nats" target="w3">
+                    <mxGeometry relative="1" as="geometry"/>
+                </mxCell>
+                <!-- Arrow: NATS to Worker N -->
+                <mxCell id="e7" style="edgeStyle=orthogonalEdgeStyle;rounded=0;orthogonalLoop=1;jettySize=auto;html=1;strokeColor=#666666;strokeWidth=2;" edge="1" parent="1" source="nats" target="wn">
+                    <mxGeometry relative="1" as="geometry"/>
+                </mxCell>
+                <!-- Bracket for TaskExecutor -->
+                <mxCell id="bracket" style="endArrow=none;html=1;strokeColor=#999999;strokeWidth=1;dashed=1;" edge="1" parent="1">
+                    <mxGeometry width="50" height="50" relative="1" as="geometry">
+                        <mxPoint x="65" y="380" as="sourcePoint"/>
+                        <mxPoint x="455" y="380" as="targetPoint"/>
+                    </mxGeometry>
+                </mxCell>
+            </root>
+        </mxGraphModel>
+    </diagram>
+</mxfile>

--- a/docs/assets/nats_multi_worker.svg
+++ b/docs/assets/nats_multi_worker.svg
@@ -1,0 +1,69 @@
+<svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" version="1.1" width="521px" height="431px" viewBox="-0.5 -0.5 521 431" style="background: transparent; background-color: transparent;" content="&lt;mxfile host=&quot;65bd71144e&quot;&gt;&lt;diagram id=&quot;nats-multi-worker&quot; name=&quot;Page-1&quot;&gt;&lt;mxGraphModel dx=&quot;1000&quot; dy=&quot;600&quot; grid=&quot;1&quot; gridSize=&quot;10&quot; guides=&quot;1&quot; tooltips=&quot;1&quot; connect=&quot;1&quot; arrows=&quot;1&quot; fold=&quot;1&quot; page=&quot;1&quot; pageScale=&quot;1&quot; pageWidth=&quot;850&quot; pageHeight=&quot;450&quot; math=&quot;0&quot; shadow=&quot;0&quot;&gt;&lt;root&gt;&lt;mxCell id=&quot;0&quot;/&gt;&lt;mxCell id=&quot;1&quot; parent=&quot;0&quot;/&gt;&lt;mxCell id=&quot;cp1&quot; value=&quot;Control Plane 1&quot; style=&quot;rounded=1;whiteSpace=wrap;html=1;fillColor=#dae8fc;strokeColor=#6c8ebf;fontSize=12;&quot; vertex=&quot;1&quot; parent=&quot;1&quot;&gt;&lt;mxGeometry x=&quot;120&quot; y=&quot;30&quot; width=&quot;140&quot; height=&quot;50&quot; as=&quot;geometry&quot;/&gt;&lt;/mxCell&gt;&lt;mxCell id=&quot;cp2&quot; value=&quot;Control Plane 2&quot; style=&quot;rounded=1;whiteSpace=wrap;html=1;fillColor=#dae8fc;strokeColor=#6c8ebf;fontSize=12;&quot; vertex=&quot;1&quot; parent=&quot;1&quot;&gt;&lt;mxGeometry x=&quot;340&quot; y=&quot;30&quot; width=&quot;140&quot; height=&quot;50&quot; as=&quot;geometry&quot;/&gt;&lt;/mxCell&gt;&lt;mxCell id=&quot;publisher&quot; value=&quot;NatsTaskPublisher (TaskListener)&quot; style=&quot;rounded=1;whiteSpace=wrap;html=1;fillColor=#d5e8d4;strokeColor=#82b366;fontSize=12;&quot; vertex=&quot;1&quot; parent=&quot;1&quot;&gt;&lt;mxGeometry x=&quot;210&quot; y=&quot;130&quot; width=&quot;180&quot; height=&quot;50&quot; as=&quot;geometry&quot;/&gt;&lt;/mxCell&gt;&lt;mxCell id=&quot;nats&quot; value=&quot;NATS JetStream&quot; style=&quot;rounded=1;whiteSpace=wrap;html=1;fillColor=#fff2cc;strokeColor=#d6b656;fontSize=12;fontStyle=1&quot; vertex=&quot;1&quot; parent=&quot;1&quot;&gt;&lt;mxGeometry x=&quot;210&quot; y=&quot;230&quot; width=&quot;180&quot; height=&quot;50&quot; as=&quot;geometry&quot;/&gt;&lt;/mxCell&gt;&lt;mxCell id=&quot;w1&quot; value=&quot;Worker 1&quot; style=&quot;rounded=1;whiteSpace=wrap;html=1;fillColor=#f8cecc;strokeColor=#b85450;fontSize=11;&quot; vertex=&quot;1&quot; parent=&quot;1&quot;&gt;&lt;mxGeometry x=&quot;20&quot; y=&quot;330&quot; width=&quot;90&quot; height=&quot;40&quot; as=&quot;geometry&quot;/&gt;&lt;/mxCell&gt;&lt;mxCell id=&quot;w2&quot; value=&quot;Worker 2&quot; style=&quot;rounded=1;whiteSpace=wrap;html=1;fillColor=#f8cecc;strokeColor=#b85450;fontSize=11;&quot; vertex=&quot;1&quot; parent=&quot;1&quot;&gt;&lt;mxGeometry x=&quot;130&quot; y=&quot;330&quot; width=&quot;90&quot; height=&quot;40&quot; as=&quot;geometry&quot;/&gt;&lt;/mxCell&gt;&lt;mxCell id=&quot;w3&quot; value=&quot;Worker 3&quot; style=&quot;rounded=1;whiteSpace=wrap;html=1;fillColor=#f8cecc;strokeColor=#b85450;fontSize=11;&quot; vertex=&quot;1&quot; parent=&quot;1&quot;&gt;&lt;mxGeometry x=&quot;240&quot; y=&quot;330&quot; width=&quot;90&quot; height=&quot;40&quot; as=&quot;geometry&quot;/&gt;&lt;/mxCell&gt;&lt;mxCell id=&quot;dots&quot; value=&quot;...&quot; style=&quot;text;html=1;strokeColor=none;fillColor=none;align=center;verticalAlign=middle;whiteSpace=wrap;rounded=0;fontSize=14;fontStyle=1&quot; vertex=&quot;1&quot; parent=&quot;1&quot;&gt;&lt;mxGeometry x=&quot;350&quot; y=&quot;330&quot; width=&quot;40&quot; height=&quot;40&quot; as=&quot;geometry&quot;/&gt;&lt;/mxCell&gt;&lt;mxCell id=&quot;wn&quot; value=&quot;Worker N&quot; style=&quot;rounded=1;whiteSpace=wrap;html=1;fillColor=#f8cecc;strokeColor=#b85450;fontSize=11;&quot; vertex=&quot;1&quot; parent=&quot;1&quot;&gt;&lt;mxGeometry x=&quot;410&quot; y=&quot;330&quot; width=&quot;90&quot; height=&quot;40&quot; as=&quot;geometry&quot;/&gt;&lt;/mxCell&gt;&lt;mxCell id=&quot;executor&quot; value=&quot;TaskExecutor (same for all)&quot; style=&quot;text;html=1;strokeColor=none;fillColor=none;align=center;verticalAlign=middle;whiteSpace=wrap;rounded=0;fontSize=12;fontStyle=2&quot; vertex=&quot;1&quot; parent=&quot;1&quot;&gt;&lt;mxGeometry x=&quot;160&quot; y=&quot;390&quot; width=&quot;200&quot; height=&quot;30&quot; as=&quot;geometry&quot;/&gt;&lt;/mxCell&gt;&lt;/root&gt;&lt;/mxGraphModel&gt;&lt;/diagram&gt;&lt;/mxfile&gt;">
+    <defs>
+        <marker id="arrowhead" markerWidth="10" markerHeight="7" refX="9" refY="3.5" orient="auto">
+            <polygon points="0 0, 10 3.5, 0 7" fill="#666666"/>
+        </marker>
+    </defs>
+    <g>
+        <!-- Control Plane 1 -->
+        <rect x="100" y="0" width="140" height="50" rx="8" ry="8" fill="#dae8fc" stroke="#6c8ebf" stroke-width="1.5"/>
+        <text x="170" y="30" font-family="Helvetica, Arial, sans-serif" font-size="12" text-anchor="middle" fill="#000000">Control Plane 1</text>
+
+        <!-- Control Plane 2 -->
+        <rect x="320" y="0" width="140" height="50" rx="8" ry="8" fill="#dae8fc" stroke="#6c8ebf" stroke-width="1.5"/>
+        <text x="390" y="30" font-family="Helvetica, Arial, sans-serif" font-size="12" text-anchor="middle" fill="#000000">Control Plane 2</text>
+
+        <!-- Arrows from Control Planes to Publisher -->
+        <path d="M 170 50 L 170 80 L 260 80 L 260 100" stroke="#666666" stroke-width="2" fill="none" marker-end="url(#arrowhead)"/>
+        <path d="M 390 50 L 390 80 L 300 80 L 300 100" stroke="#666666" stroke-width="2" fill="none" marker-end="url(#arrowhead)"/>
+
+        <!-- NatsTaskPublisher -->
+        <rect x="170" y="100" width="220" height="50" rx="8" ry="8" fill="#d5e8d4" stroke="#82b366" stroke-width="1.5"/>
+        <text x="280" y="122" font-family="Helvetica, Arial, sans-serif" font-size="12" text-anchor="middle" fill="#000000">NatsTaskPublisher</text>
+        <text x="280" y="138" font-family="Helvetica, Arial, sans-serif" font-size="11" text-anchor="middle" fill="#000000">(TaskListener)</text>
+
+        <!-- Arrow from Publisher to NATS -->
+        <path d="M 280 150 L 280 200" stroke="#666666" stroke-width="2" fill="none" marker-end="url(#arrowhead)"/>
+
+        <!-- NATS JetStream -->
+        <rect x="170" y="200" width="220" height="50" rx="8" ry="8" fill="#fff2cc" stroke="#d6b656" stroke-width="1.5"/>
+        <text x="280" y="230" font-family="Helvetica, Arial, sans-serif" font-size="12" font-weight="bold" text-anchor="middle" fill="#000000">NATS JetStream</text>
+
+        <!-- Arrows from NATS to Workers -->
+        <path d="M 210 250 L 210 270 L 65 270 L 65 300" stroke="#666666" stroke-width="2" fill="none" marker-end="url(#arrowhead)"/>
+        <path d="M 240 250 L 240 280 L 175 280 L 175 300" stroke="#666666" stroke-width="2" fill="none" marker-end="url(#arrowhead)"/>
+        <path d="M 280 250 L 280 300" stroke="#666666" stroke-width="2" fill="none" marker-end="url(#arrowhead)"/>
+        <path d="M 320 250 L 320 280 L 455 280 L 455 300" stroke="#666666" stroke-width="2" fill="none" marker-end="url(#arrowhead)"/>
+
+        <!-- Worker 1 -->
+        <rect x="20" y="300" width="90" height="40" rx="6" ry="6" fill="#f8cecc" stroke="#b85450" stroke-width="1.5"/>
+        <text x="65" y="325" font-family="Helvetica, Arial, sans-serif" font-size="11" text-anchor="middle" fill="#000000">Worker 1</text>
+
+        <!-- Worker 2 -->
+        <rect x="130" y="300" width="90" height="40" rx="6" ry="6" fill="#f8cecc" stroke="#b85450" stroke-width="1.5"/>
+        <text x="175" y="325" font-family="Helvetica, Arial, sans-serif" font-size="11" text-anchor="middle" fill="#000000">Worker 2</text>
+
+        <!-- Worker 3 -->
+        <rect x="235" y="300" width="90" height="40" rx="6" ry="6" fill="#f8cecc" stroke="#b85450" stroke-width="1.5"/>
+        <text x="280" y="325" font-family="Helvetica, Arial, sans-serif" font-size="11" text-anchor="middle" fill="#000000">Worker 3</text>
+
+        <!-- ... -->
+        <text x="370" y="325" font-family="Helvetica, Arial, sans-serif" font-size="14" font-weight="bold" text-anchor="middle" fill="#000000">...</text>
+
+        <!-- Worker N -->
+        <rect x="410" y="300" width="90" height="40" rx="6" ry="6" fill="#f8cecc" stroke="#b85450" stroke-width="1.5"/>
+        <text x="455" y="325" font-family="Helvetica, Arial, sans-serif" font-size="11" text-anchor="middle" fill="#000000">Worker N</text>
+
+        <!-- Dashed bracket line -->
+        <path d="M 40 350 L 480 350" stroke="#999999" stroke-width="1" stroke-dasharray="4,4" fill="none"/>
+
+        <!-- TaskExecutor label -->
+        <text x="260" y="390" font-family="Helvetica, Arial, sans-serif" font-size="12" font-style="italic" text-anchor="middle" fill="#000000">TaskExecutor (same for all)</text>
+
+        <!-- Bracket arrows from workers to executor -->
+        <path d="M 65 340 L 65 365" stroke="#999999" stroke-width="1" fill="none"/>
+        <path d="M 175 340 L 175 365" stroke="#999999" stroke-width="1" fill="none"/>
+        <path d="M 280 340 L 280 365" stroke="#999999" stroke-width="1" fill="none"/>
+        <path d="M 455 340 L 455 365" stroke="#999999" stroke-width="1" fill="none"/>
+    </g>
+</svg>

--- a/docs/task_based_architecture.md
+++ b/docs/task_based_architecture.md
@@ -1,0 +1,904 @@
+# Task-Based State Machine Architecture
+
+## Table of Contents
+
+1. [Overview](#overview)
+2. [Architecture Overview](#architecture-overview)
+3. [Task Framework](#task-framework)
+4. [Task Lifecycle](#task-lifecycle)
+5. [Execution Models](#execution-models)
+6. [Task-Based vs CDC-Based](#task-based-vs-cdc-based)
+7. [Deployment Scenarios](#deployment-scenarios)
+8. [Implementation Details](#implementation-details)
+9. [Configuration Reference](#configuration-reference)
+
+---
+
+## Overview
+
+The Virtual-Connector project will implement an experimental **task-based state machine architecture** as an
+alternative to current Change Data Capture (CDC) approaches. This architecture introduces **explicit work queue
+abstraction** between state transitions and their execution, enabling better decoupling, observability, and scalability.
+
+This document describes the design and first implementation of the task-based state machine architecture, including core
+concepts and components. The document may evolve as the implementation matures.
+
+### Motivation
+
+The task-based approach addresses key limitations of CDC-based or entity polling state machines:
+
+- **Decoupling**: State transitions are decoupled from task execution logic
+- **Explicit Work Representation**: Tasks are first-class entities that can be persisted, queried, and monitored
+- **Flexible Execution Models**: Supports both single-node polling, distributed NATS-based processing and custom models
+- **Built-in Retry Logic**: Tasks are automatically retried via timestamp-based scheduling
+- **Better Observability**: Task store provides queryable view of pending work
+- **Crash Recovery**: Task persistence (with SQL storage) survives control plane restarts
+
+### Architecture Pattern
+
+```
+State Transition → StateListener → Task Created → TaskStore/NATS Publisher
+                                        ↓
+                                   TaskExecutor
+                                        ↓
+                                   State Update
+                                        ↓
+                                  (cycle repeats)
+```
+
+---
+
+## Architecture Overview
+
+### Core Concepts
+
+The task-based state machine is built on four fundamental concepts:
+
+1. **Tasks**: Explicit work items representing a unit of work to be executed
+2. **TaskStore**: Persistent (or in-memory) storage for tasks with concurrency control
+3. **TaskExecutors**: Type-specific processors for different task payloads
+4. **TaskListeners**: Observers that react to task creation events
+
+### Key Components
+
+#### Task
+
+A generic container for work items with three attributes:
+
+- **id**: Unique identifier (UUID)
+- **at**: Timestamp when task should be executed
+- **payload**: Type-specific work definition (polymorphic)
+
+Tasks are immutable once created and use Jackson for JSON serialization with external type information.
+
+#### TaskStore
+
+Persistent or in-memory storage layer providing:
+
+- `create(Task)`: Store new task
+- `fetchForUpdate(QuerySpec)`: Retrieve tasks ready for execution with pessimistic locking
+- `update(Task)`: Update existing task (e.g., for retry)
+- `delete(String id)`: Remove completed task
+- `findById(String id)`: Retrieve specific task
+
+Implementations:
+
+- **InMemoryTaskStore**: For development and single-instance deployments
+- **SqlTaskStore**: For production with PostgreSQL persistence
+
+#### TaskService
+
+Wrapper around TaskStore providing:
+
+- Transaction management
+- Observable notification on task creation
+- Consistency guarantees
+
+#### TaskObservable/TaskListener
+
+Observer pattern implementation:
+
+- `TaskObservable`: Central registry for task lifecycle listeners
+- `TaskListener`: Interface for observers with `created(Task)` callback
+
+This enables loose coupling between task creation and downstream actions (publishing to NATS, logging, etc.).
+
+---
+
+## Task Framework
+
+### Core Entities
+
+#### Task Structure
+
+```java
+public class Task {
+    protected String id;              // UUID
+    protected long at;                // Timestamp (milliseconds)
+    protected TaskPayload payload;              // Type-specific payload
+
+    // Methods
+    public String getId() { ...}
+
+    public long getAt() { ...}
+
+    public TaskPayload getPayload() { ...}
+
+    public Task.Builder<T> toBuilder() { ...}
+}
+```
+
+#### TaskPayload Interface
+
+Base interface for all task payloads:
+
+```java
+public interface TaskPayload {
+    String name();  // Unique identifier: e.g., "negotiation.request.prepare"
+}
+```
+
+Extended by `ProcessTaskPayload` which adds:
+
+```java
+public abstract class ProcessTaskPayload implements TaskPayload {
+    protected String processId;       // Negotiation or Transfer Process ID
+    protected String processState;    // Current state (INITIAL, REQUESTING, etc.)
+    protected String processType;     // CONSUMER or PROVIDER
+}
+```
+
+### Task Types
+
+Those are the initial task types defined for contract negotiations and transfer processes.
+Type and naming conventions may evolve as implementation matures.
+
+#### Contract Negotiation Tasks
+
+Used to drive the contract negotiation state machine through completion:
+
+| Task Type                   | Name                          | Description                    |
+|-----------------------------|-------------------------------|--------------------------------|
+| RequestNegotiation          | negotiation.request.prepare   | Transition to REQUESTING state |
+| SendRequestNegotiation      | negotiation.request.send      | Send ContractRequestMessage    |
+| AgreeNegotiation            | negotiation.agree             | Transition to AGREEING state   |
+| SendAgreementNegotiation    | negotiation.agreement.send    | Send ContractAgreementMessage  |
+| VerifyNegotiation           | negotiation.verify            | Transition to VERIFYING state  |
+| SendVerificationNegotiation | negotiation.verification.send | Send verification message      |
+| FinalizeNegotiation         | negotiation.finalize          | Transition to FINALIZING state |
+| SendFinalizeNegotiation     | negotiation.finalize.send     | Send finalize message          |
+
+
+#### Transfer Process Tasks
+
+Used to drive transfer process through preparation, startup, suspension, resumption, termination, and completion:
+
+| Task Type             | Name                    | Description                            |
+|-----------------------|-------------------------|----------------------------------------|
+| PrepareTransfer       | transfer.prepare        | Validate transfer, provision resources |
+| SendTransferRequest   | transfer.request.send   | Send transfer request message          |
+| StartDataflow         | transfer.start.send     | Signal data plane to start data flow   |
+| SignalDataFlowStarted | transfer.started.signal | Receive and process data flow started  |
+| SuspendDataFlow       | transfer.suspend        | Suspend active data flow               |
+| ResumeDataFlow        | transfer.resume         | Resume suspended data flow             |
+| TerminateDataFlow     | transfer.terminate      | Terminate active or pending data flow  |
+| CompleteDataFlow      | transfer.complete       | Mark transfer as complete              |
+
+### TaskStore Interface
+
+```java
+public interface TaskStore {
+    /**
+     * Create and persist a new task.
+     */
+    void create(Task task);
+
+    /**
+     * Fetch and lock tasks ready for execution.
+     * Uses pessimistic locking to prevent duplicate processing.
+     */
+    List<Task> fetchForUpdate(QuerySpec querySpec);
+
+    /**
+     * Update an existing task (e.g., for retry scheduling).
+     */
+    void update(Task task);
+
+    /**
+     * Delete a completed task.
+     */
+    void delete(String id);
+
+    /**
+     * Retrieve task by ID.
+     */
+    Task findById(String id);
+}
+```
+
+**Key Locking Mechanism**:
+
+- `fetchForUpdate()` uses pessimistic locking (transaction-level)
+- Prevents multiple workers from processing the same task
+- SQL implementation uses database transactions for consistency
+
+---
+
+## Task Lifecycle
+
+### Phase 1: Task Creation from State Transitions
+
+Currently for integrating with upstream EDC, we can detect the state changes via listeners
+and create tasks accordingly:
+
+#### ContractNegotiationStateListener
+
+Listens to contract negotiation state changes and creates appropriate tasks:
+
+```java
+
+@Override
+public void initiated(ContractNegotiation negotiation) {
+    // If consumer:
+    // Create RequestNegotiation task to start negotiation flow
+    // Store task → triggers TaskObservable → notifies listeners
+}
+
+@Override
+public void requested(ContractNegotiation negotiation) {
+    // If provider: create AgreeNegotiation task
+    // If consumer: no action (awaiting counter-party response)
+}
+```
+
+**State to Task Mapping**:
+
+- INITIATED → RequestNegotiation task (consumer only)
+- REQUESTING → SendRequestNegotiation task (consumer only)
+- REQUESTED → VerifyNegotiation task (consumer only)
+- REQUESTED → AgreeNegotiation task (provider only)
+- AGREED → FinalizeNegotiation task (provider only)
+- AGREEING → SendAgreementNegotiation task (provider only)
+- VERIFYING → SendVerificationNegotiation task (consumer only)
+- VERIFIED → FinalizeNegotiation task (provider only)
+
+#### TransferProcessStateListener
+
+Similar pattern for transfer processes:
+
+```java
+
+@Override
+public void initiated(TransferProcess process) {
+    // Create PrepareTransfer task
+    taskService.create(Task.Builder.newInstance()
+            .at(System.currentTimeMillis())
+            .payload(PrepareTransfer.Builder.newInstance()
+                    .processId(process.getId())
+                    .processState(process.stateAsString())
+                    .processType(process.getType().name())
+                    .build())
+            .build());
+}
+```
+
+**State to Task Mapping**:
+
+- INITIATED → PrepareTransfer task (both consumer and provider)
+- REQUESTING → SendTransferRequest task (consumer only)
+- STARTING → StartDataflow task (provider only)
+- STARTING (on protocol request) → StartDataflow task (provider only)
+- STARTUP_REQUESTED → SignalDataflowStarted task (consumer only)
+- SUSPENDING → SuspendDataFlow task (both consumer and provider)
+- SUSPENDING_REQUESTED → SuspendDataFlow task (both consumer and provider)
+- TERMINATING → TerminateDataFlow task (both consumer and provider)
+- TERMINATING_REQUESTED → TerminateDataFlow task (both consumer and provider)
+- COMPLETING → CompleteDataFlow task (both consumer and provider)
+- COMPLETING_REQUESTED → CompleteDataFlow task (both consumer and provider)
+- RESUMING → ResumeDataFlow task (both consumer and provider)
+
+### Phase 2: Task Storage and Publication
+
+When task is created, `TaskObservable` notifies registered listeners:
+
+#### Option A: NATS Publisher Model (Distributed)
+
+When using NATS JetStream a publisher listener publishes task to NATS
+withing the `created()` callback:
+
+```
+TaskService.create()
+  → TaskObservable.created()
+  → Task stored in TaskStore
+  → NatsTaskPublisher.created()
+  → Publish to NATS JetStream with subject
+```
+
+#### Option B: Polling Model (Single Node)
+
+```
+TaskService.create()
+  → TaskObservable.created()
+  → Task stored in TaskStore
+  → TaskPollExecutor polls and executes
+```
+
+### Phase 3: Task Execution
+
+#### ContractNegotiationTaskExecutor
+
+Handles all contract negotiation task types:
+
+```java
+public class ContractNegotiationTaskExecutorImpl
+        implements ContractNegotiationTaskExecutor {
+
+    private Map<Class<?>, Handler> handlers = new HashMap<>();
+
+    public StatusResult<Void> handle(ContractNegotiationTaskPayload task) {
+        return transactionContext.execute(() -> {
+            // 1. Load negotiation from store
+
+            // 2. Validate state matches expected state
+
+            // 3. Validate process type (CONSUMER vs PROVIDER)
+
+            // 4. Check pending guard
+
+            // 5. Execute handler
+
+            return result;
+        });
+    }
+
+}
+```
+
+**Execution Pattern**:
+
+1. Load process entity from store
+2. Validate current state matches expected state
+3. Validate process type (CONSUMER/PROVIDER)
+4. Check pending guards (external dependencies)
+5. Execute handler function
+6. Handler may create follow-up tasks
+7. Return success/failure status
+
+#### Transfer Process Executor
+
+Similar pattern with additional complexity:
+
+- Integrates with `DataFlowController` for data plane coordination
+- Handles provisioning operations
+- Manages suspension/resumption
+- Terminates with cleanup
+
+### Phase 4: Task Completion or Retry
+
+#### Success Path
+
+- Task deleted from TaskStore
+- If NATS: Message acknowledged
+- Process advances to next state
+
+#### Failure Path
+
+- **Transient Errors**: Task timestamp updated to future time → automatic retry
+- **Fatal Errors**: Task deleted, process transitioned to TERMINATED state
+
+**Retry Scheduling**:
+
+```java
+private void executeTask(Task task) {
+    var result = handleTask(task);
+    if (result.succeeded()) {
+        taskStore.delete(task.getId());
+    } else {
+        // Retry: update timestamp for next attempt
+        taskStore.update(task.toBuilder()
+                .at(clock.millis())  // Current time = immediate retry
+                .build());
+    }
+}
+```
+
+---
+
+## Execution Models
+
+Virtual-Connector out-of the box supports two complementary execution models for processing tasks:
+
+### Polling-Based Execution
+
+#### Overview
+
+TaskPollExecutor provides single-threaded polling of TaskStore for simple deployments:
+
+```
+Control Plane
+  ├─ TaskStore (in-memory or SQL)
+  └─ TaskPollExecutor
+      └─ Poll every x ms → Execute tasks → Update store
+```
+
+#### Implementation
+
+```java
+public class TaskPollExecutor {
+    private final TaksStore store;
+
+
+    private void run() {
+        transactionContext.execute(() -> {
+            try {
+                // Fetch the oldest task ready for execution from the store
+                // Execute the task
+                // If no tasks, sleep for polling interval
+                // If execution fails, log error and retry later
+            } finally {
+                // Schedule next iteration
+            }
+        });
+    }
+
+}
+```
+
+#### Characteristics
+
+- **Thread Model**: Single-threaded scheduled executor per node
+- **Polling Interval**: (configurable)
+- **Batch Size**: 1 task per poll (fetchForUpdate limit=1)
+- **State**: Fetches tasks ordered by timestamp ASC (FIFO)
+- **Concurrency**:
+    - **With SKIP LOCKED**: Multiple workers on same cluster
+- **Persistence**: Optional (in-memory or SQL)
+- **Distribution**:
+    - Single-node (in-memory)
+    - Multi-node (SQL with SKIP LOCKED) - **requires database enhancement**
+
+#### Use Cases
+
+✅ **Recommended for**:
+
+- Development and testing
+- Single-instance control plane
+- Simple deployments without NATS infrastructure
+- Debugging and understanding task flow
+- Multi-node deployments when NATS is unavailable (with SKIP LOCKED enhancement)
+
+❌ **Not recommended for**:
+
+- Multi-worker deployments without SKIP LOCKED support
+- Very high-throughput production scenarios (NATS better)
+- Complex distributed architectures (NATS more efficient)
+
+---
+
+### NATS-Based Distribution (Multi-Worker)
+
+#### Overview
+
+Task-based state machine provides true multi-worker support via NATS JetStream:
+
+![NATS Multi-Worker Architecture](assets/nats_multi_worker.svg)
+
+#### NatsTaskPublisher
+
+Implements `TaskListener` to publish tasks to NATS JetStream:
+
+```java
+public class NatsTaskPublisher implements TaskListener {
+    private final JetStream js;
+    private final ObjectMapper mapper;
+
+    @Override
+    public void created(Task task) {
+        try {
+            // Serialize task to JSON
+            var message = mapper.writeValueAsString(task);
+
+            // Publish to NATS with type-based subject
+            var subject = formatSubject(task);
+            js.publish(subject, message.getBytes());
+
+        } catch (Exception e) {
+            throw new EdcException("Failed to publish task", e);
+        }
+    }
+
+    private String formatSubject(Task task) {
+        // Task to subject  mapping logic  
+    }
+}
+```
+
+#### Subject Naming Convention
+
+Tasks are published to hierarchical subjects for targeted routing:
+
+**Contract Negotiations**:
+
+```
+negotiations.consumer.negotiation.request.prepare
+negotiations.consumer.negotiation.request.send
+negotiations.provider.negotiation.agree
+negotiations.provider.negotiation.agreement.send
+```
+
+**Transfer Processes**:
+
+```
+transfers.consumer.transfer.prepare
+transfers.consumer.transfer.started.signal
+transfers.provider.transfer.start.send
+transfers.provider.transfer.complete
+```
+
+Pattern: `{domain}.{processType}.{taskName}`
+
+> Subjects hierarchy is subject to change as implementation matures.
+
+#### NatsTaskSubscriber
+
+Base class for all NATS-based task subscribers:
+
+```java
+public abstract class NatsSubscriber {
+    private final JetStream jetStream;
+    private final ExecutorService executor;
+    private final AtomicBoolean active = new AtomicBoolean();
+
+    public void start() {
+        active.set(true);
+        executor.submit(() -> run(subscription));
+    }
+
+    private void run(JetStreamSubscription sub) {
+        while (active.get()) {
+            try {
+                // Fetch batch of messages (default: 100)
+                var messages = sub.fetch(batchSize, maxWaitMs);
+
+                for (var message : messages) {
+                    try {
+                        var result = handleMessage(message);
+                        if (result.succeeded()) {
+                            message.ack();  // Success: acknowledge
+                        } else if (result.fatalError()) {
+                            message.term();  // Fatal: terminate (don't retry)
+                        } else {
+                            message.nak();  // Transient: redelivery
+                        }
+                    } catch (Exception e) {
+                        message.nak();  // Exception: redelivery
+                    }
+                }
+            } catch (Exception e) {
+                // Subscription error - log and retry
+            }
+        }
+    }
+
+    public void stop() {
+        active.set(false);
+        executor.shutdown();
+    }
+}
+```
+
+**Implementations**:
+
+1. **NatsContractNegotiationTaskSubscriber**
+    - Subscribes to: `negotiations.>`
+    - Deserializes and delegates to ContractNegotiationTaskExecutor
+
+2. **NatsTransferProcessTaskSubscriber**
+    - Subscribes to: `transfers.>`
+    - Deserializes and delegates to TransferProcessTaskExecutor
+
+The subscribers run in separate worker instances, allowing horizontal scaling.
+Since we are publishing to NATS in the same transaction as task creation and state transition, subscribers
+should check task existence before processing to avoid doing work if the state transition
+failed after publishing.
+
+#### Multi-Worker Load Balancing
+
+NATS JetStream provides automatic load distribution via **consumer groups**:
+
+```properties
+# All workers use same consumer name → forms consumer group
+edc.nats.cn.subscriber.name=cn-subscriber
+# NATS automatically distributes messages across workers
+# Each message delivered to exactly ONE worker in the group
+```
+
+**How it works**:
+
+1. Multiple worker instances connect to same NATS server
+2. All use same consumer name → automatically form consumer group
+3. Each message published to stream is delivered to one worker
+4. Failed/timeout messages are redelivered to available workers
+5. Finished workers' unacknowledged messages go to remaining workers
+
+#### Message Acknowledgment Strategy
+
+| Scenario               | Action           | Result                                            |
+|------------------------|------------------|---------------------------------------------------|
+| Task succeeds          | `message.ack()`  | Message removed from stream, not redelivered      |
+| Task fails (transient) | `message.nak()`  | Message immediately redelivered to another worker |
+| Task fails (fatal)     | `message.term()` | Message removed, logs written, no retry           |
+| Worker crashes         | (timeout)        | Message redelivered to another worker             |
+
+#### Use Cases
+
+✅ **Recommended for**:
+
+- Production deployments with multiple workers
+- High-throughput scenarios requiring load distribution
+- Distributed architectures (multiple control planes)
+- Horizontal scaling by adding worker instances
+- Message replay and audit trail requirements
+
+#### Fault Tolerance
+
+- **Worker Crash**: NATS redelivers unacknowledged messages to other workers
+- **NATS Broker Down**: Subscriber retries connection, buffered messages in broker
+- **Message Loss**: JetStream persistence to disk prevents loss
+- **Network Partition**: Redelivery of in-flight messages
+
+---
+
+## Task-Based vs CDC-Based
+
+### CDC-Based Approach (Traditional State Machine)
+
+The CDC (Change Data Capture) model uses store wrappers or complex change detection system and listeners:
+
+```
+Store.save(entity)
+  → ChangeDetector 
+  → ChangeListener invoked
+  → Queue messages
+  → Background thread polls queue
+  → StateMachineService.handle(id, state)
+  → State transition
+```
+
+### Task-Based Approach (New)
+
+Tasks provide explicit work items:
+
+```
+State Transition (via Observable)
+  → StateListener.onStateChange()
+  → Task created
+  → TaskStore.create() + TaskObservable.notified()
+  → NatsPublisher OR Polling
+  → TaskExecutor.handle()
+  → State transition
+```
+
+### Detailed Comparison
+
+| Aspect                     | CDC-Based                                        | Task-Based (Polling)                     | Task-Based (NATS)                        |
+|----------------------------|--------------------------------------------------|------------------------------------------|------------------------------------------|
+| **State Change Detection** | Intercepted in entity save                       | Observable pattern outside store         | Observable pattern outside store         |
+| **Work Representation**    | Implicit (state change event)                    | Explicit (Task entity with full payload) | Explicit (Task entity with full payload) |
+| **Persistence**            | Change detection only                            | Full task persisted with retry data      | Full task persisted with retry data      |
+| **Execution Model**        | Direct call to StateMachineService               | Decoupled TaskExecutor pattern           | Decoupled TaskExecutor pattern           |
+| **Retry Logic**            | In-memory queue or Postgres CDC                  | Task timestamp-based, survives crash     | Message NACK-based, persisted on NATS    |
+| **Single-Worker**          | Built-in (in-process loopback)                   | TaskPollExecutor                         | N/A (use polling for single)             |
+| **Multi-Worker**           | NATS pub/sub (custom)                            | SQL SKIP LOCKED (database-level)         | Native NATS subscribers                  |
+| **Observability**          | Event log only                                   | Queryable task store                     | Queryable task store                     |
+| **Scalability**            | Limited (state change events) to a single worker | Good with SKIP LOCKED                    | Excellent (message-driven)               |
+| **Crash Recovery**         | Postgres CDC wal                                 | Tasks persist in SQL                     | Tasks on NATS stream + SQL               |
+| **Audit Trail**            | Events only                                      | Task entities + metadata                 | Task entities + metadata                 |
+| **External Dependencies**  | NATS (optional)                                  | PostgreSQL (SQL) or none (in-memory)     | NATS + PostgreSQL                        |
+
+### Key Differences
+
+#### 1. Work Representation
+
+**CDC**: State ID + new state code
+
+```java
+// CDC listener notified with minimal data
+listener.stateChanged("negotiation-123",REQUESTING);
+```
+
+**Task-Based**: Complete task data
+
+```java
+// Task contains all context needed for execution
+var task = Task.Builder.newInstance()
+                .payload(SendRequestNegotiation.Builder.newInstance()
+                        .processId("negotiation-123")
+                        .processState("REQUESTING")
+                        .processType("CONSUMER")
+                        .build())
+                .build();
+```
+
+#### 2. Persistence
+
+**CDC**: Changes are handled with Postgres CDC and WAL mechanism:
+
+- Complexity for managing the replication slot which is also exclusive for one consumer
+- Custom PG extensions needed.
+
+**Task-Based**: Persistent tasks
+
+- Tasks remain in store until executed
+- Executor crash doesn't lose work
+- Natural checkpoint for recovery
+
+#### 3. Routing and Dispatch
+
+- **CDC**: Changes need post-processing to determine next action
+- **Task-Based**: Task type directly specifies action needed
+
+#### 4. Decoupling
+
+- **CDC**: Listener tightly coupled to state machine internals
+- **Task-Based**: StateListener decoupled from TaskExecutor
+
+---
+
+## Deployment Scenarios
+
+### Scenario 1: Single-Node Development (Polling)
+
+**Use Case**: Development, testing, proof-of-concept
+
+**Architecture**:
+
+![Single-Node Development Architecture](assets/deployment_scenario1_single_node_polling.svg)
+
+**Characteristics**:
+
+- ✅ No external dependencies
+- ✅ Easy to develop and debug
+- ✅ Fast development cycle
+- ❌ Task loss on control plane restart
+- ❌ Single worker only
+
+---
+
+### Scenario 2: Single or Multi-Node Production (Polling + SQL with SKIP LOCKED)
+
+**Use Case**: Production control plane(s) with SQL persistence and task-based polling
+
+**Single-Node Architecture**:
+
+![Single-Node SQL Architecture](assets/deployment_scenario2_single_node_sql.svg)
+
+**Multi-Node Architecture (with SKIP LOCKED)**:
+
+![Multi-Node SKIP LOCKED Architecture](assets/deployment_scenario2_multi_node_skip_locked.svg)
+
+**Configuration (Single-Node)**:
+
+```properties
+# Use SqlTaskStore extension
+# PostgreSQL datasource configured via EDC settings
+# TaskPollExecutor automatically enabled
+```
+
+**Configuration (Multi-Node with SKIP LOCKED)**:
+
+```properties
+# All control planes and workers connect to same PostgreSQL
+edc.datasource.default.url=jdbc:postgresql://shared-db:5432/edc
+edc.datasource.default.user=edc
+edc.datasource.default.password=...
+# TaskPollExecutor runs on multiple nodes simultaneously
+# Database-level locking (SKIP LOCKED) prevents duplicate processing
+```
+
+**SQL Schema**:
+
+```sql
+CREATE TABLE edc_tasks (
+    id VARCHAR PRIMARY KEY,
+    name VARCHAR NOT NULL,
+    payload JSON DEFAULT '{}',
+    timestamp BIGINT NOT NULL,
+    CONSTRAINT unique_id UNIQUE (id)
+);
+
+CREATE INDEX idx_tasks_timestamp ON edc_tasks(timestamp ASC);
+```
+
+**How SKIP LOCKED Works**:
+
+- **FOR UPDATE**: Locks row(s) being fetched
+- **SKIP LOCKED**: Skips any rows already locked by other workers
+- **Multiple Pollers**: Each poller fetches different tasks (no duplicates)
+- **Transaction Scope**: Lock held only during transaction
+- **Automatic Release**: Lock released on COMMIT/ROLLBACK
+
+**Characteristics (Single-Node)**:
+
+- ✅ Task persistence across restarts
+- ✅ Crash recovery
+- ✅ Queryable task history
+- ✅ Single control plane
+- ❌ Single worker only (without SKIP LOCKED enhancement)
+- ❌ Requires PostgreSQL
+
+**Characteristics (Multi-Node with SKIP LOCKED)**:
+
+- ✅ Task persistence across restarts
+- ✅ Crash recovery
+- ✅ Queryable task history
+- ✅ Multiple control planes and workers
+- ✅ Automatic load distribution (database-level)
+- ✅ No external dependencies (no NATS needed)
+- ⚠️ Requires database-level SKIP LOCKED support (PostgreSQL, Oracle, etc.)
+- ⚠️ Polling overhead may increase with number of workers
+- ❌ Not as efficient as NATS for high-throughput scenarios
+
+**Comparison: Multi-Node Polling (SKIP LOCKED) vs NATS**:
+
+| Aspect                   | Polling + SKIP LOCKED                       | NATS                                           |
+|--------------------------|---------------------------------------------|------------------------------------------------|
+| **Setup Complexity**     | Low (SQL only)                              | Medium (NATS infrastructure)                   |
+| **Infrastructure**       | PostgreSQL (existing)                       | NATS broker + PostgreSQL                       |
+| **Load Distribution**    | Database-level                              | Message broker-level                           |
+| **Fault Tolerance**      | Worker restart → retries                    | Automatic redelivery to other workers          |
+| **Latency**              | Higher (x ms polling)                       | Lower (near-instant delivery)                  |
+| **Message Replay**       | No (tasks deleted on success)               | Yes (full NATS stream history)                 |
+| **Scalability**          | Good (add workers anytime)                  | Excellent (horizontal scaling)                 |
+| **Operational Overhead** | Low                                         | Medium (NATS monitoring)                       |
+| **When to Use**          | Small to medium clusters, no NATS available | Large clusters, high throughput, existing NATS |
+
+---
+
+### Scenario 3: Multi-Node Production (NATS + SQL)
+
+**Use Case**: High-availability, high-throughput production
+
+**Architecture**:
+
+![Multi-Node NATS + SQL Architecture](assets/deployment_scenario3_multi_node_nats_sql.svg)
+
+**Components**:
+
+1. **Control Planes** (2+):
+    - Run state machines
+    - Create tasks via TaskStateListeners
+    - Publish tasks to NATS
+    - Use shared PostgreSQL for state
+
+2. **NATS Broker**:
+    - Hosts JetStream streams
+    - `cn-stream` for contract negotiation tasks
+    - `tp-stream` for transfer process tasks
+    - Persists messages to disk
+
+3. **Worker Nodes** (2+):
+    - Run NatsTaskSubscriber instances
+    - Form consumer group (load distribution)
+    - Execute tasks via TaskExecutor
+    - Report results to NATS (ACK/NAK/TERM)
+
+4. **Shared PostgreSQL**:
+    - State database (contracts, transfers)
+    - TaskStore for recovery
+    - Visible to all control planes and workers
+
+**Characteristics**:
+
+- ✅ Multi-node deployment
+- ✅ Automatic load balancing via NATS
+- ✅ Horizontal scaling (add workers anytime)
+- ✅ Task persistence
+- ✅ Crash recovery
+- ✅ High availability
+- ✅ Message replay capability
+- ❌ Requires NATS infrastructure
+- ❌ Network dependencies
+- ❌ More complex setup
+
+---

--- a/extensions/control-plane/tasks/listener/tasks-store-listener/build.gradle.kts
+++ b/extensions/control-plane/tasks/listener/tasks-store-listener/build.gradle.kts
@@ -1,0 +1,31 @@
+/*
+ *  Copyright (c) 2026 Metaform Systems, Inc.
+ *
+ *  This program and the accompanying materials are made available under the
+ *  terms of the Apache License, Version 2.0 which is available at
+ *  https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Contributors:
+ *       Metaform Systems, Inc. - initial API and implementation
+ *
+ */
+
+plugins {
+    `java-library`
+}
+
+dependencies {
+    api(libs.edc.spi.core)
+    api(libs.edc.spi.contract)
+    api(libs.edc.spi.transaction)
+    api(libs.edc.spi.transfer)
+    api(project(":spi:v-core-spi"))
+    api(project(":spi:v-task-spi"))
+    testImplementation(libs.awaitility)
+    testImplementation(libs.edc.junit)
+    testImplementation(testFixtures(libs.edc.spi.contract))
+    testImplementation(libs.testcontainers.junit)
+}
+

--- a/extensions/control-plane/tasks/listener/tasks-store-listener/src/main/java/org/eclipse/edc/virtual/controlplane/listener/ContractNegotiationStateListener.java
+++ b/extensions/control-plane/tasks/listener/tasks-store-listener/src/main/java/org/eclipse/edc/virtual/controlplane/listener/ContractNegotiationStateListener.java
@@ -1,0 +1,75 @@
+/*
+ *  Copyright (c) 2026 Metaform Systems, Inc.
+ *
+ *  This program and the accompanying materials are made available under the
+ *  terms of the Apache License, Version 2.0 which is available at
+ *  https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Contributors:
+ *       Metaform Systems, Inc. - initial API and implementation
+ *
+ */
+
+package org.eclipse.edc.virtual.controlplane.listener;
+
+import org.eclipse.edc.connector.controlplane.contract.spi.negotiation.observe.ContractNegotiationListener;
+import org.eclipse.edc.connector.controlplane.contract.spi.types.negotiation.ContractNegotiation;
+import org.eclipse.edc.virtual.controlplane.contract.spi.negotiation.tasks.AgreeNegotiation;
+import org.eclipse.edc.virtual.controlplane.contract.spi.negotiation.tasks.FinalizeNegotiation;
+import org.eclipse.edc.virtual.controlplane.contract.spi.negotiation.tasks.RequestNegotiation;
+import org.eclipse.edc.virtual.controlplane.contract.spi.negotiation.tasks.VerifyNegotiation;
+import org.eclipse.edc.virtual.controlplane.tasks.ProcessTaskPayload;
+import org.eclipse.edc.virtual.controlplane.tasks.TaskService;
+
+import java.time.Clock;
+
+public class ContractNegotiationStateListener extends StateListener implements ContractNegotiationListener {
+
+    public ContractNegotiationStateListener(TaskService taskService, Clock clock) {
+        super(taskService, clock);
+    }
+
+    @Override
+    public void initiated(ContractNegotiation negotiation) {
+        var task = baseBuilder(RequestNegotiation.Builder.newInstance(), negotiation)
+                .build();
+        storeTask(task);
+    }
+
+    @Override
+    public void requested(ContractNegotiation negotiation) {
+        if (negotiation.getType() == ContractNegotiation.Type.PROVIDER) {
+            var task = baseBuilder(AgreeNegotiation.Builder.newInstance(), negotiation)
+                    .build();
+            storeTask(task);
+        }
+    }
+
+    @Override
+    public void agreed(ContractNegotiation negotiation) {
+        if (negotiation.getType() == ContractNegotiation.Type.CONSUMER) {
+            var task = baseBuilder(VerifyNegotiation.Builder.newInstance(), negotiation)
+                    .build();
+            storeTask(task);
+        }
+    }
+
+    @Override
+    public void verified(ContractNegotiation negotiation) {
+        if (negotiation.getType() == ContractNegotiation.Type.PROVIDER) {
+            var task = baseBuilder(FinalizeNegotiation.Builder.newInstance(), negotiation)
+                    .build();
+            storeTask(task);
+        }
+    }
+
+
+    protected <T extends ProcessTaskPayload, B extends ProcessTaskPayload.Builder<T, B>> B baseBuilder(B builder, ContractNegotiation negotiation) {
+        return builder.processId(negotiation.getId())
+                .processState(negotiation.stateAsString())
+                .processType(negotiation.getType().name());
+    }
+
+}

--- a/extensions/control-plane/tasks/listener/tasks-store-listener/src/main/java/org/eclipse/edc/virtual/controlplane/listener/StateListener.java
+++ b/extensions/control-plane/tasks/listener/tasks-store-listener/src/main/java/org/eclipse/edc/virtual/controlplane/listener/StateListener.java
@@ -1,0 +1,41 @@
+/*
+ *  Copyright (c) 2026 Metaform Systems, Inc.
+ *
+ *  This program and the accompanying materials are made available under the
+ *  terms of the Apache License, Version 2.0 which is available at
+ *  https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Contributors:
+ *       Metaform Systems, Inc. - initial API and implementation
+ *
+ */
+
+package org.eclipse.edc.virtual.controlplane.listener;
+
+import org.eclipse.edc.virtual.controlplane.tasks.Task;
+import org.eclipse.edc.virtual.controlplane.tasks.TaskPayload;
+import org.eclipse.edc.virtual.controlplane.tasks.TaskService;
+
+import java.time.Clock;
+
+public abstract class StateListener {
+
+    private final TaskService taskService;
+    private final Clock clock;
+
+    protected StateListener(TaskService taskService, Clock clock) {
+        this.taskService = taskService;
+        this.clock = clock;
+    }
+
+    protected void storeTask(TaskPayload payload) {
+        var task = Task.Builder.newInstance()
+                .at(clock.millis())
+                .payload(payload)
+                .build();
+        taskService.create(task);
+    }
+
+}

--- a/extensions/control-plane/tasks/listener/tasks-store-listener/src/main/java/org/eclipse/edc/virtual/controlplane/listener/StateMachineListenerExtension.java
+++ b/extensions/control-plane/tasks/listener/tasks-store-listener/src/main/java/org/eclipse/edc/virtual/controlplane/listener/StateMachineListenerExtension.java
@@ -1,0 +1,57 @@
+/*
+ *  Copyright (c) 2026 Metaform Systems, Inc.
+ *
+ *  This program and the accompanying materials are made available under the
+ *  terms of the Apache License, Version 2.0 which is available at
+ *  https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Contributors:
+ *       Metaform Systems, Inc. - initial API and implementation
+ *
+ */
+
+package org.eclipse.edc.virtual.controlplane.listener;
+
+import org.eclipse.edc.connector.controlplane.contract.spi.negotiation.observe.ContractNegotiationObservable;
+import org.eclipse.edc.connector.controlplane.transfer.spi.observe.TransferProcessObservable;
+import org.eclipse.edc.runtime.metamodel.annotation.Inject;
+import org.eclipse.edc.spi.event.EventRouter;
+import org.eclipse.edc.spi.system.ServiceExtension;
+import org.eclipse.edc.spi.system.ServiceExtensionContext;
+import org.eclipse.edc.spi.types.TypeManager;
+import org.eclipse.edc.transaction.spi.TransactionContext;
+import org.eclipse.edc.virtual.controlplane.tasks.TaskService;
+
+import java.time.Clock;
+
+public class StateMachineListenerExtension implements ServiceExtension {
+
+    @Inject
+    private TypeManager typeManager;
+
+    @Inject
+    private Clock clock;
+
+    @Inject
+    private EventRouter eventRouter;
+
+    @Inject
+    private TaskService taskService;
+
+    @Inject
+    private TransactionContext transactionContext;
+
+    @Inject
+    private TransferProcessObservable transferProcessObservable;
+
+    @Inject
+    private ContractNegotiationObservable contractNegotiationObservable;
+
+    @Override
+    public void initialize(ServiceExtensionContext context) {
+        transferProcessObservable.registerListener(new TransferProcessStateListener(taskService, clock));
+        contractNegotiationObservable.registerListener(new ContractNegotiationStateListener(taskService, clock));
+    }
+}

--- a/extensions/control-plane/tasks/listener/tasks-store-listener/src/main/java/org/eclipse/edc/virtual/controlplane/listener/TransferProcessStateListener.java
+++ b/extensions/control-plane/tasks/listener/tasks-store-listener/src/main/java/org/eclipse/edc/virtual/controlplane/listener/TransferProcessStateListener.java
@@ -1,0 +1,88 @@
+/*
+ *  Copyright (c) 2026 Metaform Systems, Inc.
+ *
+ *  This program and the accompanying materials are made available under the
+ *  terms of the Apache License, Version 2.0 which is available at
+ *  https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Contributors:
+ *       Metaform Systems, Inc. - initial API and implementation
+ *
+ */
+
+package org.eclipse.edc.virtual.controlplane.listener;
+
+import org.eclipse.edc.connector.controlplane.transfer.spi.observe.TransferProcessListener;
+import org.eclipse.edc.connector.controlplane.transfer.spi.types.TransferProcess;
+import org.eclipse.edc.virtual.controlplane.tasks.ProcessTaskPayload;
+import org.eclipse.edc.virtual.controlplane.tasks.TaskService;
+import org.eclipse.edc.virtual.controlplane.transfer.spi.tasks.CompleteDataFlow;
+import org.eclipse.edc.virtual.controlplane.transfer.spi.tasks.PrepareTransfer;
+import org.eclipse.edc.virtual.controlplane.transfer.spi.tasks.SignalDataflowStarted;
+import org.eclipse.edc.virtual.controlplane.transfer.spi.tasks.StartDataflow;
+import org.eclipse.edc.virtual.controlplane.transfer.spi.tasks.SuspendDataFlow;
+import org.eclipse.edc.virtual.controlplane.transfer.spi.tasks.TerminateDataFlow;
+
+import java.time.Clock;
+
+public class TransferProcessStateListener extends StateListener implements TransferProcessListener {
+
+    public TransferProcessStateListener(TaskService taskService, Clock clock) {
+        super(taskService, clock);
+    }
+
+    @Override
+    public void initiated(TransferProcess process) {
+        var task = baseBuilder(PrepareTransfer.Builder.newInstance(), process)
+                .build();
+        storeTask(task);
+    }
+
+    @Override
+    public void startupRequested(TransferProcess process) {
+        var task = baseBuilder(SignalDataflowStarted.Builder.newInstance(), process)
+                .build();
+
+        storeTask(task);
+    }
+
+    @Override
+    public void suspendingRequested(TransferProcess process) {
+        var task = baseBuilder(SuspendDataFlow.Builder.newInstance(), process)
+                .build();
+
+        storeTask(task);
+    }
+
+    @Override
+    public void startingRequested(TransferProcess process) {
+        var task = baseBuilder(StartDataflow.Builder.newInstance(), process)
+                .build();
+
+        storeTask(task);
+    }
+
+    @Override
+    public void terminatingRequested(TransferProcess process) {
+        var task = baseBuilder(TerminateDataFlow.Builder.newInstance(), process)
+                .build();
+
+        storeTask(task);
+    }
+
+    @Override
+    public void completingRequested(TransferProcess process) {
+        var task = baseBuilder(CompleteDataFlow.Builder.newInstance(), process)
+                .build();
+
+        storeTask(task);
+    }
+
+    protected <T extends ProcessTaskPayload, B extends ProcessTaskPayload.Builder<T, B>> B baseBuilder(B builder, TransferProcess transferProcess) {
+        return builder.processId(transferProcess.getId())
+                .processState(transferProcess.stateAsString())
+                .processType(transferProcess.getType().name());
+    }
+}

--- a/extensions/control-plane/tasks/listener/tasks-store-listener/src/main/resources/META-INF/services/org.eclipse.edc.spi.system.ServiceExtension
+++ b/extensions/control-plane/tasks/listener/tasks-store-listener/src/main/resources/META-INF/services/org.eclipse.edc.spi.system.ServiceExtension
@@ -1,0 +1,14 @@
+#
+#  Copyright (c) 2026 Metaform Systems, Inc.
+#
+#  This program and the accompanying materials are made available under the
+#  terms of the Apache License, Version 2.0 which is available at
+#  https://www.apache.org/licenses/LICENSE-2.0
+#
+#  SPDX-License-Identifier: Apache-2.0
+#
+#  Contributors:
+#       Metaform Systems, Inc. - initial API and implementation
+#
+#
+org.eclipse.edc.virtual.controlplane.listener.StateMachineListenerExtension

--- a/extensions/control-plane/tasks/listener/tasks-store-listener/src/test/java/org/eclipse/edc/virtual/controlplane/listener/ContractNegotiationStateListenerTest.java
+++ b/extensions/control-plane/tasks/listener/tasks-store-listener/src/test/java/org/eclipse/edc/virtual/controlplane/listener/ContractNegotiationStateListenerTest.java
@@ -1,0 +1,160 @@
+/*
+ *  Copyright (c) 2026 Metaform Systems, Inc.
+ *
+ *  This program and the accompanying materials are made available under the
+ *  terms of the Apache License, Version 2.0 which is available at
+ *  https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Contributors:
+ *       Metaform Systems, Inc. - initial API and implementation
+ *
+ */
+
+package org.eclipse.edc.virtual.controlplane.listener;
+
+import org.eclipse.edc.connector.controlplane.contract.spi.types.negotiation.ContractNegotiation;
+import org.eclipse.edc.virtual.controlplane.contract.spi.negotiation.tasks.AgreeNegotiation;
+import org.eclipse.edc.virtual.controlplane.contract.spi.negotiation.tasks.FinalizeNegotiation;
+import org.eclipse.edc.virtual.controlplane.contract.spi.negotiation.tasks.RequestNegotiation;
+import org.eclipse.edc.virtual.controlplane.contract.spi.negotiation.tasks.VerifyNegotiation;
+import org.eclipse.edc.virtual.controlplane.tasks.Task;
+import org.eclipse.edc.virtual.controlplane.tasks.TaskService;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
+
+import java.time.Clock;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
+import static org.mockito.Mockito.when;
+
+class ContractNegotiationStateListenerTest {
+
+    private final TaskService taskService = mock();
+    private final Clock clock = Clock.systemUTC();
+    private ContractNegotiationStateListener listener;
+
+    @BeforeEach
+    void setUp() {
+        listener = new ContractNegotiationStateListener(taskService, clock);
+    }
+
+    @Test
+    void initiated_shouldCreateRequestNegotiationTask() {
+        var negotiation = createContractNegotiation("negotiation-123", ContractNegotiation.Type.CONSUMER, "INITIAL");
+
+        listener.initiated(negotiation);
+
+        var taskCaptor = ArgumentCaptor.forClass(Task.class);
+        verify(taskService).create(taskCaptor.capture());
+
+        var task = taskCaptor.getValue();
+        assertThat(task.getPayload()).isInstanceOf(RequestNegotiation.class);
+        var payload = (RequestNegotiation) task.getPayload();
+        assertThat(payload.getProcessId()).isEqualTo("negotiation-123");
+        assertThat(payload.getProcessState()).isEqualTo("INITIAL");
+        assertThat(payload.getProcessType()).isEqualTo("CONSUMER");
+    }
+
+    @Test
+    void requested_shouldCreateAgreeNegotiationTaskWhenProvider() {
+        var negotiation = createContractNegotiation("negotiation-123", ContractNegotiation.Type.PROVIDER, "REQUESTED");
+
+        listener.requested(negotiation);
+
+        var taskCaptor = ArgumentCaptor.forClass(Task.class);
+        verify(taskService).create(taskCaptor.capture());
+
+        var task = taskCaptor.getValue();
+        assertThat(task.getPayload()).isInstanceOf(AgreeNegotiation.class);
+        var payload = (AgreeNegotiation) task.getPayload();
+        assertThat(payload.getProcessId()).isEqualTo("negotiation-123");
+        assertThat(payload.getProcessType()).isEqualTo("PROVIDER");
+    }
+
+    @Test
+    void requested_shouldNotCreateTaskWhenConsumer() {
+        var negotiation = createContractNegotiation("negotiation-123", ContractNegotiation.Type.CONSUMER, "REQUESTED");
+
+        listener.requested(negotiation);
+
+        verifyNoInteractions(taskService);
+    }
+
+    @Test
+    void agreed_shouldCreateVerifyNegotiationTaskWhenConsumer() {
+        var negotiation = createContractNegotiation("negotiation-123", ContractNegotiation.Type.CONSUMER, "AGREED");
+
+        listener.agreed(negotiation);
+
+        var taskCaptor = ArgumentCaptor.forClass(Task.class);
+        verify(taskService).create(taskCaptor.capture());
+
+        var task = taskCaptor.getValue();
+        assertThat(task.getPayload()).isInstanceOf(VerifyNegotiation.class);
+        var payload = (VerifyNegotiation) task.getPayload();
+        assertThat(payload.getProcessId()).isEqualTo("negotiation-123");
+        assertThat(payload.getProcessType()).isEqualTo("CONSUMER");
+    }
+
+    @Test
+    void agreed_shouldNotCreateTaskWhenProvider() {
+        var negotiation = createContractNegotiation("negotiation-123", ContractNegotiation.Type.PROVIDER, "AGREED");
+
+        listener.agreed(negotiation);
+
+        verifyNoInteractions(taskService);
+    }
+
+    @Test
+    void verified_shouldCreateFinalizeNegotiationTaskWhenProvider() {
+        var negotiation = createContractNegotiation("negotiation-123", ContractNegotiation.Type.PROVIDER, "VERIFIED");
+
+        listener.verified(negotiation);
+
+        var taskCaptor = ArgumentCaptor.forClass(Task.class);
+        verify(taskService).create(taskCaptor.capture());
+
+        var task = taskCaptor.getValue();
+        assertThat(task.getPayload()).isInstanceOf(FinalizeNegotiation.class);
+        var payload = (FinalizeNegotiation) task.getPayload();
+        assertThat(payload.getProcessId()).isEqualTo("negotiation-123");
+        assertThat(payload.getProcessType()).isEqualTo("PROVIDER");
+    }
+
+    @Test
+    void verified_shouldNotCreateTaskWhenConsumer() {
+        var negotiation = createContractNegotiation("negotiation-123", ContractNegotiation.Type.CONSUMER, "VERIFIED");
+
+        listener.verified(negotiation);
+
+        verifyNoInteractions(taskService);
+    }
+
+    @Test
+    void shouldPreserveNegotiationState() {
+        var negotiation = createContractNegotiation("negotiation-123", ContractNegotiation.Type.CONSUMER, "CUSTOM_STATE");
+
+        listener.initiated(negotiation);
+
+        var taskCaptor = ArgumentCaptor.forClass(Task.class);
+        verify(taskService).create(taskCaptor.capture());
+
+        var task = taskCaptor.getValue();
+        var payload = (RequestNegotiation) task.getPayload();
+        assertThat(payload.getProcessState()).isEqualTo("CUSTOM_STATE");
+    }
+
+    private ContractNegotiation createContractNegotiation(String id, ContractNegotiation.Type type, String state) {
+        var negotiation = mock(ContractNegotiation.class);
+        when(negotiation.getId()).thenReturn(id);
+        when(negotiation.getType()).thenReturn(type);
+        when(negotiation.stateAsString()).thenReturn(state);
+        return negotiation;
+    }
+}

--- a/extensions/control-plane/tasks/listener/tasks-store-listener/src/test/java/org/eclipse/edc/virtual/controlplane/listener/TransferProcessStateListenerTest.java
+++ b/extensions/control-plane/tasks/listener/tasks-store-listener/src/test/java/org/eclipse/edc/virtual/controlplane/listener/TransferProcessStateListenerTest.java
@@ -1,0 +1,175 @@
+/*
+ *  Copyright (c) 2026 Metaform Systems, Inc.
+ *
+ *  This program and the accompanying materials are made available under the
+ *  terms of the Apache License, Version 2.0 which is available at
+ *  https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Contributors:
+ *       Metaform Systems, Inc. - initial API and implementation
+ *
+ */
+
+package org.eclipse.edc.virtual.controlplane.listener;
+
+import org.eclipse.edc.connector.controlplane.transfer.spi.types.TransferProcess;
+import org.eclipse.edc.virtual.controlplane.tasks.Task;
+import org.eclipse.edc.virtual.controlplane.tasks.TaskService;
+import org.eclipse.edc.virtual.controlplane.transfer.spi.tasks.CompleteDataFlow;
+import org.eclipse.edc.virtual.controlplane.transfer.spi.tasks.PrepareTransfer;
+import org.eclipse.edc.virtual.controlplane.transfer.spi.tasks.SignalDataflowStarted;
+import org.eclipse.edc.virtual.controlplane.transfer.spi.tasks.StartDataflow;
+import org.eclipse.edc.virtual.controlplane.transfer.spi.tasks.SuspendDataFlow;
+import org.eclipse.edc.virtual.controlplane.transfer.spi.tasks.TerminateDataFlow;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
+
+import java.time.Clock;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+class TransferProcessStateListenerTest {
+
+    private final TaskService taskService = mock();
+    private final Clock clock = Clock.systemUTC();
+    private TransferProcessStateListener listener;
+
+    @BeforeEach
+    void setUp() {
+        listener = new TransferProcessStateListener(taskService, clock);
+    }
+
+    @Test
+    void initiated_shouldCreatePrepareTransferTask() {
+        var process = createTransferProcess("transfer-123", TransferProcess.Type.CONSUMER, "INITIAL");
+
+        listener.initiated(process);
+
+        var taskCaptor = ArgumentCaptor.forClass(Task.class);
+        verify(taskService).create(taskCaptor.capture());
+
+        var task = taskCaptor.getValue();
+        assertThat(task.getPayload()).isInstanceOf(PrepareTransfer.class);
+        var payload = (PrepareTransfer) task.getPayload();
+        assertThat(payload.getProcessId()).isEqualTo("transfer-123");
+        assertThat(payload.getProcessState()).isEqualTo("INITIAL");
+        assertThat(payload.getProcessType()).isEqualTo("CONSUMER");
+    }
+
+    @Test
+    void startupRequested_shouldCreateSignalStartedDataflowTask() {
+        var process = createTransferProcess("transfer-123", TransferProcess.Type.CONSUMER, "STARTUP_REQUESTED");
+
+        listener.startupRequested(process);
+
+        var taskCaptor = ArgumentCaptor.forClass(Task.class);
+        verify(taskService).create(taskCaptor.capture());
+
+        var task = taskCaptor.getValue();
+        assertThat(task.getPayload()).isInstanceOf(SignalDataflowStarted.class);
+        var payload = (SignalDataflowStarted) task.getPayload();
+        assertThat(payload.getProcessId()).isEqualTo("transfer-123");
+    }
+
+    @Test
+    void suspendingRequested_shouldCreateSuspendDataFlowTask() {
+        var process = createTransferProcess("transfer-123", TransferProcess.Type.PROVIDER, "SUSPENDING_REQUESTED");
+
+        listener.suspendingRequested(process);
+
+        var taskCaptor = ArgumentCaptor.forClass(Task.class);
+        verify(taskService).create(taskCaptor.capture());
+
+        var task = taskCaptor.getValue();
+        assertThat(task.getPayload()).isInstanceOf(SuspendDataFlow.class);
+        var payload = (SuspendDataFlow) task.getPayload();
+        assertThat(payload.getProcessId()).isEqualTo("transfer-123");
+    }
+
+    @Test
+    void startingRequested_shouldCreateStartDataflowTask() {
+        var process = createTransferProcess("transfer-123", TransferProcess.Type.PROVIDER, "STARTING_REQUESTED");
+
+        listener.startingRequested(process);
+
+        var taskCaptor = ArgumentCaptor.forClass(Task.class);
+        verify(taskService).create(taskCaptor.capture());
+
+        var task = taskCaptor.getValue();
+        assertThat(task.getPayload()).isInstanceOf(StartDataflow.class);
+        var payload = (StartDataflow) task.getPayload();
+        assertThat(payload.getProcessId()).isEqualTo("transfer-123");
+    }
+
+    @Test
+    void terminatingRequested_shouldCreateTerminateDataFlowTask() {
+        var process = createTransferProcess("transfer-123", TransferProcess.Type.CONSUMER, "TERMINATING_REQUESTED");
+
+        listener.terminatingRequested(process);
+
+        var taskCaptor = ArgumentCaptor.forClass(Task.class);
+        verify(taskService).create(taskCaptor.capture());
+
+        var task = taskCaptor.getValue();
+        assertThat(task.getPayload()).isInstanceOf(TerminateDataFlow.class);
+        var payload = (TerminateDataFlow) task.getPayload();
+        assertThat(payload.getProcessId()).isEqualTo("transfer-123");
+    }
+
+    @Test
+    void completingRequested_shouldCreateCompleteDataFlowTask() {
+        var process = createTransferProcess("transfer-123", TransferProcess.Type.PROVIDER, "COMPLETING_REQUESTED");
+
+        listener.completingRequested(process);
+
+        var taskCaptor = ArgumentCaptor.forClass(Task.class);
+        verify(taskService).create(taskCaptor.capture());
+
+        var task = taskCaptor.getValue();
+        assertThat(task.getPayload()).isInstanceOf(CompleteDataFlow.class);
+        var payload = (CompleteDataFlow) task.getPayload();
+        assertThat(payload.getProcessId()).isEqualTo("transfer-123");
+    }
+
+    @Test
+    void shouldPreserveTransferProcessState() {
+        var process = createTransferProcess("transfer-123", TransferProcess.Type.CONSUMER, "CUSTOM_STATE");
+
+        listener.initiated(process);
+
+        var taskCaptor = ArgumentCaptor.forClass(Task.class);
+        verify(taskService).create(taskCaptor.capture());
+
+        var task = taskCaptor.getValue();
+        var payload = (PrepareTransfer) task.getPayload();
+        assertThat(payload.getProcessState()).isEqualTo("CUSTOM_STATE");
+    }
+
+    @Test
+    void shouldPreserveTransferProcessType() {
+        var process = createTransferProcess("transfer-123", TransferProcess.Type.PROVIDER, "INITIAL");
+
+        listener.initiated(process);
+
+        var taskCaptor = ArgumentCaptor.forClass(Task.class);
+        verify(taskService).create(taskCaptor.capture());
+
+        var task = taskCaptor.getValue();
+        var payload = (PrepareTransfer) task.getPayload();
+        assertThat(payload.getProcessType()).isEqualTo("PROVIDER");
+    }
+
+    private TransferProcess createTransferProcess(String id, TransferProcess.Type type, String state) {
+        var process = mock(TransferProcess.class);
+        when(process.getId()).thenReturn(id);
+        when(process.getType()).thenReturn(type);
+        when(process.stateAsString()).thenReturn(state);
+        return process;
+    }
+}

--- a/extensions/control-plane/tasks/listener/tasks-store-poll-executor/build.gradle.kts
+++ b/extensions/control-plane/tasks/listener/tasks-store-poll-executor/build.gradle.kts
@@ -1,0 +1,31 @@
+/*
+ *  Copyright (c) 2026 Metaform Systems, Inc.
+ *
+ *  This program and the accompanying materials are made available under the
+ *  terms of the Apache License, Version 2.0 which is available at
+ *  https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Contributors:
+ *       Metaform Systems, Inc. - initial API and implementation
+ *
+ */
+
+plugins {
+    `java-library`
+}
+
+dependencies {
+    api(libs.edc.spi.core)
+    api(libs.edc.spi.contract)
+    api(libs.edc.spi.transaction)
+    api(libs.edc.spi.transfer)
+    api(project(":spi:v-core-spi"))
+    api(project(":spi:v-task-spi"))
+    testImplementation(libs.awaitility)
+    testImplementation(libs.edc.junit)
+    testImplementation(testFixtures(libs.edc.spi.contract))
+    testImplementation(libs.testcontainers.junit)
+}
+

--- a/extensions/control-plane/tasks/listener/tasks-store-poll-executor/src/main/java/org/eclipse/edc/virtual/controlplane/tasks/executor/TaskPollExecutor.java
+++ b/extensions/control-plane/tasks/listener/tasks-store-poll-executor/src/main/java/org/eclipse/edc/virtual/controlplane/tasks/executor/TaskPollExecutor.java
@@ -1,0 +1,153 @@
+/*
+ *  Copyright (c) 2026 Metaform Systems, Inc.
+ *
+ *  This program and the accompanying materials are made available under the
+ *  terms of the Apache License, Version 2.0 which is available at
+ *  https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Contributors:
+ *       Metaform Systems, Inc. - initial API and implementation
+ *
+ */
+
+package org.eclipse.edc.virtual.controlplane.tasks.executor;
+
+import org.eclipse.edc.spi.monitor.Monitor;
+import org.eclipse.edc.spi.query.QuerySpec;
+import org.eclipse.edc.spi.query.SortOrder;
+import org.eclipse.edc.spi.response.StatusResult;
+import org.eclipse.edc.spi.system.ExecutorInstrumentation;
+import org.eclipse.edc.transaction.spi.TransactionContext;
+import org.eclipse.edc.virtual.controlplane.contract.spi.negotiation.ContractNegotiationTaskExecutor;
+import org.eclipse.edc.virtual.controlplane.contract.spi.negotiation.tasks.ContractNegotiationTaskPayload;
+import org.eclipse.edc.virtual.controlplane.tasks.Task;
+import org.eclipse.edc.virtual.controlplane.tasks.store.TaskStore;
+import org.eclipse.edc.virtual.controlplane.transfer.spi.TransferProcessTaskExecutor;
+import org.eclipse.edc.virtual.controlplane.transfer.spi.tasks.TransferProcessTaskPayload;
+import org.jetbrains.annotations.NotNull;
+
+import java.time.Clock;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.atomic.AtomicBoolean;
+
+import static java.util.concurrent.TimeUnit.MILLISECONDS;
+import static java.util.concurrent.TimeUnit.SECONDS;
+
+
+public class TaskPollExecutor {
+
+    private final ContractNegotiationTaskExecutor contractNegotiationTaskExecutor;
+    private final TransferProcessTaskExecutor transferProcessTaskExecutor;
+    private final TaskStore taskStore;
+    private final TransactionContext transactionContext;
+    private final Monitor monitor;
+    private final ScheduledExecutorService executor;
+    private final Clock clock;
+    private final AtomicBoolean active = new AtomicBoolean();
+    private final int shutdownTimeout = 10;
+
+    private final QuerySpec query = QuerySpec.Builder.newInstance()
+            .sortField("at")
+            .sortOrder(SortOrder.ASC)
+            .limit(1)
+            .build();
+
+
+    public TaskPollExecutor(ExecutorInstrumentation instrumentation, ContractNegotiationTaskExecutor contractNegotiationTaskExecutor,
+                            TransferProcessTaskExecutor transferProcessTaskExecutor, TaskStore taskStore, TransactionContext transactionContext,
+                            Monitor monitor, Clock clock) {
+        this.contractNegotiationTaskExecutor = contractNegotiationTaskExecutor;
+        this.transferProcessTaskExecutor = transferProcessTaskExecutor;
+        this.taskStore = taskStore;
+        this.transactionContext = transactionContext;
+        this.monitor = monitor;
+
+        executor = instrumentation.instrument(
+                Executors.newSingleThreadScheduledExecutor(r -> {
+                    var thread = Executors.defaultThreadFactory().newThread(r);
+                    thread.setName("TaskPollExecutor");
+                    return thread;
+                }), "TaskPollExecutor");
+        this.clock = clock;
+    }
+
+    /**
+     * Start the loop that will run processors until it's stopped
+     *
+     * @return a future that will complete when the loop starts
+     */
+    public Future<?> start() {
+        active.set(true);
+        return scheduleNextIterationIn(0L);
+    }
+
+    @NotNull
+    private Future<?> scheduleNextIterationIn(long delayMillis) {
+        return executor.schedule(this::run, delayMillis, MILLISECONDS);
+    }
+
+    /**
+     * Stop the loop gracefully as suggested in the {@link ExecutorService} documentation
+     */
+    public void stop() {
+        active.set(false);
+        executor.shutdown();
+
+        try {
+            if (!executor.awaitTermination(shutdownTimeout, SECONDS)) {
+                executor.shutdownNow();
+                if (!executor.awaitTermination(shutdownTimeout, SECONDS)) {
+                    monitor.severe("StateMachineManager [%s] await termination timeout");
+                }
+            }
+        } catch (InterruptedException e) {
+            monitor.severe("TaskPollExecutor  await termination failed", e);
+            executor.shutdownNow();
+            Thread.currentThread().interrupt();
+        }
+
+    }
+
+    private void run() {
+        if (active.get()) {
+            transactionContext.execute(() -> {
+                try {
+                    var tasks = taskStore.fetchForUpdate(query);
+                    for (var task : tasks) {
+                        executeTask(task);
+                    }
+                } catch (Exception e) {
+                    monitor.severe("TaskPollExecutor failed to process tasks", e);
+                } finally {
+                    scheduleNextIterationIn(100L);
+                }
+            });
+
+        }
+    }
+
+    private void executeTask(Task task) {
+        var result = handleTask(task);
+        if (result.succeeded()) {
+            taskStore.delete(task.getId());
+        } else {
+            monitor.severe("Failed to process task " + task.getId() + ": " + result.getFailureDetail());
+            taskStore.update(task.toBuilder().at(clock.millis()).build());
+        }
+    }
+
+    private StatusResult<Void> handleTask(Task task) {
+        if (task.getPayload() instanceof ContractNegotiationTaskPayload cnPayload) {
+            return contractNegotiationTaskExecutor.handle(cnPayload);
+        } else if (task.getPayload() instanceof TransferProcessTaskPayload tpPayload) {
+            return transferProcessTaskExecutor.handle(tpPayload);
+        } else {
+            return StatusResult.success();
+        }
+    }
+}

--- a/extensions/control-plane/tasks/listener/tasks-store-poll-executor/src/main/java/org/eclipse/edc/virtual/controlplane/tasks/executor/TaskPollExecutorExtension.java
+++ b/extensions/control-plane/tasks/listener/tasks-store-poll-executor/src/main/java/org/eclipse/edc/virtual/controlplane/tasks/executor/TaskPollExecutorExtension.java
@@ -1,0 +1,64 @@
+/*
+ *  Copyright (c) 2026 Metaform Systems, Inc.
+ *
+ *  This program and the accompanying materials are made available under the
+ *  terms of the Apache License, Version 2.0 which is available at
+ *  https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Contributors:
+ *       Metaform Systems, Inc. - initial API and implementation
+ *
+ */
+
+package org.eclipse.edc.virtual.controlplane.tasks.executor;
+
+import org.eclipse.edc.runtime.metamodel.annotation.Inject;
+import org.eclipse.edc.spi.monitor.Monitor;
+import org.eclipse.edc.spi.system.ExecutorInstrumentation;
+import org.eclipse.edc.spi.system.ServiceExtension;
+import org.eclipse.edc.spi.system.ServiceExtensionContext;
+import org.eclipse.edc.transaction.spi.TransactionContext;
+import org.eclipse.edc.virtual.controlplane.contract.spi.negotiation.ContractNegotiationTaskExecutor;
+import org.eclipse.edc.virtual.controlplane.tasks.store.TaskStore;
+import org.eclipse.edc.virtual.controlplane.transfer.spi.TransferProcessTaskExecutor;
+
+import java.time.Clock;
+
+public class TaskPollExecutorExtension implements ServiceExtension {
+
+    @Inject
+    private TaskStore taskStore;
+    @Inject
+    private Monitor monitor;
+    @Inject
+    private TransactionContext transactionContext;
+    @Inject
+    private TransferProcessTaskExecutor transferProcessTaskExecutor;
+    @Inject
+    private ContractNegotiationTaskExecutor contractNegotiationTaskExecutor;
+    private TaskPollExecutor executor;
+
+    @Inject
+    private ExecutorInstrumentation executorInstrumentation;
+
+    @Inject
+    private Clock clock;
+
+    @Override
+    public void initialize(ServiceExtensionContext context) {
+        executor = new TaskPollExecutor(executorInstrumentation, contractNegotiationTaskExecutor, transferProcessTaskExecutor,
+                taskStore, transactionContext, monitor, clock);
+    }
+
+    @Override
+    public void start() {
+        executor.start();
+    }
+
+    @Override
+    public void shutdown() {
+        executor.stop();
+    }
+}

--- a/extensions/control-plane/tasks/listener/tasks-store-poll-executor/src/main/resources/META-INF/services/org.eclipse.edc.spi.system.ServiceExtension
+++ b/extensions/control-plane/tasks/listener/tasks-store-poll-executor/src/main/resources/META-INF/services/org.eclipse.edc.spi.system.ServiceExtension
@@ -1,0 +1,14 @@
+#
+#  Copyright (c) 2026 Metaform Systems, Inc.
+#
+#  This program and the accompanying materials are made available under the
+#  terms of the Apache License, Version 2.0 which is available at
+#  https://www.apache.org/licenses/LICENSE-2.0
+#
+#  SPDX-License-Identifier: Apache-2.0
+#
+#  Contributors:
+#       Metaform Systems, Inc. - initial API and implementation
+#
+#
+org.eclipse.edc.virtual.controlplane.tasks.executor.TaskPollExecutorExtension

--- a/extensions/control-plane/tasks/listener/tasks-store-poll-executor/src/test/java/org/eclipse/edc/virtual/controlplane/tasks/executor/TaskPollExecutorTest.java
+++ b/extensions/control-plane/tasks/listener/tasks-store-poll-executor/src/test/java/org/eclipse/edc/virtual/controlplane/tasks/executor/TaskPollExecutorTest.java
@@ -1,0 +1,368 @@
+/*
+ *  Copyright (c) 2026 Metaform Systems, Inc.
+ *
+ *  This program and the accompanying materials are made available under the
+ *  terms of the Apache License, Version 2.0 which is available at
+ *  https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Contributors:
+ *       Metaform Systems, Inc. - initial API and implementation
+ *
+ */
+
+package org.eclipse.edc.virtual.controlplane.tasks.executor;
+
+import org.eclipse.edc.spi.monitor.Monitor;
+import org.eclipse.edc.spi.query.QuerySpec;
+import org.eclipse.edc.spi.response.StatusResult;
+import org.eclipse.edc.spi.system.ExecutorInstrumentation;
+import org.eclipse.edc.transaction.spi.NoopTransactionContext;
+import org.eclipse.edc.transaction.spi.TransactionContext;
+import org.eclipse.edc.virtual.controlplane.contract.spi.negotiation.ContractNegotiationTaskExecutor;
+import org.eclipse.edc.virtual.controlplane.contract.spi.negotiation.tasks.ContractNegotiationTaskPayload;
+import org.eclipse.edc.virtual.controlplane.contract.spi.negotiation.tasks.RequestNegotiation;
+import org.eclipse.edc.virtual.controlplane.tasks.ProcessTaskPayload;
+import org.eclipse.edc.virtual.controlplane.tasks.Task;
+import org.eclipse.edc.virtual.controlplane.tasks.store.TaskStore;
+import org.eclipse.edc.virtual.controlplane.transfer.spi.TransferProcessTaskExecutor;
+import org.eclipse.edc.virtual.controlplane.transfer.spi.tasks.PrepareTransfer;
+import org.eclipse.edc.virtual.controlplane.transfer.spi.tasks.TransferProcessTaskPayload;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.time.Clock;
+import java.util.List;
+import java.util.concurrent.TimeUnit;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.awaitility.Awaitility.await;
+import static org.eclipse.edc.spi.response.ResponseStatus.FATAL_ERROR;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.atLeastOnce;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+class TaskPollExecutorTest {
+
+    private final ContractNegotiationTaskExecutor contractNegotiationTaskExecutor = mock();
+    private final TransferProcessTaskExecutor transferProcessTaskExecutor = mock();
+    private final TaskStore taskStore = mock();
+    private final TransactionContext transactionContext = new NoopTransactionContext();
+    private final Monitor monitor = mock();
+    private final ExecutorInstrumentation instrumentation = mock();
+    private final Clock clock = Clock.systemUTC();
+    private TaskPollExecutor pollExecutor;
+
+    private static org.mockito.MockingDetails mockingDetails(Object mock) {
+        return org.mockito.Mockito.mockingDetails(mock);
+    }
+
+    @BeforeEach
+    void setUp() {
+        when(instrumentation.instrument(any(), anyString())).thenAnswer(invocation -> invocation.getArgument(0));
+
+        pollExecutor = new TaskPollExecutor(
+                instrumentation,
+                contractNegotiationTaskExecutor,
+                transferProcessTaskExecutor,
+                taskStore,
+                transactionContext,
+                monitor,
+                clock
+        );
+    }
+
+    @AfterEach
+    void tearDown() {
+        pollExecutor.stop();
+    }
+
+    @Test
+    void start_shouldActivatePollExecutor() {
+        when(taskStore.fetchForUpdate(any(QuerySpec.class))).thenReturn(List.of());
+
+        var future = pollExecutor.start();
+
+        assertThat(future).isNotNull();
+        assertThat(future.isCancelled()).isFalse();
+    }
+
+    @Test
+    void start_shouldBeginPollingTasks() {
+        var payload = RequestNegotiation.Builder.newInstance()
+                .processId("negotiation-123")
+                .processState("INITIAL")
+                .processType("CONSUMER")
+                .build();
+        var task = Task.Builder.newInstance()
+                .at(System.currentTimeMillis())
+                .payload(payload)
+                .build();
+
+        when(taskStore.fetchForUpdate(any(QuerySpec.class)))
+                .thenReturn(List.of(task))
+                .thenReturn(List.of());
+        when(contractNegotiationTaskExecutor.handle(any())).thenReturn(StatusResult.success());
+
+        pollExecutor.start();
+
+        await().atMost(2, TimeUnit.SECONDS).untilAsserted(() ->
+                verify(taskStore, atLeastOnce()).fetchForUpdate(any(QuerySpec.class))
+        );
+    }
+
+    @Test
+    void executeTask_shouldDeleteTaskOnSuccess() {
+        var payload = PrepareTransfer.Builder.newInstance()
+                .processId("transfer-123")
+                .processState("INITIAL")
+                .processType("CONSUMER")
+                .build();
+        var task = Task.Builder.newInstance()
+                .at(System.currentTimeMillis())
+                .payload(payload)
+                .build();
+
+        when(taskStore.fetchForUpdate(any(QuerySpec.class)))
+                .thenReturn(List.of(task))
+                .thenReturn(List.of());
+        when(transferProcessTaskExecutor.handle(any())).thenReturn(StatusResult.success());
+
+        pollExecutor.start();
+
+        await().atMost(2, TimeUnit.SECONDS).untilAsserted(() ->
+                verify(taskStore).delete(task.getId())
+        );
+    }
+
+    @Test
+    void executeTask_shouldUpdateTaskOnFailure() {
+        var payload = RequestNegotiation.Builder.newInstance()
+                .processId("negotiation-123")
+                .processState("INITIAL")
+                .processType("CONSUMER")
+                .build();
+        var task = Task.Builder.newInstance()
+                .at(System.currentTimeMillis())
+                .payload(payload)
+                .build();
+
+        when(taskStore.fetchForUpdate(any(QuerySpec.class)))
+                .thenReturn(List.of(task))
+                .thenReturn(List.of());
+        when(contractNegotiationTaskExecutor.handle(any()))
+                .thenReturn(StatusResult.failure(FATAL_ERROR, "Processing failed"));
+
+        pollExecutor.start();
+
+        await().atMost(2, TimeUnit.SECONDS).untilAsserted(() ->
+                verify(taskStore).update(any(Task.class))
+        );
+    }
+
+    @Test
+    void handleTask_shouldDispatchContractNegotiationTaskPayload() {
+        var payload = RequestNegotiation.Builder.newInstance()
+                .processId("negotiation-123")
+                .processState("INITIAL")
+                .processType("CONSUMER")
+                .build();
+        var task = Task.Builder.newInstance()
+                .at(System.currentTimeMillis())
+                .payload(payload)
+                .build();
+
+        when(taskStore.fetchForUpdate(any(QuerySpec.class)))
+                .thenReturn(List.of(task))
+                .thenReturn(List.of());
+        when(contractNegotiationTaskExecutor.handle(any())).thenReturn(StatusResult.success());
+
+        pollExecutor.start();
+
+        await().atMost(2, TimeUnit.SECONDS).untilAsserted(() ->
+                verify(contractNegotiationTaskExecutor).handle(any(ContractNegotiationTaskPayload.class))
+        );
+    }
+
+    @Test
+    void handleTask_shouldDispatchTransferProcessTaskPayload() {
+        var payload = PrepareTransfer.Builder.newInstance()
+                .processId("transfer-123")
+                .processState("INITIAL")
+                .processType("CONSUMER")
+                .build();
+        var task = Task.Builder.newInstance()
+                .at(System.currentTimeMillis())
+                .payload(payload)
+                .build();
+
+        when(taskStore.fetchForUpdate(any(QuerySpec.class)))
+                .thenReturn(List.of(task))
+                .thenReturn(List.of());
+        when(transferProcessTaskExecutor.handle(any())).thenReturn(StatusResult.success());
+
+        pollExecutor.start();
+
+        await().atMost(2, TimeUnit.SECONDS).untilAsserted(() ->
+                verify(transferProcessTaskExecutor).handle(any(TransferProcessTaskPayload.class))
+        );
+    }
+
+    @Test
+    void handleTask_shouldHandleUnknownPayloadType() {
+        var payload = new UnknownPayload("process-1", "INITIAL", "CONSUMER");
+        var task = Task.Builder.newInstance()
+                .at(System.currentTimeMillis())
+                .payload(payload)
+                .build();
+
+        when(taskStore.fetchForUpdate(any(QuerySpec.class)))
+                .thenReturn(List.of(task))
+                .thenReturn(List.of());
+
+        pollExecutor.start();
+
+        await().atMost(2, TimeUnit.SECONDS).untilAsserted(() ->
+                verify(taskStore).delete(task.getId())
+        );
+    }
+
+    @Test
+    void run_shouldContinuePollingAfterSuccessfulExecution() {
+        var payload = RequestNegotiation.Builder.newInstance()
+                .processId("negotiation-123")
+                .processState("INITIAL")
+                .processType("CONSUMER")
+                .build();
+        var task = Task.Builder.newInstance()
+                .at(System.currentTimeMillis())
+                .payload(payload)
+                .build();
+
+        when(taskStore.fetchForUpdate(any(QuerySpec.class)))
+                .thenReturn(List.of(task))
+                .thenReturn(List.of())
+                .thenReturn(List.of());
+        when(contractNegotiationTaskExecutor.handle(any())).thenReturn(StatusResult.success());
+
+        pollExecutor.start();
+
+        await().atMost(2, TimeUnit.SECONDS).untilAsserted(() ->
+                verify(taskStore, times(3)).fetchForUpdate(any(QuerySpec.class))
+        );
+    }
+
+    @Test
+    void run_shouldContinuePollingAfterExecutionException() {
+        when(taskStore.fetchForUpdate(any(QuerySpec.class)))
+                .thenThrow(new RuntimeException("Store error"))
+                .thenReturn(List.of());
+
+        pollExecutor.start();
+
+        await().atMost(2, TimeUnit.SECONDS).untilAsserted(() ->
+                verify(monitor).severe(any(String.class), any(Exception.class))
+        );
+    }
+
+    @Test
+    void stop_shouldStopPolling() throws InterruptedException {
+        when(taskStore.fetchForUpdate(any(QuerySpec.class))).thenReturn(List.of());
+
+        pollExecutor.start();
+        Thread.sleep(200); // Allow some polling cycles
+        pollExecutor.stop();
+
+        // Verify that no more tasks are fetched after stopping
+        var callCountBefore = mockingDetails(taskStore).getInvocations().size();
+        Thread.sleep(300);
+        var callCountAfter = mockingDetails(taskStore).getInvocations().size();
+
+        assertThat(callCountAfter).isEqualTo(callCountBefore);
+    }
+
+    @Test
+    void executeTask_shouldLogErrorOnProcessingFailure() {
+        var payload = RequestNegotiation.Builder.newInstance()
+                .processId("negotiation-123")
+                .processState("INITIAL")
+                .processType("CONSUMER")
+                .build();
+        var task = Task.Builder.newInstance()
+                .at(System.currentTimeMillis())
+                .payload(payload)
+                .build();
+
+        when(taskStore.fetchForUpdate(any(QuerySpec.class)))
+                .thenReturn(List.of(task))
+                .thenReturn(List.of());
+        when(contractNegotiationTaskExecutor.handle(any()))
+                .thenReturn(StatusResult.failure(FATAL_ERROR, "Task execution failed"));
+
+        pollExecutor.start();
+
+        await().atMost(2, TimeUnit.SECONDS).untilAsserted(() ->
+                verify(monitor).severe(any(String.class))
+        );
+    }
+
+    @Test
+    void executeTask_shouldProcessMultipleTasks() {
+        var payload1 = RequestNegotiation.Builder.newInstance()
+                .processId("negotiation-1")
+                .processState("INITIAL")
+                .processType("CONSUMER")
+                .build();
+        var task1 = Task.Builder.newInstance()
+                .at(System.currentTimeMillis())
+                .payload(payload1)
+                .build();
+
+        var payload2 = PrepareTransfer.Builder.newInstance()
+                .processId("transfer-1")
+                .processState("INITIAL")
+                .processType("CONSUMER")
+                .build();
+        var task2 = Task.Builder.newInstance()
+                .at(System.currentTimeMillis() + 1)
+                .payload(payload2)
+                .build();
+
+        when(taskStore.fetchForUpdate(any(QuerySpec.class)))
+                .thenReturn(List.of(task1, task2))
+                .thenReturn(List.of());
+        when(contractNegotiationTaskExecutor.handle(any())).thenReturn(StatusResult.success());
+        when(transferProcessTaskExecutor.handle(any())).thenReturn(StatusResult.success());
+
+        pollExecutor.start();
+
+        await().atMost(2, TimeUnit.SECONDS).untilAsserted(() -> {
+            verify(contractNegotiationTaskExecutor).handle(any());
+            verify(transferProcessTaskExecutor).handle(any());
+            verify(taskStore, times(2)).delete(any());
+        });
+    }
+
+    /**
+     * Unknown task payload for testing handler logic
+     */
+    public static class UnknownPayload extends ProcessTaskPayload {
+
+        UnknownPayload(String processId, String processState, String processType) {
+            this.processId = processId;
+            this.processState = processState;
+            this.processType = processType;
+        }
+
+        @Override
+        public String name() {
+            return "unknown.payload";
+        }
+    }
+}

--- a/extensions/control-plane/tasks/publisher/tasks-publisher-nats/build.gradle.kts
+++ b/extensions/control-plane/tasks/publisher/tasks-publisher-nats/build.gradle.kts
@@ -1,0 +1,33 @@
+/*
+ *  Copyright (c) 2026 Metaform Systems, Inc.
+ *
+ *  This program and the accompanying materials are made available under the
+ *  terms of the Apache License, Version 2.0 which is available at
+ *  https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Contributors:
+ *       Metaform Systems, Inc. - initial API and implementation
+ *
+ */
+
+plugins {
+    `java-library`
+}
+
+dependencies {
+    api(libs.edc.spi.core)
+    api(libs.edc.spi.contract)
+    api(libs.edc.spi.transfer)
+    api(libs.edc.spi.transaction)
+    api(project(":spi:v-core-spi"))
+    api(project(":spi:v-task-spi"))
+    implementation(libs.nats.client)
+    testImplementation(libs.awaitility)
+    testImplementation(libs.edc.junit)
+    testImplementation(testFixtures(libs.edc.spi.contract))
+    testImplementation(testFixtures(project(":extensions:lib:nats-lib")))
+    testImplementation(libs.testcontainers.junit)
+}
+

--- a/extensions/control-plane/tasks/publisher/tasks-publisher-nats/src/main/java/org/eclipse/edc/virtual/controlplane/events/publisher/nats/NatsTaskPublisher.java
+++ b/extensions/control-plane/tasks/publisher/tasks-publisher-nats/src/main/java/org/eclipse/edc/virtual/controlplane/events/publisher/nats/NatsTaskPublisher.java
@@ -1,0 +1,65 @@
+/*
+ *  Copyright (c) 2026 Metaform Systems, Inc.
+ *
+ *  This program and the accompanying materials are made available under the
+ *  terms of the Apache License, Version 2.0 which is available at
+ *  https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Contributors:
+ *       Metaform Systems, Inc. - initial API and implementation
+ *
+ */
+
+package org.eclipse.edc.virtual.controlplane.events.publisher.nats;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import io.nats.client.JetStream;
+import org.eclipse.edc.spi.EdcException;
+import org.eclipse.edc.spi.monitor.Monitor;
+import org.eclipse.edc.virtual.controlplane.contract.spi.negotiation.tasks.ContractNegotiationTaskPayload;
+import org.eclipse.edc.virtual.controlplane.tasks.Task;
+import org.eclipse.edc.virtual.controlplane.tasks.TaskListener;
+import org.eclipse.edc.virtual.controlplane.transfer.spi.tasks.TransferProcessTaskPayload;
+
+import java.util.function.Supplier;
+
+import static java.lang.String.format;
+
+public class NatsTaskPublisher implements TaskListener {
+
+    private final JetStream js;
+    private final Monitor monitor;
+    private final Supplier<ObjectMapper> objectMapper;
+
+    public NatsTaskPublisher(JetStream js, Monitor monitor, Supplier<ObjectMapper> objectMapper) {
+        this.js = js;
+        this.monitor = monitor;
+        this.objectMapper = objectMapper;
+    }
+
+
+    private String formatSubject(Task task) {
+        if ((task.getPayload() instanceof ContractNegotiationTaskPayload t)) {
+            return format("negotiations.%s.%s", t.getProcessType().toLowerCase(), t.name());
+        }
+        if ((task.getPayload() instanceof TransferProcessTaskPayload t)) {
+            return format("transfers.%s.%s", t.getProcessType().toLowerCase(), t.name());
+        }
+        monitor.severe("Unsupported event type for task id " + task.getId());
+        throw new IllegalArgumentException("Unsupported event type: " + task.getPayload());
+    }
+
+    @Override
+    public void created(Task task) {
+        try {
+            var message = objectMapper.get().writeValueAsString(task);
+            js.publish(formatSubject(task), message.getBytes());
+        } catch (Exception e) {
+            monitor.severe("Failed to publish task created event for task id " + task.getId(), e);
+            throw new EdcException(e);
+        }
+
+    }
+}

--- a/extensions/control-plane/tasks/publisher/tasks-publisher-nats/src/main/java/org/eclipse/edc/virtual/controlplane/events/publisher/nats/NatsTaskPublisherExtension.java
+++ b/extensions/control-plane/tasks/publisher/tasks-publisher-nats/src/main/java/org/eclipse/edc/virtual/controlplane/events/publisher/nats/NatsTaskPublisherExtension.java
@@ -1,0 +1,70 @@
+/*
+ *  Copyright (c) 2026 Metaform Systems, Inc.
+ *
+ *  This program and the accompanying materials are made available under the
+ *  terms of the Apache License, Version 2.0 which is available at
+ *  https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Contributors:
+ *       Metaform Systems, Inc. - initial API and implementation
+ *
+ */
+
+package org.eclipse.edc.virtual.controlplane.events.publisher.nats;
+
+import io.nats.client.Nats;
+import org.eclipse.edc.runtime.metamodel.annotation.Configuration;
+import org.eclipse.edc.runtime.metamodel.annotation.Inject;
+import org.eclipse.edc.runtime.metamodel.annotation.Setting;
+import org.eclipse.edc.runtime.metamodel.annotation.Settings;
+import org.eclipse.edc.spi.monitor.Monitor;
+import org.eclipse.edc.spi.system.ServiceExtension;
+import org.eclipse.edc.spi.system.ServiceExtensionContext;
+import org.eclipse.edc.spi.types.TypeManager;
+import org.eclipse.edc.virtual.controlplane.tasks.TaskObservable;
+
+import java.time.Clock;
+
+public class NatsTaskPublisherExtension implements ServiceExtension {
+
+
+    @Inject
+    private TypeManager typeManager;
+
+    @Configuration
+    private NatsPublisherConfig natsPublisherConfig;
+
+
+    @Inject
+    private Clock clock;
+
+    @Inject
+    private Monitor monitor;
+
+    @Inject
+    private TaskObservable taskObservable;
+
+    @Override
+    public void initialize(ServiceExtensionContext context) {
+        try {
+            var connection = Nats.connect(natsPublisherConfig.url());
+            var js = connection.jetStream();
+            var publisher = new NatsTaskPublisher(js, monitor, () -> typeManager.getMapper());
+
+            taskObservable.registerListener(publisher);
+        } catch (Exception e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    @Settings
+    public record NatsPublisherConfig(
+            @Setting(key = "edc.nats.cn.publisher.url", description = "The URL of the NATS server to connect to for publishing contract negotiation events.", defaultValue = "nats://localhost:4222")
+            String url,
+            @Setting(key = "edc.nats.cn.publisher.subject-prefix", description = "The prefix for the subjects", defaultValue = "negotiations")
+            String subjectPrefix
+    ) {
+    }
+}

--- a/extensions/control-plane/tasks/publisher/tasks-publisher-nats/src/main/resources/META-INF/services/org.eclipse.edc.spi.system.ServiceExtension
+++ b/extensions/control-plane/tasks/publisher/tasks-publisher-nats/src/main/resources/META-INF/services/org.eclipse.edc.spi.system.ServiceExtension
@@ -1,0 +1,14 @@
+#
+#  Copyright (c) 2026 Metaform Systems, Inc.
+#
+#  This program and the accompanying materials are made available under the
+#  terms of the Apache License, Version 2.0 which is available at
+#  https://www.apache.org/licenses/LICENSE-2.0
+#
+#  SPDX-License-Identifier: Apache-2.0
+#
+#  Contributors:
+#       Metaform Systems, Inc. - initial API and implementation
+#
+#
+org.eclipse.edc.virtual.controlplane.events.publisher.nats.NatsTaskPublisherExtension

--- a/extensions/control-plane/tasks/publisher/tasks-publisher-nats/src/test/java/org/eclipse/edc/virtual/controlplane/events/publisher/nats/NatsTaskPublisherTest.java
+++ b/extensions/control-plane/tasks/publisher/tasks-publisher-nats/src/test/java/org/eclipse/edc/virtual/controlplane/events/publisher/nats/NatsTaskPublisherTest.java
@@ -1,0 +1,202 @@
+/*
+ *  Copyright (c) 2026 Metaform Systems, Inc.
+ *
+ *  This program and the accompanying materials are made available under the
+ *  terms of the Apache License, Version 2.0 which is available at
+ *  https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Contributors:
+ *       Metaform Systems, Inc. - initial API and implementation
+ *
+ */
+
+package org.eclipse.edc.virtual.controlplane.events.publisher.nats;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import io.nats.client.JetStream;
+import org.eclipse.edc.spi.EdcException;
+import org.eclipse.edc.spi.monitor.Monitor;
+import org.eclipse.edc.virtual.controlplane.contract.spi.negotiation.tasks.RequestNegotiation;
+import org.eclipse.edc.virtual.controlplane.tasks.ProcessTaskPayload;
+import org.eclipse.edc.virtual.controlplane.tasks.Task;
+import org.eclipse.edc.virtual.controlplane.transfer.spi.tasks.PrepareTransfer;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.ArgumentMatchers.isA;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+
+class NatsTaskPublisherTest {
+
+    private final JetStream jetStream = mock();
+    private final Monitor monitor = mock();
+    private NatsTaskPublisher publisher;
+
+    @BeforeEach
+    void setUp() {
+        publisher = new NatsTaskPublisher(jetStream, monitor, ObjectMapper::new);
+    }
+
+    @Test
+    void created_shouldPublishContractNegotiationTaskToCorrectSubject() throws Exception {
+        var payload = RequestNegotiation.Builder.newInstance()
+                .processId("negotiation-123")
+                .processState("INITIAL")
+                .processType("CONSUMER")
+                .build();
+        var task = Task.Builder.newInstance()
+                .at(System.currentTimeMillis())
+                .payload(payload)
+                .build();
+
+        publisher.created(task);
+
+        verify(jetStream).publish(eq("negotiations.consumer.negotiation.request.prepare"), isA(byte[].class));
+    }
+
+    @Test
+    void created_shouldPublishTransferProcessTaskToCorrectSubject() throws Exception {
+        var payload = PrepareTransfer.Builder.newInstance()
+                .processId("transfer-123")
+                .processState("INITIAL")
+                .processType("CONSUMER")
+                .build();
+        var task = Task.Builder.newInstance()
+                .at(System.currentTimeMillis())
+                .payload(payload)
+                .build();
+
+        publisher.created(task);
+
+        verify(jetStream).publish(eq("transfers.consumer.transfer.prepare"), isA(byte[].class));
+    }
+
+    @Test
+    void created_shouldSerializeTaskAsJsonBytes() throws Exception {
+        var payload = RequestNegotiation.Builder.newInstance()
+                .processId("negotiation-123")
+                .processState("INITIAL")
+                .processType("CONSUMER")
+                .build();
+        var task = Task.Builder.newInstance()
+                .at(System.currentTimeMillis())
+                .payload(payload)
+                .build();
+
+        publisher.created(task);
+
+        verify(jetStream).publish(any(String.class), isA(byte[].class));
+    }
+
+    @Test
+    void created_shouldThrowEdcExceptionOnSerializationFailure() {
+        var mockPayload = mock(ProcessTaskPayload.class);
+        var task = Task.Builder.newInstance()
+                .at(System.currentTimeMillis())
+                .payload(mockPayload)
+                .build();
+
+        // ObjectMapper will fail to serialize the mock object
+        assertThatThrownBy(() -> publisher.created(task))
+                .isInstanceOf(EdcException.class);
+
+        verify(monitor).severe(any(String.class), any(Exception.class));
+    }
+
+    @Test
+    void created_shouldThrowEdcExceptionOnPublishFailure() throws Exception {
+        var payload = RequestNegotiation.Builder.newInstance()
+                .processId("negotiation-123")
+                .processState("INITIAL")
+                .processType("CONSUMER")
+                .build();
+        var task = Task.Builder.newInstance()
+                .at(System.currentTimeMillis())
+                .payload(payload)
+                .build();
+        var exception = new RuntimeException("NATS publish failed");
+        doThrow(exception).when(jetStream).publish(any(String.class), any(byte[].class));
+
+        assertThatThrownBy(() -> publisher.created(task))
+                .isInstanceOf(EdcException.class)
+                .hasCause(exception);
+
+        verify(monitor).severe(any(String.class), eq(exception));
+    }
+
+    @Test
+    void created_shouldThrowEdcExceptionForUnsupportedPayloadType() {
+        var payload = new UnsupportedPayload("process-1", "INITIAL", "CONSUMER");
+        var task = Task.Builder.newInstance()
+                .at(System.currentTimeMillis())
+                .payload(payload)
+                .build();
+
+        assertThatThrownBy(() -> publisher.created(task))
+                .isInstanceOf(EdcException.class)
+                .hasCauseInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("Unsupported event type");
+
+        verify(monitor).severe(any(String.class));
+    }
+
+    @Test
+    void created_shouldPublishWithCorrectMessageFormat() throws Exception {
+        var payload = PrepareTransfer.Builder.newInstance()
+                .processId("transfer-456")
+                .processState("STARTED")
+                .processType("PROVIDER")
+                .build();
+        var task = Task.Builder.newInstance()
+                .at(System.currentTimeMillis())
+                .payload(payload)
+                .build();
+
+        publisher.created(task);
+
+        verify(jetStream).publish(any(String.class), isA(byte[].class));
+    }
+
+    @Test
+    void created_shouldLogErrorWithTaskIdOnPublishFailure() throws Exception {
+        var payload = RequestNegotiation.Builder.newInstance()
+                .processId("negotiation-789")
+                .processState("INITIAL")
+                .processType("PROVIDER")
+                .build();
+        var task = Task.Builder.newInstance()
+                .at(System.currentTimeMillis())
+                .payload(payload)
+                .build();
+        var exception = new RuntimeException("Publish error");
+        doThrow(exception).when(jetStream).publish(any(String.class), any(byte[].class));
+
+        assertThatThrownBy(() -> publisher.created(task))
+                .isInstanceOf(EdcException.class);
+
+        verify(monitor).severe(any(String.class), eq(exception));
+    }
+
+    /**
+     * Unsupported task payload for testing error handling
+     */
+    private static class UnsupportedPayload extends ProcessTaskPayload {
+        UnsupportedPayload(String processId, String processState, String processType) {
+            this.processId = processId;
+            this.processState = processState;
+            this.processType = processType;
+        }
+
+        @Override
+        public String name() {
+            return "unsupported.payload";
+        }
+    }
+}

--- a/extensions/control-plane/tasks/store/tasks-store-sql/build.gradle.kts
+++ b/extensions/control-plane/tasks/store/tasks-store-sql/build.gradle.kts
@@ -1,0 +1,37 @@
+/*
+ *  Copyright (c) 2026 Metaform Systems, Inc.
+ *
+ *  This program and the accompanying materials are made available under the
+ *  terms of the Apache License, Version 2.0 which is available at
+ *  https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Contributors:
+ *       Metaform Systems, Inc. - initial API and implementation
+ *
+ */
+
+plugins {
+    `java-library`
+}
+
+dependencies {
+    api(libs.edc.spi.core)
+    api(libs.edc.spi.contract)
+    api(libs.edc.spi.transaction)
+    api(libs.edc.spi.transfer)
+    api(project(":spi:v-core-spi"))
+    api(project(":spi:v-task-spi"))
+    implementation(libs.edc.spi.transaction.datasource)
+    implementation(libs.edc.lib.sql)
+    implementation(libs.edc.core.sql.bootstrapper)
+    testImplementation(libs.awaitility)
+    testImplementation(libs.edc.junit)
+    testImplementation(testFixtures(libs.edc.spi.contract))
+    testImplementation(libs.testcontainers.junit)
+    testImplementation(testFixtures(project(":spi:v-task-spi")))
+    testImplementation(testFixtures(libs.edc.fixtures.sql))
+
+}
+

--- a/extensions/control-plane/tasks/store/tasks-store-sql/src/main/java/org/eclipse/edc/virtual/controlplane/tasks/sql/BaseSqlDialectStatementsTask.java
+++ b/extensions/control-plane/tasks/store/tasks-store-sql/src/main/java/org/eclipse/edc/virtual/controlplane/tasks/sql/BaseSqlDialectStatementsTask.java
@@ -1,0 +1,65 @@
+/*
+ *  Copyright (c) 2026 Metaform Systems, Inc.
+ *
+ *  This program and the accompanying materials are made available under the
+ *  terms of the Apache License, Version 2.0 which is available at
+ *  https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Contributors:
+ *       Metaform Systems, Inc. - initial API and implementation
+ *
+ */
+
+package org.eclipse.edc.virtual.controlplane.tasks.sql;
+
+import org.eclipse.edc.spi.query.QuerySpec;
+import org.eclipse.edc.sql.translation.PostgresqlOperatorTranslator;
+import org.eclipse.edc.sql.translation.SqlQueryStatement;
+import org.eclipse.edc.virtual.controlplane.tasks.sql.schema.postgres.TaskMapping;
+
+import static java.lang.String.format;
+
+public class BaseSqlDialectStatementsTask implements TaskStatements {
+
+    @Override
+    public String getInsertTemplate() {
+        return executeStatement()
+                .column(getIdColumn())
+                .column(getNameColumn())
+                .jsonColumn(getPayloadColumn())
+                .column(getTimestampColumn())
+                .insertInto(getTaskTable());
+    }
+
+    @Override
+    public String getUpdateTemplate() {
+        return executeStatement()
+                .column(getNameColumn())
+                .jsonColumn(getPayloadColumn())
+                .column(getTimestampColumn())
+                .update(getTaskTable(), getIdColumn());
+    }
+
+    @Override
+    public String findByIdTemplate() {
+        return format("SELECT * FROM %s WHERE %s = ?", getTaskTable(), getIdColumn());
+    }
+
+    @Override
+    public String fetchUnpublishedTemplate() {
+        return format("SELECT * FROM %s ORDER BY %s ASC LIMIT ?", getTaskTable(), getTimestampColumn());
+    }
+
+    @Override
+    public SqlQueryStatement createQuery(QuerySpec querySpec) {
+        var select = format("SELECT * FROM %s", getTaskTable());
+        return new SqlQueryStatement(select, querySpec, new TaskMapping(this), new PostgresqlOperatorTranslator());
+    }
+
+    @Override
+    public String getDeleteStatement() {
+        return executeStatement().delete(getTaskTable(), getIdColumn());
+    }
+}

--- a/extensions/control-plane/tasks/store/tasks-store-sql/src/main/java/org/eclipse/edc/virtual/controlplane/tasks/sql/SqlTaskStore.java
+++ b/extensions/control-plane/tasks/store/tasks-store-sql/src/main/java/org/eclipse/edc/virtual/controlplane/tasks/sql/SqlTaskStore.java
@@ -1,0 +1,120 @@
+/*
+ *  Copyright (c) 2026 Metaform Systems, Inc.
+ *
+ *  This program and the accompanying materials are made available under the
+ *  terms of the Apache License, Version 2.0 which is available at
+ *  https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Contributors:
+ *       Metaform Systems, Inc. - initial API and implementation
+ *
+ */
+
+package org.eclipse.edc.virtual.controlplane.tasks.sql;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.eclipse.edc.spi.persistence.EdcPersistenceException;
+import org.eclipse.edc.spi.query.QuerySpec;
+import org.eclipse.edc.sql.QueryExecutor;
+import org.eclipse.edc.sql.store.AbstractSqlStore;
+import org.eclipse.edc.transaction.datasource.spi.DataSourceRegistry;
+import org.eclipse.edc.transaction.spi.TransactionContext;
+import org.eclipse.edc.virtual.controlplane.tasks.Task;
+import org.eclipse.edc.virtual.controlplane.tasks.TaskPayload;
+import org.eclipse.edc.virtual.controlplane.tasks.store.TaskStore;
+
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.util.List;
+
+public class SqlTaskStore extends AbstractSqlStore implements TaskStore {
+
+    private final TaskStatements statements;
+
+    public SqlTaskStore(DataSourceRegistry dataSourceRegistry, String dataSourceName, TransactionContext transactionContext, ObjectMapper objectMapper, QueryExecutor queryExecutor, TaskStatements statements) {
+        super(dataSourceRegistry, dataSourceName, transactionContext, objectMapper, queryExecutor);
+        this.statements = statements;
+    }
+
+    @Override
+    public void create(Task task) {
+        transactionContext.execute(() -> {
+            try (var connection = getConnection()) {
+                var stmt = statements.getInsertTemplate();
+                queryExecutor.execute(connection, stmt,
+                        task.getId(),
+                        task.getPayload().name(),
+                        toJson(task.getPayload()),
+                        task.getAt()
+                );
+            } catch (SQLException e) {
+                throw new EdcPersistenceException(e);
+            }
+        });
+    }
+
+    @Override
+    public void update(Task task) {
+        transactionContext.execute(() -> {
+            try (var connection = getConnection()) {
+                var stmt = statements.getUpdateTemplate();
+                queryExecutor.execute(connection, stmt,
+                        task.getPayload().name(),
+                        toJson(task.getPayload()),
+                        task.getAt(),
+                        task.getId()
+                );
+            } catch (SQLException e) {
+                throw new EdcPersistenceException(e);
+            }
+        });
+    }
+
+    @Override
+    public List<Task> fetchForUpdate(QuerySpec querySpec) {
+        return transactionContext.execute(() -> {
+            try (var connection = getConnection()) {
+                var query = statements.createQuery(querySpec).forUpdate(true);
+                return queryExecutor.query(connection, true, this::mapResultSet, query.getQueryAsString(), query.getParameters()).toList();
+            } catch (SQLException e) {
+                throw new EdcPersistenceException(e);
+            }
+        });
+    }
+
+    @Override
+    public Task findById(String id) {
+        return transactionContext.execute(() -> {
+            try (var connection = getConnection()) {
+                var stmt = statements.findByIdTemplate();
+                return queryExecutor.single(connection, true, this::mapResultSet, stmt, id);
+            } catch (SQLException e) {
+                throw new EdcPersistenceException(e);
+            }
+        });
+    }
+
+    @Override
+    public void delete(String id) {
+        transactionContext.execute(() -> {
+            try (var connection = getConnection()) {
+                var stmt = statements.getDeleteStatement();
+                queryExecutor.execute(connection, stmt, id);
+            } catch (SQLException e) {
+                throw new EdcPersistenceException(e);
+            }
+        });
+    }
+
+    private Task mapResultSet(ResultSet resultSet) throws Exception {
+
+        var payload = fromJson(resultSet.getString(statements.getPayloadColumn()), TaskPayload.class);
+        return Task.Builder.newInstance()
+                .id(resultSet.getString(statements.getIdColumn()))
+                .payload(payload)
+                .at(resultSet.getLong(statements.getTimestampColumn()))
+                .build();
+    }
+}

--- a/extensions/control-plane/tasks/store/tasks-store-sql/src/main/java/org/eclipse/edc/virtual/controlplane/tasks/sql/SqlTaskStoreExtension.java
+++ b/extensions/control-plane/tasks/store/tasks-store-sql/src/main/java/org/eclipse/edc/virtual/controlplane/tasks/sql/SqlTaskStoreExtension.java
@@ -1,0 +1,67 @@
+/*
+ *  Copyright (c) 2026 Metaform Systems, Inc.
+ *
+ *  This program and the accompanying materials are made available under the
+ *  terms of the Apache License, Version 2.0 which is available at
+ *  https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Contributors:
+ *       Metaform Systems, Inc. - initial API and implementation
+ *
+ */
+
+package org.eclipse.edc.virtual.controlplane.tasks.sql;
+
+import org.eclipse.edc.runtime.metamodel.annotation.Extension;
+import org.eclipse.edc.runtime.metamodel.annotation.Inject;
+import org.eclipse.edc.runtime.metamodel.annotation.Provider;
+import org.eclipse.edc.runtime.metamodel.annotation.Setting;
+import org.eclipse.edc.spi.system.ServiceExtension;
+import org.eclipse.edc.spi.system.ServiceExtensionContext;
+import org.eclipse.edc.spi.types.TypeManager;
+import org.eclipse.edc.sql.QueryExecutor;
+import org.eclipse.edc.sql.bootstrapper.SqlSchemaBootstrapper;
+import org.eclipse.edc.transaction.datasource.spi.DataSourceRegistry;
+import org.eclipse.edc.transaction.spi.TransactionContext;
+import org.eclipse.edc.virtual.controlplane.tasks.sql.schema.postgres.PostgresDialectStatementsTask;
+import org.eclipse.edc.virtual.controlplane.tasks.store.TaskStore;
+
+import static org.eclipse.edc.virtual.controlplane.tasks.sql.SqlTaskStoreExtension.NAME;
+
+@Extension(NAME)
+public class SqlTaskStoreExtension implements ServiceExtension {
+
+    public static final String NAME = "Tasks SQL Store Extension";
+
+
+    @Setting(description = "The datasource to be used", defaultValue = DataSourceRegistry.DEFAULT_DATASOURCE, key = "edc.sql.store.tasks.datasource")
+    private String dataSourceName;
+    @Inject
+    private DataSourceRegistry dataSourceRegistry;
+    @Inject
+    private TransactionContext transactionContext;
+    @Inject
+    private TypeManager typeManager;
+    @Inject
+    private QueryExecutor queryExecutor;
+    @Inject(required = false)
+    private TaskStatements statements;
+    @Inject
+    private SqlSchemaBootstrapper sqlSchemaBootstrapper;
+
+    @Override
+    public void initialize(ServiceExtensionContext context) {
+        sqlSchemaBootstrapper.addStatementFromResource(dataSourceName, "task-schema.sql");
+    }
+
+    @Provider
+    public TaskStore createSqlStore() {
+        return new SqlTaskStore(dataSourceRegistry, dataSourceName, transactionContext, typeManager.getMapper(), queryExecutor, getStatementImpl());
+    }
+
+    private TaskStatements getStatementImpl() {
+        return statements != null ? statements : new PostgresDialectStatementsTask();
+    }
+}

--- a/extensions/control-plane/tasks/store/tasks-store-sql/src/main/java/org/eclipse/edc/virtual/controlplane/tasks/sql/TaskStatements.java
+++ b/extensions/control-plane/tasks/store/tasks-store-sql/src/main/java/org/eclipse/edc/virtual/controlplane/tasks/sql/TaskStatements.java
@@ -1,0 +1,56 @@
+/*
+ *  Copyright (c) 2026 Metaform Systems, Inc.
+ *
+ *  This program and the accompanying materials are made available under the
+ *  terms of the Apache License, Version 2.0 which is available at
+ *  https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Contributors:
+ *       Metaform Systems, Inc. - initial API and implementation
+ *
+ */
+
+package org.eclipse.edc.virtual.controlplane.tasks.sql;
+
+import org.eclipse.edc.spi.query.QuerySpec;
+import org.eclipse.edc.sql.statement.SqlStatements;
+import org.eclipse.edc.sql.translation.SqlQueryStatement;
+
+public interface TaskStatements extends SqlStatements {
+
+
+    default String getTaskTable() {
+        return "edc_tasks";
+    }
+
+    default String getIdColumn() {
+        return "id";
+    }
+
+    default String getNameColumn() {
+        return "name";
+    }
+
+    default String getPayloadColumn() {
+        return "payload";
+    }
+
+    default String getTimestampColumn() {
+        return "timestamp";
+    }
+
+    String getInsertTemplate();
+
+    String getUpdateTemplate();
+
+    String fetchUnpublishedTemplate();
+
+    String findByIdTemplate();
+
+    String getDeleteStatement();
+
+    SqlQueryStatement createQuery(QuerySpec querySpec);
+    
+}

--- a/extensions/control-plane/tasks/store/tasks-store-sql/src/main/java/org/eclipse/edc/virtual/controlplane/tasks/sql/schema/postgres/PostgresDialectStatementsTask.java
+++ b/extensions/control-plane/tasks/store/tasks-store-sql/src/main/java/org/eclipse/edc/virtual/controlplane/tasks/sql/schema/postgres/PostgresDialectStatementsTask.java
@@ -1,0 +1,29 @@
+/*
+ *  Copyright (c) 2026 Metaform Systems, Inc.
+ *
+ *  This program and the accompanying materials are made available under the
+ *  terms of the Apache License, Version 2.0 which is available at
+ *  https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Contributors:
+ *       Metaform Systems, Inc. - initial API and implementation
+ *
+ */
+
+package org.eclipse.edc.virtual.controlplane.tasks.sql.schema.postgres;
+
+import org.eclipse.edc.sql.dialect.PostgresDialect;
+import org.eclipse.edc.virtual.controlplane.tasks.sql.BaseSqlDialectStatementsTask;
+
+/**
+ * Postgres-specific specialization for creating queries based on Postgres JSON operators
+ */
+public class PostgresDialectStatementsTask extends BaseSqlDialectStatementsTask {
+
+    @Override
+    public String getFormatAsJsonOperator() {
+        return PostgresDialect.getJsonCastOperator();
+    }
+}

--- a/extensions/control-plane/tasks/store/tasks-store-sql/src/main/java/org/eclipse/edc/virtual/controlplane/tasks/sql/schema/postgres/TaskMapping.java
+++ b/extensions/control-plane/tasks/store/tasks-store-sql/src/main/java/org/eclipse/edc/virtual/controlplane/tasks/sql/schema/postgres/TaskMapping.java
@@ -1,0 +1,35 @@
+/*
+ *  Copyright (c) 2026 Metaform Systems, Inc.
+ *
+ *  This program and the accompanying materials are made available under the
+ *  terms of the Apache License, Version 2.0 which is available at
+ *  https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Contributors:
+ *       Metaform Systems, Inc. - initial API and implementation
+ *
+ */
+
+package org.eclipse.edc.virtual.controlplane.tasks.sql.schema.postgres;
+
+import org.eclipse.edc.sql.translation.TranslationMapping;
+import org.eclipse.edc.virtual.controlplane.tasks.sql.TaskStatements;
+
+
+/**
+ * Provides a mapping from the canonical format to SQL column names for a {@code Task}
+ */
+public class TaskMapping extends TranslationMapping {
+
+    public static final String FIELD_ID = "id";
+    public static final String FIELD_AT_TIMESTAMP = "at";
+    public static final String FIELD_NAME = "name";
+
+    public TaskMapping(TaskStatements statements) {
+        add(FIELD_ID, statements.getIdColumn());
+        add(FIELD_AT_TIMESTAMP, statements.getTimestampColumn());
+        add(FIELD_NAME, statements.getNameColumn());
+    }
+}

--- a/extensions/control-plane/tasks/store/tasks-store-sql/src/main/resources/META-INF/services/org.eclipse.edc.spi.system.ServiceExtension
+++ b/extensions/control-plane/tasks/store/tasks-store-sql/src/main/resources/META-INF/services/org.eclipse.edc.spi.system.ServiceExtension
@@ -1,0 +1,14 @@
+#
+#  Copyright (c) 2026 Metaform Systems, Inc.
+#
+#  This program and the accompanying materials are made available under the
+#  terms of the Apache License, Version 2.0 which is available at
+#  https://www.apache.org/licenses/LICENSE-2.0
+#
+#  SPDX-License-Identifier: Apache-2.0
+#
+#  Contributors:
+#       Metaform Systems, Inc. - initial API and implementation
+#
+#
+org.eclipse.edc.virtual.controlplane.tasks.sql.SqlTaskStoreExtension

--- a/extensions/control-plane/tasks/store/tasks-store-sql/src/main/resources/task-schema.sql
+++ b/extensions/control-plane/tasks/store/tasks-store-sql/src/main/resources/task-schema.sql
@@ -1,0 +1,23 @@
+/*
+ *  Copyright (c) 2025 Metaform Systems, Inc.
+ *
+ *  This program and the accompanying materials are made available under the
+ *  terms of the Apache License, Version 2.0 which is available at
+ *  https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Contributors:
+ *       Metaform Systems, Inc. - initial API and implementation
+ *
+ */
+
+-- only intended for and tested with Postgres!
+CREATE TABLE IF NOT EXISTS edc_tasks
+(
+    id                      VARCHAR PRIMARY KEY NOT NULL,
+    name                    VARCHAR             NOT NULL,
+    payload                 JSON DEFAULT '{}',
+    timestamp               BIGINT              NOT NULL
+);
+

--- a/extensions/control-plane/tasks/store/tasks-store-sql/src/test/java/org/eclipse/edc/virtual/controlplane/tasks/sql/SqlTaskStoreTest.java
+++ b/extensions/control-plane/tasks/store/tasks-store-sql/src/test/java/org/eclipse/edc/virtual/controlplane/tasks/sql/SqlTaskStoreTest.java
@@ -1,0 +1,56 @@
+/*
+ *  Copyright (c) 2026 Metaform Systems, Inc.
+ *
+ *  This program and the accompanying materials are made available under the
+ *  terms of the Apache License, Version 2.0 which is available at
+ *  https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Contributors:
+ *       Metaform Systems, Inc. - initial API and implementation
+ *
+ */
+
+package org.eclipse.edc.virtual.controlplane.tasks.sql;
+
+import org.eclipse.edc.json.JacksonTypeManager;
+import org.eclipse.edc.junit.annotations.ComponentTest;
+import org.eclipse.edc.junit.testfixtures.TestUtils;
+import org.eclipse.edc.sql.QueryExecutor;
+import org.eclipse.edc.sql.testfixtures.PostgresqlStoreSetupExtension;
+import org.eclipse.edc.virtual.controlplane.tasks.sql.schema.postgres.PostgresDialectStatementsTask;
+import org.eclipse.edc.virtual.controlplane.tasks.store.TaskStore;
+import org.eclipse.edc.virtual.controlplane.tasks.store.TaskStoreTestBase;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.extension.ExtendWith;
+
+@ComponentTest
+@ExtendWith(PostgresqlStoreSetupExtension.class)
+public class SqlTaskStoreTest extends TaskStoreTestBase {
+    private final TaskStatements statements = new PostgresDialectStatementsTask();
+    private SqlTaskStore store;
+
+    @Override
+    protected TaskStore getStore() {
+        return store;
+    }
+
+    @BeforeEach
+    void setup(PostgresqlStoreSetupExtension extension, QueryExecutor queryExecutor) {
+        var typeManager = new JacksonTypeManager();
+
+        typeManager.registerTypes(TestPayload.class);
+        store = new SqlTaskStore(extension.getDataSourceRegistry(), extension.getDatasourceName(),
+                extension.getTransactionContext(), typeManager.getMapper(), queryExecutor, statements);
+
+        var schema = TestUtils.getResourceFileContentAsString("task-schema.sql");
+        extension.runQuery(schema);
+    }
+
+    @AfterEach
+    void tearDown(PostgresqlStoreSetupExtension extension) {
+        extension.runQuery("DROP TABLE " + statements.getTaskTable() + " CASCADE");
+    }
+}

--- a/extensions/control-plane/tasks/subscriber/negotiation-tasks-subscriber-nats/build.gradle.kts
+++ b/extensions/control-plane/tasks/subscriber/negotiation-tasks-subscriber-nats/build.gradle.kts
@@ -1,0 +1,33 @@
+/*
+ *  Copyright (c) 2026 Metaform Systems, Inc.
+ *
+ *  This program and the accompanying materials are made available under the
+ *  terms of the Apache License, Version 2.0 which is available at
+ *  https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Contributors:
+ *       Metaform Systems, Inc. - initial API and implementation
+ *
+ */
+
+plugins {
+    `java-library`
+}
+
+dependencies {
+    api(libs.edc.spi.core)
+    api(libs.edc.spi.contract)
+    api(project(":spi:v-core-spi"))
+    api(project(":spi:v-task-spi"))
+    implementation(libs.nats.client)
+    implementation(project(":extensions:lib:nats-lib"))
+    testImplementation(libs.awaitility)
+    testImplementation(libs.edc.junit)
+    testImplementation(testFixtures(libs.edc.spi.contract))
+    testImplementation(libs.testcontainers.junit)
+    testImplementation(testFixtures(project(":extensions:lib:nats-lib")))
+    testImplementation(project(":core:v-task-core"))
+}
+

--- a/extensions/control-plane/tasks/subscriber/negotiation-tasks-subscriber-nats/src/main/java/org/eclipse/edc/virtual/controlplane/contract/negotiation/subscriber/NatsContractNegotiationSubscriberExtension.java
+++ b/extensions/control-plane/tasks/subscriber/negotiation-tasks-subscriber-nats/src/main/java/org/eclipse/edc/virtual/controlplane/contract/negotiation/subscriber/NatsContractNegotiationSubscriberExtension.java
@@ -1,0 +1,104 @@
+/*
+ *  Copyright (c) 2026 Metaform Systems, Inc.
+ *
+ *  This program and the accompanying materials are made available under the
+ *  terms of the Apache License, Version 2.0 which is available at
+ *  https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Contributors:
+ *       Metaform Systems, Inc. - initial API and implementation
+ *
+ */
+
+package org.eclipse.edc.virtual.controlplane.contract.negotiation.subscriber;
+
+import org.eclipse.edc.runtime.metamodel.annotation.Configuration;
+import org.eclipse.edc.runtime.metamodel.annotation.Inject;
+import org.eclipse.edc.runtime.metamodel.annotation.Setting;
+import org.eclipse.edc.runtime.metamodel.annotation.Settings;
+import org.eclipse.edc.spi.monitor.Monitor;
+import org.eclipse.edc.spi.system.ExecutorInstrumentation;
+import org.eclipse.edc.spi.system.ServiceExtension;
+import org.eclipse.edc.spi.system.ServiceExtensionContext;
+import org.eclipse.edc.spi.types.TypeManager;
+import org.eclipse.edc.virtual.controlplane.contract.spi.negotiation.ContractNegotiationTaskExecutor;
+
+public class NatsContractNegotiationSubscriberExtension implements ServiceExtension {
+
+    @Configuration
+    private NatsSubscriberConfig subscriberConfig;
+
+    @Inject
+    private TypeManager typeManager;
+
+    @Inject
+    private ContractNegotiationTaskExecutor taskExecutor;
+
+    @Inject
+    private ExecutorInstrumentation executorInstrumentation;
+
+    @Inject
+    private Monitor monitor;
+
+    private NatsContractNegotiationTaskSubscriber subscriber;
+
+
+    @Override
+    public void initialize(ServiceExtensionContext context) {
+        subscriber = NatsContractNegotiationTaskSubscriber.Builder.newInstance()
+                .url(subscriberConfig.url())
+                .name(subscriberConfig.name())
+                .stream(subscriberConfig.stream)
+                .subject(subscriberConfig.subject())
+                .monitor(monitor)
+                .mapperSupplier(() -> typeManager.getMapper())
+                .taskExecutor(taskExecutor)
+                .autoCreate(subscriberConfig.autoCreate)
+                .executorInstrumentation(executorInstrumentation)
+                .batchSize(subscriberConfig.batchSize)
+                .maxWait(subscriberConfig.maxWait)
+                .build();
+    }
+
+    @Override
+    public void prepare() {
+        if (subscriber != null) {
+            subscriber.prepare();
+        }
+    }
+
+    @Override
+    public void start() {
+        if (subscriber != null) {
+            subscriber.start();
+        }
+    }
+
+    @Override
+    public void shutdown() {
+        if (subscriber != null) {
+            subscriber.stop();
+        }
+    }
+
+    @Settings
+    public record NatsSubscriberConfig(
+            @Setting(key = "edc.nats.cn.subscriber.url", description = "The URL of the NATS server to connect to for contract negotiation events.", defaultValue = "nats://localhost:4222")
+            String url,
+            @Setting(key = "edc.nats.cn.subscriber.name", description = "The name of the consumer for contract negotiation events", defaultValue = "cn-subscriber")
+            String name,
+            @Setting(key = "edc.nats.cn.subscriber.autocreate", description = "When true, it will automatically create the stream and the consumer if not present", defaultValue = "false")
+            Boolean autoCreate,
+            @Setting(key = "edc.nats.cn.subscriber.stream", description = "The stream name where to attach the consumer", defaultValue = "cn-stream")
+            String stream,
+            @Setting(key = "edc.nats.cn.subscriber.subject", description = "The subject of the consumer for contract negotiation events", defaultValue = "negotiations.>")
+            String subject,
+            @Setting(key = "edc.nats.cn.subscriber.batch-size", description = "The size of the batch when fetching messages", defaultValue = "100")
+            Integer batchSize,
+            @Setting(key = "edc.nats.cn.subscriber.max-wait", description = "The max waiting time for messages (ms)", defaultValue = "100")
+            Integer maxWait
+    ) {
+    }
+}

--- a/extensions/control-plane/tasks/subscriber/negotiation-tasks-subscriber-nats/src/main/java/org/eclipse/edc/virtual/controlplane/contract/negotiation/subscriber/NatsContractNegotiationTaskSubscriber.java
+++ b/extensions/control-plane/tasks/subscriber/negotiation-tasks-subscriber-nats/src/main/java/org/eclipse/edc/virtual/controlplane/contract/negotiation/subscriber/NatsContractNegotiationTaskSubscriber.java
@@ -1,0 +1,84 @@
+/*
+ *  Copyright (c) 2026 Metaform Systems, Inc.
+ *
+ *  This program and the accompanying materials are made available under the
+ *  terms of the Apache License, Version 2.0 which is available at
+ *  https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Contributors:
+ *       Metaform Systems, Inc. - initial API and implementation
+ *
+ */
+
+package org.eclipse.edc.virtual.controlplane.contract.negotiation.subscriber;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import io.nats.client.Message;
+import org.eclipse.edc.spi.response.ResponseStatus;
+import org.eclipse.edc.spi.response.StatusResult;
+import org.eclipse.edc.virtual.controlplane.contract.spi.negotiation.ContractNegotiationTaskExecutor;
+import org.eclipse.edc.virtual.controlplane.contract.spi.negotiation.tasks.ContractNegotiationTaskPayload;
+import org.eclipse.edc.virtual.controlplane.tasks.Task;
+import org.eclipse.edc.virtual.nats.subscriber.NatsSubscriber;
+
+import java.util.Objects;
+import java.util.function.Supplier;
+
+public class NatsContractNegotiationTaskSubscriber extends NatsSubscriber {
+
+    protected ContractNegotiationTaskExecutor taskExecutor;
+    protected Supplier<ObjectMapper> mapperSupplier;
+
+    private NatsContractNegotiationTaskSubscriber() {
+    }
+
+    // TODO check if the task was actually stored
+    @Override
+    protected StatusResult<Void> handleMessage(Message message) {
+        try {
+            var task = mapperSupplier.get().readValue(message.getData(), Task.class);
+            if (task.getPayload() instanceof ContractNegotiationTaskPayload payload) {
+                return taskExecutor.handle(payload);
+            } else {
+                return StatusResult.failure(ResponseStatus.FATAL_ERROR, "Invalid task payload type");
+            }
+        } catch (Exception e) {
+            return StatusResult.failure(ResponseStatus.FATAL_ERROR, e.getMessage());
+        }
+    }
+
+    public static class Builder extends NatsSubscriber.Builder<NatsContractNegotiationTaskSubscriber, Builder> {
+
+        protected Builder() {
+            super(new NatsContractNegotiationTaskSubscriber());
+        }
+
+        public static Builder newInstance() {
+            return new Builder();
+        }
+
+        public Builder mapperSupplier(Supplier<ObjectMapper> mapperSupplier) {
+            subscriber.mapperSupplier = mapperSupplier;
+            return self();
+        }
+
+        public Builder taskExecutor(ContractNegotiationTaskExecutor taskExecutor) {
+            subscriber.taskExecutor = taskExecutor;
+            return self();
+        }
+
+        @Override
+        public Builder self() {
+            return this;
+        }
+
+        @Override
+        public NatsContractNegotiationTaskSubscriber build() {
+            Objects.requireNonNull(subscriber.mapperSupplier, "mapperSupplier must be set");
+            Objects.requireNonNull(subscriber.taskExecutor, "stateMachineService must be set");
+            return super.build();
+        }
+    }
+}

--- a/extensions/control-plane/tasks/subscriber/negotiation-tasks-subscriber-nats/src/main/resources/META-INF/services/org.eclipse.edc.spi.system.ServiceExtension
+++ b/extensions/control-plane/tasks/subscriber/negotiation-tasks-subscriber-nats/src/main/resources/META-INF/services/org.eclipse.edc.spi.system.ServiceExtension
@@ -1,0 +1,14 @@
+#
+#  Copyright (c) 2026 Metaform Systems, Inc.
+#
+#  This program and the accompanying materials are made available under the
+#  terms of the Apache License, Version 2.0 which is available at
+#  https://www.apache.org/licenses/LICENSE-2.0
+#
+#  SPDX-License-Identifier: Apache-2.0
+#
+#  Contributors:
+#       Metaform Systems, Inc. - initial API and implementation
+#
+#
+org.eclipse.edc.virtual.controlplane.contract.negotiation.subscriber.NatsContractNegotiationSubscriberExtension

--- a/extensions/control-plane/tasks/subscriber/negotiation-tasks-subscriber-nats/src/test/java/org/eclipse/edc/virtual/controlplane/contract/negotiation/subscriber/NatsContractNegotiationTaskSubscriberTest.java
+++ b/extensions/control-plane/tasks/subscriber/negotiation-tasks-subscriber-nats/src/test/java/org/eclipse/edc/virtual/controlplane/contract/negotiation/subscriber/NatsContractNegotiationTaskSubscriberTest.java
@@ -1,0 +1,148 @@
+/*
+ *  Copyright (c) 2026 Metaform Systems, Inc.
+ *
+ *  This program and the accompanying materials are made available under the
+ *  terms of the Apache License, Version 2.0 which is available at
+ *  https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Contributors:
+ *       Metaform Systems, Inc. - initial API and implementation
+ *
+ */
+
+package org.eclipse.edc.virtual.controlplane.contract.negotiation.subscriber;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.eclipse.edc.connector.controlplane.contract.spi.types.negotiation.ContractNegotiation;
+import org.eclipse.edc.connector.controlplane.contract.spi.types.negotiation.ContractNegotiationStates;
+import org.eclipse.edc.spi.response.StatusResult;
+import org.eclipse.edc.virtual.controlplane.contract.spi.negotiation.ContractNegotiationTaskExecutor;
+import org.eclipse.edc.virtual.controlplane.contract.spi.negotiation.tasks.AgreeNegotiation;
+import org.eclipse.edc.virtual.controlplane.contract.spi.negotiation.tasks.ContractNegotiationTaskPayload;
+import org.eclipse.edc.virtual.controlplane.contract.spi.negotiation.tasks.FinalizeNegotiation;
+import org.eclipse.edc.virtual.controlplane.contract.spi.negotiation.tasks.RequestNegotiation;
+import org.eclipse.edc.virtual.controlplane.contract.spi.negotiation.tasks.SendAgreement;
+import org.eclipse.edc.virtual.controlplane.contract.spi.negotiation.tasks.SendFinalizeNegotiation;
+import org.eclipse.edc.virtual.controlplane.contract.spi.negotiation.tasks.SendRequestNegotiation;
+import org.eclipse.edc.virtual.controlplane.contract.spi.negotiation.tasks.SendVerificationNegotiation;
+import org.eclipse.edc.virtual.controlplane.contract.spi.negotiation.tasks.VerifyNegotiation;
+import org.eclipse.edc.virtual.controlplane.tasks.ProcessTaskPayload;
+import org.eclipse.edc.virtual.controlplane.tasks.Task;
+import org.eclipse.edc.virtual.controlplane.tasks.TaskTypes;
+import org.eclipse.edc.virtual.nats.testfixtures.NatsEndToEndExtension;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Order;
+import org.junit.jupiter.api.extension.ExtensionContext;
+import org.junit.jupiter.api.extension.RegisterExtension;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.ArgumentsProvider;
+import org.junit.jupiter.params.provider.ArgumentsSource;
+
+import java.util.stream.Stream;
+
+import static org.awaitility.Awaitility.await;
+import static org.eclipse.edc.connector.controlplane.contract.spi.types.negotiation.ContractNegotiation.Type.CONSUMER;
+import static org.eclipse.edc.connector.controlplane.contract.spi.types.negotiation.ContractNegotiation.Type.PROVIDER;
+import static org.eclipse.edc.connector.controlplane.contract.spi.types.negotiation.ContractNegotiationStates.AGREED;
+import static org.eclipse.edc.connector.controlplane.contract.spi.types.negotiation.ContractNegotiationStates.AGREEING;
+import static org.eclipse.edc.connector.controlplane.contract.spi.types.negotiation.ContractNegotiationStates.FINALIZED;
+import static org.eclipse.edc.connector.controlplane.contract.spi.types.negotiation.ContractNegotiationStates.FINALIZING;
+import static org.eclipse.edc.connector.controlplane.contract.spi.types.negotiation.ContractNegotiationStates.INITIAL;
+import static org.eclipse.edc.connector.controlplane.contract.spi.types.negotiation.ContractNegotiationStates.REQUESTED;
+import static org.eclipse.edc.connector.controlplane.contract.spi.types.negotiation.ContractNegotiationStates.REQUESTING;
+import static org.eclipse.edc.connector.controlplane.contract.spi.types.negotiation.ContractNegotiationStates.VERIFIED;
+import static org.eclipse.edc.connector.controlplane.contract.spi.types.negotiation.ContractNegotiationStates.VERIFYING;
+import static org.junit.jupiter.params.provider.Arguments.arguments;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.refEq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+public class NatsContractNegotiationTaskSubscriberTest {
+
+    public static final String STREAM_NAME = "stream_test";
+    public static final String CONSUMER_NAME = "consumer_test";
+    @Order(0)
+    @RegisterExtension
+    static final NatsEndToEndExtension NATS_EXTENSION = new NatsEndToEndExtension();
+    private final ContractNegotiationTaskExecutor taskManager = mock();
+    private NatsContractNegotiationTaskSubscriber subscriber;
+    private static final ObjectMapper MAPPER = new ObjectMapper();
+
+    @BeforeAll
+    static void beforeAll() {
+        TaskTypes.TYPES.forEach(MAPPER::registerSubtypes);
+    }
+
+    @BeforeEach
+    void beforeEach() {
+        NATS_EXTENSION.createStream(STREAM_NAME, "negotiations.>");
+        NATS_EXTENSION.createConsumer(STREAM_NAME, CONSUMER_NAME, "negotiations.>");
+        subscriber = NatsContractNegotiationTaskSubscriber.Builder.newInstance()
+                .url(NATS_EXTENSION.getNatsUrl())
+                .name(CONSUMER_NAME)
+                .stream(STREAM_NAME)
+                .subject("negotiations.>")
+                .monitor(mock())
+                .mapperSupplier(() -> MAPPER)
+                .taskExecutor(taskManager)
+                .build();
+
+    }
+
+    @AfterEach
+    void afterEach() {
+        subscriber.stop();
+        NATS_EXTENSION.deleteStream(STREAM_NAME);
+    }
+
+    @ParameterizedTest
+    @ArgumentsSource(StateTransitionProvider.class)
+    void handleMessage(ContractNegotiationTaskPayload payload) throws JsonProcessingException {
+        when(taskManager.handle(any())).thenReturn(StatusResult.success());
+        subscriber.start();
+        var task = Task.Builder.newInstance().at(System.currentTimeMillis())
+                .payload(payload)
+                .build();
+
+        NATS_EXTENSION.publish("negotiations.provider." + payload.name(), MAPPER.writeValueAsBytes(task));
+
+        await().untilAsserted(() -> {
+            verify(taskManager).handle(refEq(payload));
+        });
+    }
+
+
+    public static class StateTransitionProvider implements ArgumentsProvider {
+
+        protected <T extends ProcessTaskPayload, B extends ProcessTaskPayload.Builder<T, B>> B baseBuilder(B builder, String id, ContractNegotiationStates state, ContractNegotiation.Type type) {
+            return builder.processId(id)
+                    .processState(state.name())
+                    .processType(type.name());
+        }
+
+        @Override
+        public Stream<? extends Arguments> provideArguments(ExtensionContext context) {
+
+            return Stream.of(
+                    arguments(baseBuilder(RequestNegotiation.Builder.newInstance(), "id", INITIAL, CONSUMER).build(), REQUESTING),
+                    arguments(baseBuilder(SendRequestNegotiation.Builder.newInstance(), "id", REQUESTING, CONSUMER).build(), REQUESTED),
+                    arguments(baseBuilder(VerifyNegotiation.Builder.newInstance(), "id", AGREED, CONSUMER).build(), VERIFYING),
+                    arguments(baseBuilder(SendVerificationNegotiation.Builder.newInstance(), "id", VERIFYING, CONSUMER).build(), VERIFIED),
+                    arguments(baseBuilder(AgreeNegotiation.Builder.newInstance(), "id", REQUESTED, PROVIDER).build(), AGREEING),
+                    arguments(baseBuilder(SendAgreement.Builder.newInstance(), "id", AGREEING, PROVIDER).build(), AGREED),
+                    arguments(baseBuilder(FinalizeNegotiation.Builder.newInstance(), "id", VERIFIED, PROVIDER).build(), FINALIZING),
+                    arguments(baseBuilder(SendFinalizeNegotiation.Builder.newInstance(), "id", FINALIZING, PROVIDER).build(), FINALIZED)
+            );
+        }
+    }
+
+
+}

--- a/extensions/control-plane/tasks/subscriber/transfer-tasks-subscriber-nats/build.gradle.kts
+++ b/extensions/control-plane/tasks/subscriber/transfer-tasks-subscriber-nats/build.gradle.kts
@@ -1,0 +1,33 @@
+/*
+ *  Copyright (c) 2026 Metaform Systems, Inc.
+ *
+ *  This program and the accompanying materials are made available under the
+ *  terms of the Apache License, Version 2.0 which is available at
+ *  https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Contributors:
+ *       Metaform Systems, Inc. - initial API and implementation
+ *
+ */
+
+plugins {
+    `java-library`
+}
+
+dependencies {
+    api(libs.edc.spi.core)
+    api(libs.edc.spi.transfer)
+    api(project(":spi:v-core-spi"))
+    api(project(":spi:v-task-spi"))
+    implementation(libs.nats.client)
+    implementation(project(":extensions:lib:nats-lib"))
+    testImplementation(libs.awaitility)
+    testImplementation(libs.edc.junit)
+    testImplementation(testFixtures(libs.edc.spi.contract))
+    testImplementation(libs.testcontainers.junit)
+    testImplementation(testFixtures(project(":extensions:lib:nats-lib")))
+    testImplementation(project(":core:v-task-core"))
+}
+

--- a/extensions/control-plane/tasks/subscriber/transfer-tasks-subscriber-nats/src/main/java/org/eclipse/edc/virtual/controlplane/transfer/subscriber/nats/NatsTransferProcessTaskSubscriber.java
+++ b/extensions/control-plane/tasks/subscriber/transfer-tasks-subscriber-nats/src/main/java/org/eclipse/edc/virtual/controlplane/transfer/subscriber/nats/NatsTransferProcessTaskSubscriber.java
@@ -1,0 +1,84 @@
+/*
+ *  Copyright (c) 2026 Metaform Systems, Inc.
+ *
+ *  This program and the accompanying materials are made available under the
+ *  terms of the Apache License, Version 2.0 which is available at
+ *  https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Contributors:
+ *       Metaform Systems, Inc. - initial API and implementation
+ *
+ */
+
+package org.eclipse.edc.virtual.controlplane.transfer.subscriber.nats;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import io.nats.client.Message;
+import org.eclipse.edc.spi.response.ResponseStatus;
+import org.eclipse.edc.spi.response.StatusResult;
+import org.eclipse.edc.virtual.controlplane.tasks.Task;
+import org.eclipse.edc.virtual.controlplane.transfer.spi.TransferProcessTaskExecutor;
+import org.eclipse.edc.virtual.controlplane.transfer.spi.tasks.TransferProcessTaskPayload;
+import org.eclipse.edc.virtual.nats.subscriber.NatsSubscriber;
+
+import java.util.Objects;
+import java.util.function.Supplier;
+
+public class NatsTransferProcessTaskSubscriber extends NatsSubscriber {
+
+    private Supplier<ObjectMapper> mapperSupplier;
+    private TransferProcessTaskExecutor taskExecutor;
+
+    private NatsTransferProcessTaskSubscriber() {
+    }
+
+    // TODO check if the task was actually stored
+
+    protected StatusResult<Void> handleMessage(Message message) {
+        try {
+            var task = mapperSupplier.get().readValue(message.getData(), Task.class);
+            if (task.getPayload() instanceof TransferProcessTaskPayload payload) {
+                return taskExecutor.handle(payload);
+            } else {
+                return StatusResult.failure(ResponseStatus.FATAL_ERROR, "Invalid task payload type");
+            }
+        } catch (Exception e) {
+            return StatusResult.failure(ResponseStatus.FATAL_ERROR, e.getMessage());
+        }
+    }
+
+    public static class Builder extends NatsSubscriber.Builder<NatsTransferProcessTaskSubscriber, Builder> {
+
+        protected Builder() {
+            super(new NatsTransferProcessTaskSubscriber());
+        }
+
+        public static Builder newInstance() {
+            return new Builder();
+        }
+
+        public Builder mapperSupplier(Supplier<ObjectMapper> mapperSupplier) {
+            subscriber.mapperSupplier = mapperSupplier;
+            return self();
+        }
+
+        public Builder taskExecutor(TransferProcessTaskExecutor taskManager) {
+            subscriber.taskExecutor = taskManager;
+            return self();
+        }
+
+        @Override
+        public Builder self() {
+            return this;
+        }
+
+        @Override
+        public NatsTransferProcessTaskSubscriber build() {
+            Objects.requireNonNull(subscriber.mapperSupplier, "mapperSupplier must be set");
+            Objects.requireNonNull(subscriber.taskExecutor, "stateMachineService must be set");
+            return super.build();
+        }
+    }
+}

--- a/extensions/control-plane/tasks/subscriber/transfer-tasks-subscriber-nats/src/main/java/org/eclipse/edc/virtual/controlplane/transfer/subscriber/nats/NatsTransferProcessTaskSubscriberExtension.java
+++ b/extensions/control-plane/tasks/subscriber/transfer-tasks-subscriber-nats/src/main/java/org/eclipse/edc/virtual/controlplane/transfer/subscriber/nats/NatsTransferProcessTaskSubscriberExtension.java
@@ -1,0 +1,105 @@
+/*
+ *  Copyright (c) 2026 Metaform Systems, Inc.
+ *
+ *  This program and the accompanying materials are made available under the
+ *  terms of the Apache License, Version 2.0 which is available at
+ *  https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Contributors:
+ *       Metaform Systems, Inc. - initial API and implementation
+ *
+ */
+
+package org.eclipse.edc.virtual.controlplane.transfer.subscriber.nats;
+
+import org.eclipse.edc.runtime.metamodel.annotation.Configuration;
+import org.eclipse.edc.runtime.metamodel.annotation.Inject;
+import org.eclipse.edc.runtime.metamodel.annotation.Setting;
+import org.eclipse.edc.runtime.metamodel.annotation.Settings;
+import org.eclipse.edc.spi.monitor.Monitor;
+import org.eclipse.edc.spi.system.ExecutorInstrumentation;
+import org.eclipse.edc.spi.system.ServiceExtension;
+import org.eclipse.edc.spi.system.ServiceExtensionContext;
+import org.eclipse.edc.spi.types.TypeManager;
+import org.eclipse.edc.virtual.controlplane.transfer.spi.TransferProcessTaskExecutor;
+
+public class NatsTransferProcessTaskSubscriberExtension implements ServiceExtension {
+
+    @Configuration
+    private NatsSubscriberConfig subscriberConfig;
+
+    @Inject
+    private TypeManager typeManager;
+
+    @Inject
+    private TransferProcessTaskExecutor taskExecutor;
+
+    @Inject
+    private ExecutorInstrumentation executorInstrumentation;
+
+    @Inject
+    private Monitor monitor;
+
+    private NatsTransferProcessTaskSubscriber subscriber;
+
+    @Override
+    public void initialize(ServiceExtensionContext context) {
+        subscriber = NatsTransferProcessTaskSubscriber.Builder.newInstance()
+                .url(subscriberConfig.url())
+                .name(subscriberConfig.name())
+                .stream(subscriberConfig.stream)
+                .subject(subscriberConfig.subject())
+                .monitor(monitor)
+                .mapperSupplier(() -> typeManager.getMapper())
+                .taskExecutor(taskExecutor)
+                .autoCreate(subscriberConfig.autoCreate)
+                .executorInstrumentation(executorInstrumentation)
+                .batchSize(subscriberConfig.batchSize)
+                .maxWait(subscriberConfig.maxWait)
+                .build();
+    }
+
+    @Override
+    public void prepare() {
+        if (subscriber != null) {
+            subscriber.prepare();
+        }
+    }
+
+    @Override
+    public void start() {
+        if (subscriber != null) {
+            subscriber.start();
+        }
+    }
+
+    @Override
+    public void shutdown() {
+        if (subscriber != null) {
+            subscriber.stop();
+        }
+    }
+
+    @Settings
+    public record NatsSubscriberConfig(
+
+            @Setting(key = "edc.nats.tp.subscriber.url", description = "The URL of the NATS server to connect to for transfer process events.", defaultValue = "nats://localhost:4222")
+            String url,
+            @Setting(key = "edc.nats.tp.subscriber.name", description = "The name of the consumer for transfer process events", defaultValue = "tp-subscriber")
+            String name,
+            @Setting(key = "edc.nats.tp.subscriber.autocreate", description = "When true, it will automatically create the stream and the consumer if not present", defaultValue = "false")
+            Boolean autoCreate,
+            @Setting(key = "edc.nats.tp.subscriber.stream", description = "The stream name where to attach the consumer", defaultValue = "tp-stream")
+            String stream,
+            @Setting(key = "edc.nats.tp.subscriber.subject", description = "The subject of the consumer for contract negotiation events", defaultValue = "transfers.>")
+            String subject,
+            @Setting(key = "edc.nats.tp.subscriber.batch-size", description = "The size of the batch when fetching messages", defaultValue = "100")
+            Integer batchSize,
+            @Setting(key = "edc.nats.tp.subscriber.max-wait", description = "The max waiting time for messages (ms)", defaultValue = "100")
+            Integer maxWait
+
+    ) {
+    }
+}

--- a/extensions/control-plane/tasks/subscriber/transfer-tasks-subscriber-nats/src/main/resources/META-INF/services/org.eclipse.edc.spi.system.ServiceExtension
+++ b/extensions/control-plane/tasks/subscriber/transfer-tasks-subscriber-nats/src/main/resources/META-INF/services/org.eclipse.edc.spi.system.ServiceExtension
@@ -1,0 +1,14 @@
+#
+#  Copyright (c) 2026 Metaform Systems, Inc.
+#
+#  This program and the accompanying materials are made available under the
+#  terms of the Apache License, Version 2.0 which is available at
+#  https://www.apache.org/licenses/LICENSE-2.0
+#
+#  SPDX-License-Identifier: Apache-2.0
+#
+#  Contributors:
+#       Metaform Systems, Inc. - initial API and implementation
+#
+#
+org.eclipse.edc.virtual.controlplane.transfer.subscriber.nats.NatsTransferProcessTaskSubscriberExtension

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -28,12 +28,16 @@ pluginManagement {
 // spi
 include(":spi:v-auth-spi")
 include(":spi:v-core-spi")
+include(":spi:v-task-spi")
 include(":spi:iam:decentralized-claims:dcp-scope-spi")
 
 // core
 include(":core:v-connector-core")
+include(":core:v-task-core")
 include(":core:negotiation-manager")
+include(":core:negotiation-task-executor")
 include(":core:transfer-process-manager")
+include(":core:transfer-process-task-executor")
 
 // data-protocols
 include(":data-protocols:dsp")
@@ -57,6 +61,13 @@ include(":extensions:cdc:publisher:negotiation-cdc-publisher-nats")
 include(":extensions:cdc:subscriber:negotiation-subscriber-nats")
 include(":extensions:cdc:publisher:transfer-process-cdc-publisher-nats")
 include(":extensions:cdc:subscriber:transfer-process-subscriber-nats")
+include(":extensions:control-plane:tasks:listener:tasks-store-listener")
+include(":extensions:control-plane:tasks:listener:tasks-store-poll-executor")
+include(":extensions:control-plane:tasks:publisher:tasks-publisher-nats")
+include(":extensions:control-plane:tasks:store:tasks-store-sql")
+include(":extensions:control-plane:tasks:subscriber:negotiation-tasks-subscriber-nats")
+include(":extensions:control-plane:tasks:subscriber:transfer-tasks-subscriber-nats")
+
 include(":extensions:lib:nats-lib")
 include(":extensions:common:api:api-authentication")
 include(":extensions:common:api:api-authorization")
@@ -89,8 +100,12 @@ include(":system-tests:dsp-tck-tests")
 include(":system-tests:extensions:v-tck-extension")
 include(":system-tests:runtimes:tck:tck-controlplane-memory")
 include(":system-tests:runtimes:tck:tck-controlplane-postgres")
+include(":system-tests:runtimes:tck:tck-controlplane-postgres-events")
 include(":system-tests:runtimes:e2e:e2e-controlplane-memory")
+include(":system-tests:runtimes:e2e:e2e-controlplane-memory-tasks")
 include(":system-tests:runtimes:e2e:e2e-controlplane-postgres")
+include(":system-tests:runtimes:e2e:e2e-controlplane-postgres-tasks")
+include(":system-tests:runtimes:e2e:e2e-controlplane-postgres-nats-tasks")
 include(":system-tests:runtimes:e2e:e2e-dcp-controlplane-postgres")
 
 // BOM modules ----------------------------------------------------------------

--- a/spi/v-task-spi/build.gradle.kts
+++ b/spi/v-task-spi/build.gradle.kts
@@ -1,0 +1,27 @@
+/*
+ *  Copyright (c) 2026 Metaform Systems, Inc.
+ *
+ *  This program and the accompanying materials are made available under the
+ *  terms of the Apache License, Version 2.0 which is available at
+ *  https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Contributors:
+ *       Metaform Systems, Inc. - initial API and implementation
+ *
+ */
+
+plugins {
+    `java-library`
+    `java-test-fixtures`
+}
+
+dependencies {
+    implementation(libs.edc.spi.core)
+    implementation(libs.edc.spi.protocol)
+    implementation(libs.edc.spi.contract)
+    implementation(libs.edc.spi.transfer)
+    testFixturesImplementation(libs.edc.junit)
+}
+

--- a/spi/v-task-spi/src/main/java/org/eclipse/edc/virtual/controlplane/contract/spi/negotiation/ContractNegotiationTaskExecutor.java
+++ b/spi/v-task-spi/src/main/java/org/eclipse/edc/virtual/controlplane/contract/spi/negotiation/ContractNegotiationTaskExecutor.java
@@ -1,0 +1,37 @@
+/*
+ *  Copyright (c) 2026 Metaform Systems, Inc.
+ *
+ *  This program and the accompanying materials are made available under the
+ *  terms of the Apache License, Version 2.0 which is available at
+ *  https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Contributors:
+ *       Metaform Systems, Inc. - initial API and implementation
+ *
+ */
+
+package org.eclipse.edc.virtual.controlplane.contract.spi.negotiation;
+
+import org.eclipse.edc.runtime.metamodel.annotation.ExtensionPoint;
+import org.eclipse.edc.spi.response.StatusResult;
+import org.eclipse.edc.virtual.controlplane.contract.spi.negotiation.tasks.ContractNegotiationTaskPayload;
+
+/**
+ * A service interface for handling contract negotiation tasks.
+ * Implementations can be registered to process various contract negotiation tasks.
+ */
+@ExtensionPoint
+public interface ContractNegotiationTaskExecutor {
+
+    /**
+     * Handles a contract negotiation task.
+     *
+     * @param task the contract negotiation task
+     * @return a StatusResult indicating success or failure
+     */
+    StatusResult<Void> handle(ContractNegotiationTaskPayload task);
+
+
+}

--- a/spi/v-task-spi/src/main/java/org/eclipse/edc/virtual/controlplane/contract/spi/negotiation/tasks/AgreeNegotiation.java
+++ b/spi/v-task-spi/src/main/java/org/eclipse/edc/virtual/controlplane/contract/spi/negotiation/tasks/AgreeNegotiation.java
@@ -1,0 +1,52 @@
+/*
+ *  Copyright (c) 2026 Metaform Systems, Inc.
+ *
+ *  This program and the accompanying materials are made available under the
+ *  terms of the Apache License, Version 2.0 which is available at
+ *  https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Contributors:
+ *       Metaform Systems, Inc. - initial API and implementation
+ *
+ */
+
+package org.eclipse.edc.virtual.controlplane.contract.spi.negotiation.tasks;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonTypeName;
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+import com.fasterxml.jackson.databind.annotation.JsonPOJOBuilder;
+import org.eclipse.edc.virtual.controlplane.tasks.ProcessTaskPayload;
+
+@JsonDeserialize(builder = AgreeNegotiation.Builder.class)
+@JsonTypeName("task:AgreeNegotiation")
+public class AgreeNegotiation extends ContractNegotiationTaskPayload {
+
+    private AgreeNegotiation() {
+    }
+
+    @Override
+    public String name() {
+        return "negotiation.agreement.agree";
+    }
+
+    @JsonPOJOBuilder(withPrefix = "")
+    public static class Builder extends ProcessTaskPayload.Builder<AgreeNegotiation, Builder> {
+
+        private Builder() {
+            super(new AgreeNegotiation());
+        }
+
+        @JsonCreator
+        public static AgreeNegotiation.Builder newInstance() {
+            return new AgreeNegotiation.Builder();
+        }
+
+        @Override
+        public AgreeNegotiation.Builder self() {
+            return this;
+        }
+    }
+}

--- a/spi/v-task-spi/src/main/java/org/eclipse/edc/virtual/controlplane/contract/spi/negotiation/tasks/ContractNegotiationTaskPayload.java
+++ b/spi/v-task-spi/src/main/java/org/eclipse/edc/virtual/controlplane/contract/spi/negotiation/tasks/ContractNegotiationTaskPayload.java
@@ -1,0 +1,21 @@
+/*
+ *  Copyright (c) 2026 Metaform Systems, Inc.
+ *
+ *  This program and the accompanying materials are made available under the
+ *  terms of the Apache License, Version 2.0 which is available at
+ *  https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Contributors:
+ *       Metaform Systems, Inc. - initial API and implementation
+ *
+ */
+
+package org.eclipse.edc.virtual.controlplane.contract.spi.negotiation.tasks;
+
+import org.eclipse.edc.virtual.controlplane.tasks.ProcessTaskPayload;
+
+public abstract class ContractNegotiationTaskPayload extends ProcessTaskPayload {
+
+}

--- a/spi/v-task-spi/src/main/java/org/eclipse/edc/virtual/controlplane/contract/spi/negotiation/tasks/FinalizeNegotiation.java
+++ b/spi/v-task-spi/src/main/java/org/eclipse/edc/virtual/controlplane/contract/spi/negotiation/tasks/FinalizeNegotiation.java
@@ -1,0 +1,52 @@
+/*
+ *  Copyright (c) 2026 Metaform Systems, Inc.
+ *
+ *  This program and the accompanying materials are made available under the
+ *  terms of the Apache License, Version 2.0 which is available at
+ *  https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Contributors:
+ *       Metaform Systems, Inc. - initial API and implementation
+ *
+ */
+
+package org.eclipse.edc.virtual.controlplane.contract.spi.negotiation.tasks;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonTypeName;
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+import com.fasterxml.jackson.databind.annotation.JsonPOJOBuilder;
+import org.eclipse.edc.virtual.controlplane.tasks.ProcessTaskPayload;
+
+@JsonDeserialize(builder = FinalizeNegotiation.Builder.class)
+@JsonTypeName("task:FinalizeNegotiation")
+public class FinalizeNegotiation extends ContractNegotiationTaskPayload {
+
+    private FinalizeNegotiation() {
+    }
+
+    @Override
+    public String name() {
+        return "negotiation.finalize.init";
+    }
+
+    @JsonPOJOBuilder(withPrefix = "")
+    public static class Builder extends ProcessTaskPayload.Builder<FinalizeNegotiation, Builder> {
+
+        private Builder() {
+            super(new FinalizeNegotiation());
+        }
+
+        @JsonCreator
+        public static FinalizeNegotiation.Builder newInstance() {
+            return new FinalizeNegotiation.Builder();
+        }
+
+        @Override
+        public FinalizeNegotiation.Builder self() {
+            return this;
+        }
+    }
+}

--- a/spi/v-task-spi/src/main/java/org/eclipse/edc/virtual/controlplane/contract/spi/negotiation/tasks/RequestNegotiation.java
+++ b/spi/v-task-spi/src/main/java/org/eclipse/edc/virtual/controlplane/contract/spi/negotiation/tasks/RequestNegotiation.java
@@ -1,0 +1,52 @@
+/*
+ *  Copyright (c) 2026 Metaform Systems, Inc.
+ *
+ *  This program and the accompanying materials are made available under the
+ *  terms of the Apache License, Version 2.0 which is available at
+ *  https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Contributors:
+ *       Metaform Systems, Inc. - initial API and implementation
+ *
+ */
+
+package org.eclipse.edc.virtual.controlplane.contract.spi.negotiation.tasks;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonTypeName;
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+import com.fasterxml.jackson.databind.annotation.JsonPOJOBuilder;
+import org.eclipse.edc.virtual.controlplane.tasks.ProcessTaskPayload;
+
+@JsonDeserialize(builder = RequestNegotiation.Builder.class)
+@JsonTypeName("task:RequestNegotiation")
+public class RequestNegotiation extends ContractNegotiationTaskPayload {
+
+    private RequestNegotiation() {
+    }
+
+    @Override
+    public String name() {
+        return "negotiation.request.prepare";
+    }
+
+    @JsonPOJOBuilder(withPrefix = "")
+    public static class Builder extends ProcessTaskPayload.Builder<RequestNegotiation, Builder> {
+
+        private Builder() {
+            super(new RequestNegotiation());
+        }
+
+        @JsonCreator
+        public static RequestNegotiation.Builder newInstance() {
+            return new RequestNegotiation.Builder();
+        }
+
+        @Override
+        public RequestNegotiation.Builder self() {
+            return this;
+        }
+    }
+}

--- a/spi/v-task-spi/src/main/java/org/eclipse/edc/virtual/controlplane/contract/spi/negotiation/tasks/SendAgreement.java
+++ b/spi/v-task-spi/src/main/java/org/eclipse/edc/virtual/controlplane/contract/spi/negotiation/tasks/SendAgreement.java
@@ -1,0 +1,52 @@
+/*
+ *  Copyright (c) 2026 Metaform Systems, Inc.
+ *
+ *  This program and the accompanying materials are made available under the
+ *  terms of the Apache License, Version 2.0 which is available at
+ *  https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Contributors:
+ *       Metaform Systems, Inc. - initial API and implementation
+ *
+ */
+
+package org.eclipse.edc.virtual.controlplane.contract.spi.negotiation.tasks;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonTypeName;
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+import com.fasterxml.jackson.databind.annotation.JsonPOJOBuilder;
+import org.eclipse.edc.virtual.controlplane.tasks.ProcessTaskPayload;
+
+@JsonDeserialize(builder = SendAgreement.Builder.class)
+@JsonTypeName("task:SendAgreement")
+public class SendAgreement extends ContractNegotiationTaskPayload {
+
+    private SendAgreement() {
+    }
+
+    @Override
+    public String name() {
+        return "negotiation.agreement.send";
+    }
+
+    @JsonPOJOBuilder(withPrefix = "")
+    public static class Builder extends ProcessTaskPayload.Builder<SendAgreement, Builder> {
+
+        private Builder() {
+            super(new SendAgreement());
+        }
+
+        @JsonCreator
+        public static SendAgreement.Builder newInstance() {
+            return new SendAgreement.Builder();
+        }
+
+        @Override
+        public SendAgreement.Builder self() {
+            return this;
+        }
+    }
+}

--- a/spi/v-task-spi/src/main/java/org/eclipse/edc/virtual/controlplane/contract/spi/negotiation/tasks/SendFinalizeNegotiation.java
+++ b/spi/v-task-spi/src/main/java/org/eclipse/edc/virtual/controlplane/contract/spi/negotiation/tasks/SendFinalizeNegotiation.java
@@ -1,0 +1,52 @@
+/*
+ *  Copyright (c) 2026 Metaform Systems, Inc.
+ *
+ *  This program and the accompanying materials are made available under the
+ *  terms of the Apache License, Version 2.0 which is available at
+ *  https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Contributors:
+ *       Metaform Systems, Inc. - initial API and implementation
+ *
+ */
+
+package org.eclipse.edc.virtual.controlplane.contract.spi.negotiation.tasks;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonTypeName;
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+import com.fasterxml.jackson.databind.annotation.JsonPOJOBuilder;
+import org.eclipse.edc.virtual.controlplane.tasks.ProcessTaskPayload;
+
+@JsonDeserialize(builder = SendFinalizeNegotiation.Builder.class)
+@JsonTypeName("task:SendFinalizeNegotiation")
+public class SendFinalizeNegotiation extends ContractNegotiationTaskPayload {
+
+    private SendFinalizeNegotiation() {
+    }
+
+    @Override
+    public String name() {
+        return "negotiation.finalize.send";
+    }
+
+    @JsonPOJOBuilder(withPrefix = "")
+    public static class Builder extends ProcessTaskPayload.Builder<SendFinalizeNegotiation, Builder> {
+
+        private Builder() {
+            super(new SendFinalizeNegotiation());
+        }
+
+        @JsonCreator
+        public static SendFinalizeNegotiation.Builder newInstance() {
+            return new SendFinalizeNegotiation.Builder();
+        }
+
+        @Override
+        public SendFinalizeNegotiation.Builder self() {
+            return this;
+        }
+    }
+}

--- a/spi/v-task-spi/src/main/java/org/eclipse/edc/virtual/controlplane/contract/spi/negotiation/tasks/SendRequestNegotiation.java
+++ b/spi/v-task-spi/src/main/java/org/eclipse/edc/virtual/controlplane/contract/spi/negotiation/tasks/SendRequestNegotiation.java
@@ -1,0 +1,52 @@
+/*
+ *  Copyright (c) 2026 Metaform Systems, Inc.
+ *
+ *  This program and the accompanying materials are made available under the
+ *  terms of the Apache License, Version 2.0 which is available at
+ *  https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Contributors:
+ *       Metaform Systems, Inc. - initial API and implementation
+ *
+ */
+
+package org.eclipse.edc.virtual.controlplane.contract.spi.negotiation.tasks;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonTypeName;
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+import com.fasterxml.jackson.databind.annotation.JsonPOJOBuilder;
+import org.eclipse.edc.virtual.controlplane.tasks.ProcessTaskPayload;
+
+@JsonDeserialize(builder = SendRequestNegotiation.Builder.class)
+@JsonTypeName("task:SendRequestNegotiation")
+public class SendRequestNegotiation extends ContractNegotiationTaskPayload {
+
+    private SendRequestNegotiation() {
+    }
+
+    @Override
+    public String name() {
+        return "negotiation.request.send";
+    }
+
+    @JsonPOJOBuilder(withPrefix = "")
+    public static class Builder extends ProcessTaskPayload.Builder<SendRequestNegotiation, Builder> {
+
+        private Builder() {
+            super(new SendRequestNegotiation());
+        }
+
+        @JsonCreator
+        public static SendRequestNegotiation.Builder newInstance() {
+            return new SendRequestNegotiation.Builder();
+        }
+
+        @Override
+        public SendRequestNegotiation.Builder self() {
+            return this;
+        }
+    }
+}

--- a/spi/v-task-spi/src/main/java/org/eclipse/edc/virtual/controlplane/contract/spi/negotiation/tasks/SendVerificationNegotiation.java
+++ b/spi/v-task-spi/src/main/java/org/eclipse/edc/virtual/controlplane/contract/spi/negotiation/tasks/SendVerificationNegotiation.java
@@ -1,0 +1,52 @@
+/*
+ *  Copyright (c) 2026 Metaform Systems, Inc.
+ *
+ *  This program and the accompanying materials are made available under the
+ *  terms of the Apache License, Version 2.0 which is available at
+ *  https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Contributors:
+ *       Metaform Systems, Inc. - initial API and implementation
+ *
+ */
+
+package org.eclipse.edc.virtual.controlplane.contract.spi.negotiation.tasks;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonTypeName;
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+import com.fasterxml.jackson.databind.annotation.JsonPOJOBuilder;
+import org.eclipse.edc.virtual.controlplane.tasks.ProcessTaskPayload;
+
+@JsonDeserialize(builder = SendVerificationNegotiation.Builder.class)
+@JsonTypeName("task:SendVerificationNegotiation")
+public class SendVerificationNegotiation extends ContractNegotiationTaskPayload {
+
+    private SendVerificationNegotiation() {
+    }
+
+    @Override
+    public String name() {
+        return "negotiation.verification.send";
+    }
+
+    @JsonPOJOBuilder(withPrefix = "")
+    public static class Builder extends ProcessTaskPayload.Builder<SendVerificationNegotiation, Builder> {
+
+        private Builder() {
+            super(new SendVerificationNegotiation());
+        }
+
+        @JsonCreator
+        public static SendVerificationNegotiation.Builder newInstance() {
+            return new SendVerificationNegotiation.Builder();
+        }
+
+        @Override
+        public SendVerificationNegotiation.Builder self() {
+            return this;
+        }
+    }
+}

--- a/spi/v-task-spi/src/main/java/org/eclipse/edc/virtual/controlplane/contract/spi/negotiation/tasks/VerifyNegotiation.java
+++ b/spi/v-task-spi/src/main/java/org/eclipse/edc/virtual/controlplane/contract/spi/negotiation/tasks/VerifyNegotiation.java
@@ -1,0 +1,52 @@
+/*
+ *  Copyright (c) 2026 Metaform Systems, Inc.
+ *
+ *  This program and the accompanying materials are made available under the
+ *  terms of the Apache License, Version 2.0 which is available at
+ *  https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Contributors:
+ *       Metaform Systems, Inc. - initial API and implementation
+ *
+ */
+
+package org.eclipse.edc.virtual.controlplane.contract.spi.negotiation.tasks;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonTypeName;
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+import com.fasterxml.jackson.databind.annotation.JsonPOJOBuilder;
+import org.eclipse.edc.virtual.controlplane.tasks.ProcessTaskPayload;
+
+@JsonDeserialize(builder = VerifyNegotiation.Builder.class)
+@JsonTypeName("task:VerifyNegotiation")
+public class VerifyNegotiation extends ContractNegotiationTaskPayload {
+
+    private VerifyNegotiation() {
+    }
+
+    @Override
+    public String name() {
+        return "negotiation.verification.verify";
+    }
+
+    @JsonPOJOBuilder(withPrefix = "")
+    public static class Builder extends ProcessTaskPayload.Builder<VerifyNegotiation, Builder> {
+
+        private Builder() {
+            super(new VerifyNegotiation());
+        }
+
+        @JsonCreator
+        public static VerifyNegotiation.Builder newInstance() {
+            return new VerifyNegotiation.Builder();
+        }
+
+        @Override
+        public VerifyNegotiation.Builder self() {
+            return this;
+        }
+    }
+}

--- a/spi/v-task-spi/src/main/java/org/eclipse/edc/virtual/controlplane/tasks/ProcessTaskPayload.java
+++ b/spi/v-task-spi/src/main/java/org/eclipse/edc/virtual/controlplane/tasks/ProcessTaskPayload.java
@@ -1,0 +1,72 @@
+/*
+ *  Copyright (c) 2026 Metaform Systems, Inc.
+ *
+ *  This program and the accompanying materials are made available under the
+ *  terms of the Apache License, Version 2.0 which is available at
+ *  https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Contributors:
+ *       Metaform Systems, Inc. - initial API and implementation
+ *
+ */
+
+package org.eclipse.edc.virtual.controlplane.tasks;
+
+import java.util.Objects;
+
+public abstract class ProcessTaskPayload implements TaskPayload {
+
+    protected String processType;
+    protected String processId;
+    protected String processState;
+
+
+    public String getProcessId() {
+        return processId;
+    }
+
+    public String getProcessState() {
+        return processState;
+    }
+
+    public String getProcessType() {
+        return processType;
+    }
+
+    public abstract static class Builder<T extends ProcessTaskPayload, B extends ProcessTaskPayload.Builder<T, B>> {
+
+        protected final T task;
+
+        protected Builder(T task) {
+            this.task = task;
+        }
+
+        public abstract B self();
+
+
+        public B processId(String processId) {
+            task.processId = processId;
+            return self();
+        }
+
+        public B processType(String processType) {
+            task.processType = processType;
+            return self();
+        }
+
+        public B processState(String processState) {
+            task.processState = processState;
+            return self();
+        }
+
+
+        public T build() {
+            Objects.requireNonNull(task.processId);
+            Objects.requireNonNull(task.processState);
+            Objects.requireNonNull(task.processType);
+            return task;
+        }
+    }
+}

--- a/spi/v-task-spi/src/main/java/org/eclipse/edc/virtual/controlplane/tasks/Task.java
+++ b/spi/v-task-spi/src/main/java/org/eclipse/edc/virtual/controlplane/tasks/Task.java
@@ -1,0 +1,90 @@
+/*
+ *  Copyright (c) 2026 Metaform Systems, Inc.
+ *
+ *  This program and the accompanying materials are made available under the
+ *  terms of the Apache License, Version 2.0 which is available at
+ *  https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Contributors:
+ *       Metaform Systems, Inc. - initial API and implementation
+ *
+ */
+
+package org.eclipse.edc.virtual.controlplane.tasks;
+
+
+import com.fasterxml.jackson.annotation.JsonTypeInfo;
+
+import java.util.Objects;
+import java.util.UUID;
+
+public class Task {
+    protected String id;
+
+    protected long at;
+
+    protected TaskPayload payload;
+
+    public long getAt() {
+        return at;
+    }
+
+    public String getId() {
+        return id;
+    }
+
+    @JsonTypeInfo(use = JsonTypeInfo.Id.NAME, property = "type", include = JsonTypeInfo.As.EXTERNAL_PROPERTY)
+    public TaskPayload getPayload() {
+        return payload;
+    }
+
+
+    public Task.Builder toBuilder() {
+        return Builder.newInstance()
+                .id(id)
+                .at(at)
+                .payload(payload);
+    }
+
+    public static class Builder {
+
+        protected final Task task;
+
+        protected Builder() {
+            task = new Task();
+        }
+
+        public static  Task.Builder newInstance() {
+            return new Task.Builder();
+        }
+
+        public Task.Builder id(String id) {
+            task.id = id;
+            return this;
+        }
+
+        public Task.Builder at(long at) {
+            task.at = at;
+            return this;
+        }
+
+        public Task.Builder payload(TaskPayload payload) {
+            task.payload = payload;
+            return this;
+        }
+
+        public Task build() {
+            if (task.id == null) {
+                task.id = UUID.randomUUID().toString();
+            }
+            if (task.at == 0) {
+                throw new IllegalStateException("Event 'at' field must be set");
+            }
+            Objects.requireNonNull(task.payload, "Task payload must be set");
+            return task;
+        }
+
+    }
+}

--- a/spi/v-task-spi/src/main/java/org/eclipse/edc/virtual/controlplane/tasks/TaskListener.java
+++ b/spi/v-task-spi/src/main/java/org/eclipse/edc/virtual/controlplane/tasks/TaskListener.java
@@ -1,0 +1,20 @@
+/*
+ *  Copyright (c) 2026 Metaform Systems, Inc.
+ *
+ *  This program and the accompanying materials are made available under the
+ *  terms of the Apache License, Version 2.0 which is available at
+ *  https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Contributors:
+ *       Metaform Systems, Inc. - initial API and implementation
+ *
+ */
+
+package org.eclipse.edc.virtual.controlplane.tasks;
+
+public interface TaskListener {
+    
+    void created(Task task);
+}

--- a/spi/v-task-spi/src/main/java/org/eclipse/edc/virtual/controlplane/tasks/TaskObservable.java
+++ b/spi/v-task-spi/src/main/java/org/eclipse/edc/virtual/controlplane/tasks/TaskObservable.java
@@ -1,0 +1,25 @@
+/*
+ *  Copyright (c) 2026 Metaform Systems, Inc.
+ *
+ *  This program and the accompanying materials are made available under the
+ *  terms of the Apache License, Version 2.0 which is available at
+ *  https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Contributors:
+ *       Metaform Systems, Inc. - initial API and implementation
+ *
+ */
+
+package org.eclipse.edc.virtual.controlplane.tasks;
+
+import org.eclipse.edc.runtime.metamodel.annotation.ExtensionPoint;
+import org.eclipse.edc.spi.observe.Observable;
+
+/**
+ * Manages and invokes {@link TaskListener}s when an event related to a task is emitted.
+ */
+@ExtensionPoint
+public interface TaskObservable extends Observable<TaskListener> {
+}

--- a/spi/v-task-spi/src/main/java/org/eclipse/edc/virtual/controlplane/tasks/TaskPayload.java
+++ b/spi/v-task-spi/src/main/java/org/eclipse/edc/virtual/controlplane/tasks/TaskPayload.java
@@ -1,0 +1,23 @@
+/*
+ *  Copyright (c) 2026 Metaform Systems, Inc.
+ *
+ *  This program and the accompanying materials are made available under the
+ *  terms of the Apache License, Version 2.0 which is available at
+ *  https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Contributors:
+ *       Metaform Systems, Inc. - initial API and implementation
+ *
+ */
+
+package org.eclipse.edc.virtual.controlplane.tasks;
+
+
+import com.fasterxml.jackson.annotation.JsonTypeInfo;
+
+@JsonTypeInfo(use = JsonTypeInfo.Id.NAME, property = "@type")
+public interface TaskPayload {
+    String name();
+}

--- a/spi/v-task-spi/src/main/java/org/eclipse/edc/virtual/controlplane/tasks/TaskService.java
+++ b/spi/v-task-spi/src/main/java/org/eclipse/edc/virtual/controlplane/tasks/TaskService.java
@@ -1,0 +1,30 @@
+/*
+ *  Copyright (c) 2026 Metaform Systems, Inc.
+ *
+ *  This program and the accompanying materials are made available under the
+ *  terms of the Apache License, Version 2.0 which is available at
+ *  https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Contributors:
+ *       Metaform Systems, Inc. - initial API and implementation
+ *
+ */
+
+package org.eclipse.edc.virtual.controlplane.tasks;
+
+import org.eclipse.edc.spi.query.QuerySpec;
+
+import java.util.List;
+
+public interface TaskService {
+
+    void create(Task task);
+
+    List<Task> fetchLatestTask(QuerySpec querySpec);
+
+    void delete(String id);
+
+    Task findById(String id);
+}

--- a/spi/v-task-spi/src/main/java/org/eclipse/edc/virtual/controlplane/tasks/store/TaskStore.java
+++ b/spi/v-task-spi/src/main/java/org/eclipse/edc/virtual/controlplane/tasks/store/TaskStore.java
@@ -1,0 +1,33 @@
+/*
+ *  Copyright (c) 2026 Metaform Systems, Inc.
+ *
+ *  This program and the accompanying materials are made available under the
+ *  terms of the Apache License, Version 2.0 which is available at
+ *  https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Contributors:
+ *       Metaform Systems, Inc. - initial API and implementation
+ *
+ */
+
+package org.eclipse.edc.virtual.controlplane.tasks.store;
+
+import org.eclipse.edc.spi.query.QuerySpec;
+import org.eclipse.edc.virtual.controlplane.tasks.Task;
+
+import java.util.List;
+
+public interface TaskStore {
+
+    void create(Task task);
+
+    List<Task> fetchForUpdate(QuerySpec querySpec);
+
+    void delete(String id);
+
+    void update(Task task);
+
+    Task findById(String id);
+}

--- a/spi/v-task-spi/src/main/java/org/eclipse/edc/virtual/controlplane/transfer/spi/TransferProcessTaskExecutor.java
+++ b/spi/v-task-spi/src/main/java/org/eclipse/edc/virtual/controlplane/transfer/spi/TransferProcessTaskExecutor.java
@@ -1,0 +1,36 @@
+/*
+ *  Copyright (c) 2026 Metaform Systems, Inc.
+ *
+ *  This program and the accompanying materials are made available under the
+ *  terms of the Apache License, Version 2.0 which is available at
+ *  https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Contributors:
+ *       Metaform Systems, Inc. - initial API and implementation
+ *
+ */
+
+package org.eclipse.edc.virtual.controlplane.transfer.spi;
+
+import org.eclipse.edc.runtime.metamodel.annotation.ExtensionPoint;
+import org.eclipse.edc.spi.response.StatusResult;
+import org.eclipse.edc.virtual.controlplane.transfer.spi.tasks.TransferProcessTaskPayload;
+
+/**
+ * A service interface for handling transfer process tasks.
+ * Implementations can be registered to process various transfer process tasks.
+ */
+@ExtensionPoint
+public interface TransferProcessTaskExecutor {
+
+    /**
+     * Handles a transfer process task.
+     *
+     * @param task the transfer process task
+     * @return a StatusResult indicating success or failure
+     */
+    StatusResult<Void> handle(TransferProcessTaskPayload task);
+
+}

--- a/spi/v-task-spi/src/main/java/org/eclipse/edc/virtual/controlplane/transfer/spi/tasks/CompleteDataFlow.java
+++ b/spi/v-task-spi/src/main/java/org/eclipse/edc/virtual/controlplane/transfer/spi/tasks/CompleteDataFlow.java
@@ -1,0 +1,52 @@
+/*
+ *  Copyright (c) 2026 Metaform Systems, Inc.
+ *
+ *  This program and the accompanying materials are made available under the
+ *  terms of the Apache License, Version 2.0 which is available at
+ *  https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Contributors:
+ *       Metaform Systems, Inc. - initial API and implementation
+ *
+ */
+
+package org.eclipse.edc.virtual.controlplane.transfer.spi.tasks;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonTypeName;
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+import com.fasterxml.jackson.databind.annotation.JsonPOJOBuilder;
+import org.eclipse.edc.virtual.controlplane.tasks.ProcessTaskPayload;
+
+@JsonDeserialize(builder = CompleteDataFlow.Builder.class)
+@JsonTypeName("task:CompleteDataFlow")
+public class CompleteDataFlow extends TransferProcessTaskPayload {
+
+    private CompleteDataFlow() {
+    }
+
+    @Override
+    public String name() {
+        return "transfer.complete";
+    }
+
+    @JsonPOJOBuilder(withPrefix = "")
+    public static class Builder extends ProcessTaskPayload.Builder<CompleteDataFlow, Builder> {
+
+        private Builder() {
+            super(new CompleteDataFlow());
+        }
+
+        @JsonCreator
+        public static CompleteDataFlow.Builder newInstance() {
+            return new CompleteDataFlow.Builder();
+        }
+
+        @Override
+        public CompleteDataFlow.Builder self() {
+            return this;
+        }
+    }
+}

--- a/spi/v-task-spi/src/main/java/org/eclipse/edc/virtual/controlplane/transfer/spi/tasks/PrepareTransfer.java
+++ b/spi/v-task-spi/src/main/java/org/eclipse/edc/virtual/controlplane/transfer/spi/tasks/PrepareTransfer.java
@@ -1,0 +1,52 @@
+/*
+ *  Copyright (c) 2026 Metaform Systems, Inc.
+ *
+ *  This program and the accompanying materials are made available under the
+ *  terms of the Apache License, Version 2.0 which is available at
+ *  https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Contributors:
+ *       Metaform Systems, Inc. - initial API and implementation
+ *
+ */
+
+package org.eclipse.edc.virtual.controlplane.transfer.spi.tasks;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonTypeName;
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+import com.fasterxml.jackson.databind.annotation.JsonPOJOBuilder;
+import org.eclipse.edc.virtual.controlplane.tasks.ProcessTaskPayload;
+
+@JsonDeserialize(builder = PrepareTransfer.Builder.class)
+@JsonTypeName("task:PrepareTransfer")
+public class PrepareTransfer extends TransferProcessTaskPayload {
+
+    private PrepareTransfer() {
+    }
+
+    @Override
+    public String name() {
+        return "transfer.prepare";
+    }
+
+    @JsonPOJOBuilder(withPrefix = "")
+    public static class Builder extends ProcessTaskPayload.Builder<PrepareTransfer, Builder> {
+
+        private Builder() {
+            super(new PrepareTransfer());
+        }
+
+        @JsonCreator
+        public static PrepareTransfer.Builder newInstance() {
+            return new PrepareTransfer.Builder();
+        }
+
+        @Override
+        public PrepareTransfer.Builder self() {
+            return this;
+        }
+    }
+}

--- a/spi/v-task-spi/src/main/java/org/eclipse/edc/virtual/controlplane/transfer/spi/tasks/ResumeDataFlow.java
+++ b/spi/v-task-spi/src/main/java/org/eclipse/edc/virtual/controlplane/transfer/spi/tasks/ResumeDataFlow.java
@@ -1,0 +1,52 @@
+/*
+ *  Copyright (c) 2026 Metaform Systems, Inc.
+ *
+ *  This program and the accompanying materials are made available under the
+ *  terms of the Apache License, Version 2.0 which is available at
+ *  https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Contributors:
+ *       Metaform Systems, Inc. - initial API and implementation
+ *
+ */
+
+package org.eclipse.edc.virtual.controlplane.transfer.spi.tasks;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonTypeName;
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+import com.fasterxml.jackson.databind.annotation.JsonPOJOBuilder;
+import org.eclipse.edc.virtual.controlplane.tasks.ProcessTaskPayload;
+
+@JsonDeserialize(builder = ResumeDataFlow.Builder.class)
+@JsonTypeName("task:ResumeDataFlow")
+public class ResumeDataFlow extends TransferProcessTaskPayload {
+
+    private ResumeDataFlow() {
+    }
+
+    @Override
+    public String name() {
+        return "transfer.resume";
+    }
+
+    @JsonPOJOBuilder(withPrefix = "")
+    public static class Builder extends ProcessTaskPayload.Builder<ResumeDataFlow, Builder> {
+
+        private Builder() {
+            super(new ResumeDataFlow());
+        }
+
+        @JsonCreator
+        public static ResumeDataFlow.Builder newInstance() {
+            return new ResumeDataFlow.Builder();
+        }
+
+        @Override
+        public ResumeDataFlow.Builder self() {
+            return this;
+        }
+    }
+}

--- a/spi/v-task-spi/src/main/java/org/eclipse/edc/virtual/controlplane/transfer/spi/tasks/SendTransferRequest.java
+++ b/spi/v-task-spi/src/main/java/org/eclipse/edc/virtual/controlplane/transfer/spi/tasks/SendTransferRequest.java
@@ -1,0 +1,52 @@
+/*
+ *  Copyright (c) 2026 Metaform Systems, Inc.
+ *
+ *  This program and the accompanying materials are made available under the
+ *  terms of the Apache License, Version 2.0 which is available at
+ *  https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Contributors:
+ *       Metaform Systems, Inc. - initial API and implementation
+ *
+ */
+
+package org.eclipse.edc.virtual.controlplane.transfer.spi.tasks;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonTypeName;
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+import com.fasterxml.jackson.databind.annotation.JsonPOJOBuilder;
+import org.eclipse.edc.virtual.controlplane.tasks.ProcessTaskPayload;
+
+@JsonDeserialize(builder = SendTransferRequest.Builder.class)
+@JsonTypeName("task:SendTransferRequest")
+public class SendTransferRequest extends TransferProcessTaskPayload {
+
+    private SendTransferRequest() {
+    }
+
+    @Override
+    public String name() {
+        return "transfer.request.send";
+    }
+
+    @JsonPOJOBuilder(withPrefix = "")
+    public static class Builder extends ProcessTaskPayload.Builder<SendTransferRequest, Builder> {
+
+        private Builder() {
+            super(new SendTransferRequest());
+        }
+
+        @JsonCreator
+        public static SendTransferRequest.Builder newInstance() {
+            return new SendTransferRequest.Builder();
+        }
+
+        @Override
+        public SendTransferRequest.Builder self() {
+            return this;
+        }
+    }
+}

--- a/spi/v-task-spi/src/main/java/org/eclipse/edc/virtual/controlplane/transfer/spi/tasks/SignalDataflowStarted.java
+++ b/spi/v-task-spi/src/main/java/org/eclipse/edc/virtual/controlplane/transfer/spi/tasks/SignalDataflowStarted.java
@@ -1,0 +1,52 @@
+/*
+ *  Copyright (c) 2026 Metaform Systems, Inc.
+ *
+ *  This program and the accompanying materials are made available under the
+ *  terms of the Apache License, Version 2.0 which is available at
+ *  https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Contributors:
+ *       Metaform Systems, Inc. - initial API and implementation
+ *
+ */
+
+package org.eclipse.edc.virtual.controlplane.transfer.spi.tasks;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonTypeName;
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+import com.fasterxml.jackson.databind.annotation.JsonPOJOBuilder;
+import org.eclipse.edc.virtual.controlplane.tasks.ProcessTaskPayload;
+
+@JsonDeserialize(builder = SignalDataflowStarted.Builder.class)
+@JsonTypeName("task:SignalDataflowStarted")
+public class SignalDataflowStarted extends TransferProcessTaskPayload {
+
+    private SignalDataflowStarted() {
+    }
+
+    @Override
+    public String name() {
+        return "transfer.dataplane.started";
+    }
+
+    @JsonPOJOBuilder(withPrefix = "")
+    public static class Builder extends ProcessTaskPayload.Builder<SignalDataflowStarted, Builder> {
+
+        private Builder() {
+            super(new SignalDataflowStarted());
+        }
+
+        @JsonCreator
+        public static SignalDataflowStarted.Builder newInstance() {
+            return new SignalDataflowStarted.Builder();
+        }
+
+        @Override
+        public SignalDataflowStarted.Builder self() {
+            return this;
+        }
+    }
+}

--- a/spi/v-task-spi/src/main/java/org/eclipse/edc/virtual/controlplane/transfer/spi/tasks/StartDataflow.java
+++ b/spi/v-task-spi/src/main/java/org/eclipse/edc/virtual/controlplane/transfer/spi/tasks/StartDataflow.java
@@ -1,0 +1,52 @@
+/*
+ *  Copyright (c) 2026 Metaform Systems, Inc.
+ *
+ *  This program and the accompanying materials are made available under the
+ *  terms of the Apache License, Version 2.0 which is available at
+ *  https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Contributors:
+ *       Metaform Systems, Inc. - initial API and implementation
+ *
+ */
+
+package org.eclipse.edc.virtual.controlplane.transfer.spi.tasks;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonTypeName;
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+import com.fasterxml.jackson.databind.annotation.JsonPOJOBuilder;
+import org.eclipse.edc.virtual.controlplane.tasks.ProcessTaskPayload;
+
+@JsonDeserialize(builder = StartDataflow.Builder.class)
+@JsonTypeName("task:StartDataflow")
+public class StartDataflow extends TransferProcessTaskPayload {
+
+    private StartDataflow() {
+    }
+
+    @Override
+    public String name() {
+        return "transfer.start.send";
+    }
+
+    @JsonPOJOBuilder(withPrefix = "")
+    public static class Builder extends ProcessTaskPayload.Builder<StartDataflow, Builder> {
+
+        private Builder() {
+            super(new StartDataflow());
+        }
+
+        @JsonCreator
+        public static StartDataflow.Builder newInstance() {
+            return new StartDataflow.Builder();
+        }
+
+        @Override
+        public StartDataflow.Builder self() {
+            return this;
+        }
+    }
+}

--- a/spi/v-task-spi/src/main/java/org/eclipse/edc/virtual/controlplane/transfer/spi/tasks/SuspendDataFlow.java
+++ b/spi/v-task-spi/src/main/java/org/eclipse/edc/virtual/controlplane/transfer/spi/tasks/SuspendDataFlow.java
@@ -1,0 +1,52 @@
+/*
+ *  Copyright (c) 2026 Metaform Systems, Inc.
+ *
+ *  This program and the accompanying materials are made available under the
+ *  terms of the Apache License, Version 2.0 which is available at
+ *  https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Contributors:
+ *       Metaform Systems, Inc. - initial API and implementation
+ *
+ */
+
+package org.eclipse.edc.virtual.controlplane.transfer.spi.tasks;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonTypeName;
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+import com.fasterxml.jackson.databind.annotation.JsonPOJOBuilder;
+import org.eclipse.edc.virtual.controlplane.tasks.ProcessTaskPayload;
+
+@JsonDeserialize(builder = SuspendDataFlow.Builder.class)
+@JsonTypeName("task:SuspendDataFlow")
+public class SuspendDataFlow extends TransferProcessTaskPayload {
+
+    private SuspendDataFlow() {
+    }
+
+    @Override
+    public String name() {
+        return "transfer.suspend";
+    }
+
+    @JsonPOJOBuilder(withPrefix = "")
+    public static class Builder extends ProcessTaskPayload.Builder<SuspendDataFlow, Builder> {
+
+        private Builder() {
+            super(new SuspendDataFlow());
+        }
+
+        @JsonCreator
+        public static SuspendDataFlow.Builder newInstance() {
+            return new SuspendDataFlow.Builder();
+        }
+
+        @Override
+        public SuspendDataFlow.Builder self() {
+            return this;
+        }
+    }
+}

--- a/spi/v-task-spi/src/main/java/org/eclipse/edc/virtual/controlplane/transfer/spi/tasks/TerminateDataFlow.java
+++ b/spi/v-task-spi/src/main/java/org/eclipse/edc/virtual/controlplane/transfer/spi/tasks/TerminateDataFlow.java
@@ -1,0 +1,52 @@
+/*
+ *  Copyright (c) 2026 Metaform Systems, Inc.
+ *
+ *  This program and the accompanying materials are made available under the
+ *  terms of the Apache License, Version 2.0 which is available at
+ *  https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Contributors:
+ *       Metaform Systems, Inc. - initial API and implementation
+ *
+ */
+
+package org.eclipse.edc.virtual.controlplane.transfer.spi.tasks;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonTypeName;
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+import com.fasterxml.jackson.databind.annotation.JsonPOJOBuilder;
+import org.eclipse.edc.virtual.controlplane.tasks.ProcessTaskPayload;
+
+@JsonDeserialize(builder = TerminateDataFlow.Builder.class)
+@JsonTypeName("task:TerminateDataFlow")
+public class TerminateDataFlow extends TransferProcessTaskPayload {
+
+    private TerminateDataFlow() {
+    }
+
+    @Override
+    public String name() {
+        return "transfer.terminate";
+    }
+
+    @JsonPOJOBuilder(withPrefix = "")
+    public static class Builder extends ProcessTaskPayload.Builder<TerminateDataFlow, Builder> {
+
+        private Builder() {
+            super(new TerminateDataFlow());
+        }
+
+        @JsonCreator
+        public static TerminateDataFlow.Builder newInstance() {
+            return new TerminateDataFlow.Builder();
+        }
+
+        @Override
+        public TerminateDataFlow.Builder self() {
+            return this;
+        }
+    }
+}

--- a/spi/v-task-spi/src/main/java/org/eclipse/edc/virtual/controlplane/transfer/spi/tasks/TransferProcessTaskPayload.java
+++ b/spi/v-task-spi/src/main/java/org/eclipse/edc/virtual/controlplane/transfer/spi/tasks/TransferProcessTaskPayload.java
@@ -1,0 +1,21 @@
+/*
+ *  Copyright (c) 2026 Metaform Systems, Inc.
+ *
+ *  This program and the accompanying materials are made available under the
+ *  terms of the Apache License, Version 2.0 which is available at
+ *  https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Contributors:
+ *       Metaform Systems, Inc. - initial API and implementation
+ *
+ */
+
+package org.eclipse.edc.virtual.controlplane.transfer.spi.tasks;
+
+import org.eclipse.edc.virtual.controlplane.tasks.ProcessTaskPayload;
+
+public abstract class TransferProcessTaskPayload extends ProcessTaskPayload {
+
+}

--- a/spi/v-task-spi/src/testFixtures/java/org/eclipse/edc/virtual/controlplane/tasks/store/TaskStoreTestBase.java
+++ b/spi/v-task-spi/src/testFixtures/java/org/eclipse/edc/virtual/controlplane/tasks/store/TaskStoreTestBase.java
@@ -1,0 +1,238 @@
+/*
+ *  Copyright (c) 2026 Metaform Systems, Inc.
+ *
+ *  This program and the accompanying materials are made available under the
+ *  terms of the Apache License, Version 2.0 which is available at
+ *  https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Contributors:
+ *       Metaform Systems, Inc. - initial API and implementation
+ *
+ */
+
+package org.eclipse.edc.virtual.controlplane.tasks.store;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.databind.annotation.JsonPOJOBuilder;
+import org.eclipse.edc.spi.query.QuerySpec;
+import org.eclipse.edc.virtual.controlplane.tasks.ProcessTaskPayload;
+import org.eclipse.edc.virtual.controlplane.tasks.Task;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public abstract class TaskStoreTestBase {
+
+    protected abstract TaskStore getStore();
+
+    @Test
+    void create_shouldStoreTask() {
+        var payload = createTestPayload("process-1");
+        var task = Task.Builder.newInstance()
+                .at(System.currentTimeMillis())
+                .payload(payload).build();
+
+        getStore().create(task);
+
+        var retrieved = getStore().findById(task.getId());
+        assertThat(retrieved).usingRecursiveComparison().isEqualTo(task);
+    }
+
+    @Test
+    void create_shouldGenerateUniqueIds() {
+        var payload1 = createTestPayload("process-1");
+        var task1 = Task.Builder.newInstance()
+                .at(System.currentTimeMillis())
+                .payload(payload1).build();
+
+        var payload2 = createTestPayload("process-2");
+        var task2 = Task.Builder.newInstance()
+                .at(System.currentTimeMillis())
+                .payload(payload2).build();
+
+        getStore().create(task1);
+        getStore().create(task2);
+
+        assertThat(task1.getId()).isNotEqualTo(task2.getId());
+        assertThat(getStore().findById(task1.getId())).usingRecursiveComparison().isEqualTo(task1);
+        assertThat(getStore().findById(task2.getId())).usingRecursiveComparison().isEqualTo(task2);
+    }
+
+    @Test
+    void findById_shouldReturnTaskWhenPresent() {
+        var payload = createTestPayload("process-1");
+        var task = Task.Builder.newInstance()
+                .at(System.currentTimeMillis())
+                .payload(payload).build();
+        getStore().create(task);
+
+        var retrieved = getStore().findById(task.getId());
+
+        assertThat(retrieved).usingRecursiveComparison().isEqualTo(task);
+    }
+
+    @Test
+    void findById_shouldReturnNullWhenNotFound() {
+        var retrieved = getStore().findById("nonexistent-id");
+
+        assertThat(retrieved).isNull();
+    }
+
+    @Test
+    void delete_shouldRemoveTask() {
+        var payload = createTestPayload("process-1");
+        var task = Task.Builder.newInstance()
+                .at(System.currentTimeMillis())
+                .payload(payload).build();
+        getStore().create(task);
+
+        getStore().delete(task.getId());
+
+        assertThat(getStore().findById(task.getId())).isNull();
+    }
+
+    @Test
+    void delete_shouldNotThrowWhenTaskNotFound() {
+        getStore().delete("nonexistent-id");
+        // Should not throw
+    }
+
+    @Test
+    void update_shouldModifyExistingTask() {
+        var payload = createTestPayload("process-1");
+        var task = Task.Builder.newInstance()
+                .at(System.currentTimeMillis())
+                .payload(payload).build();
+        getStore().create(task);
+
+        var updatedPayload = TestPayload.Builder.newInstance()
+                .processId("process-2")
+                .processState("UPDATED")
+                .processType("PROVIDER")
+                .build();
+
+        var updatedTask = Task.Builder.newInstance()
+                .at(System.currentTimeMillis())
+                .id(task.getId())
+                .payload(updatedPayload)
+                .build();
+        getStore().update(updatedTask);
+
+        var retrieved = getStore().findById(task.getId());
+        assertThat(retrieved.getId()).isEqualTo(task.getId());
+        assertThat(retrieved.getPayload()).usingRecursiveComparison().isEqualTo(updatedPayload);
+    }
+
+    @Test
+    void fetchForUpdate() {
+        var payload1 = createTestPayload("process-1");
+        var task1 = Task.Builder.newInstance()
+                .at(System.currentTimeMillis())
+                .payload(payload1).build();
+
+        var payload2 = createTestPayload("process-2");
+        var task2 = Task.Builder.newInstance()
+                .at(System.currentTimeMillis())
+                .payload(payload2).build();
+
+        getStore().create(task1);
+        getStore().create(task2);
+
+        var results = getStore().fetchForUpdate(QuerySpec.none());
+
+        assertThat(results).hasSize(2)
+                .usingRecursiveFieldByFieldElementComparator()
+                .containsExactlyInAnyOrder(task1, task2);
+    }
+
+    @Test
+    void fetchForUpdate_with_OrderBy() {
+        var payload1 = createTestPayload("process-1");
+        var task1 = Task.Builder.newInstance()
+                .at(2000L)
+                .payload(payload1).build();
+
+        var payload2 = createTestPayload("process-2");
+        var task2 = Task.Builder.newInstance()
+                .at(1000L)
+                .payload(payload2).build();
+
+        getStore().create(task1);
+        getStore().create(task2);
+
+        var query = QuerySpec.Builder.newInstance().sortField("at")
+                .build();
+
+        var results = getStore().fetchForUpdate(query);
+
+        assertThat(results).hasSize(2)
+                .usingRecursiveFieldByFieldElementComparator()
+                .containsExactly(task2, task1);
+    }
+
+    @Test
+    void fetchForUpdate_empty() {
+        var results = getStore().fetchForUpdate(QuerySpec.none());
+
+        assertThat(results).isEmpty();
+    }
+
+    @Test
+    void create_shouldAllowMultipleTasksForSameProcess() {
+        var payload1 = createTestPayload("process-1");
+        var task1 = Task.Builder.newInstance()
+                .at(System.currentTimeMillis())
+                .payload(payload1).build();
+
+        var payload2 = createTestPayload("process-1");
+        var task2 = Task.Builder.newInstance()
+                .at(System.currentTimeMillis())
+                .payload(payload2).build();
+
+        getStore().create(task1);
+        getStore().create(task2);
+
+        var results = getStore().fetchForUpdate(QuerySpec.none());
+        assertThat(results).hasSize(2);
+    }
+
+    private TestPayload createTestPayload(String processId) {
+        return TestPayload.Builder.newInstance()
+                .processId(processId)
+                .processState("INITIAL")
+                .processType("CONSUMER")
+                .build();
+    }
+
+
+    public static class TestPayload extends ProcessTaskPayload {
+
+        private TestPayload() {
+        }
+
+        @Override
+        public String name() {
+            return "transfer.prepare";
+        }
+
+        @JsonPOJOBuilder(withPrefix = "")
+        public static class Builder extends ProcessTaskPayload.Builder<TestPayload, TestPayload.Builder> {
+
+            private Builder() {
+                super(new TestPayload());
+            }
+
+            @JsonCreator
+            public static Builder newInstance() {
+                return new TestPayload.Builder();
+            }
+
+            @Override
+            public Builder self() {
+                return this;
+            }
+        }
+    }
+}

--- a/system-tests/extensions/v-tck-extension/src/main/java/org/eclipse/edc/virtua/tck/dsp/DspTckExtension.java
+++ b/system-tests/extensions/v-tck-extension/src/main/java/org/eclipse/edc/virtua/tck/dsp/DspTckExtension.java
@@ -32,9 +32,9 @@ public class DspTckExtension implements ServiceExtension {
     @Override
     public void prepare() {
         participantContextService.createParticipantContext(ParticipantContext.Builder.newInstance()
-                        .participantContextId("participantContextId")
-                        .identity("participantContextId")
-                        .build())
+                    .participantContextId("participantContextId")
+                    .identity("participantContextId")
+                .build())
                 .orElseThrow(f -> new EdcException("Failed to create ParticipantContext"));
     }
 }

--- a/system-tests/runtime-tests/build.gradle.kts
+++ b/system-tests/runtime-tests/build.gradle.kts
@@ -45,7 +45,9 @@ dependencies {
     testImplementation(libs.bouncyCastle.bcpkixJdk18on)
 
     testCompileOnly(project(":system-tests:runtimes:e2e:e2e-controlplane-memory"))
+    testCompileOnly(project(":system-tests:runtimes:e2e:e2e-controlplane-memory-tasks"))
     testCompileOnly(project(":system-tests:runtimes:e2e:e2e-controlplane-postgres"))
+    testCompileOnly(project(":system-tests:runtimes:e2e:e2e-controlplane-postgres-nats-tasks"))
     testCompileOnly(project(":system-tests:runtimes:e2e:e2e-dcp-controlplane-postgres"))
     testCompileOnly(project(":system-tests:runtimes:issuer"))
     testCompileOnly(project(":system-tests:runtimes:identity-hub"))

--- a/system-tests/runtime-tests/src/test/java/org/eclipse/edc/virtual/Runtimes.java
+++ b/system-tests/runtime-tests/src/test/java/org/eclipse/edc/virtual/Runtimes.java
@@ -34,8 +34,20 @@ public interface Runtimes {
                 ":system-tests:runtimes:e2e:e2e-controlplane-memory",
         };
 
+        String[] MEMORY_TASKS = {
+                ":system-tests:runtimes:e2e:e2e-controlplane-memory-tasks",
+        };
+
+        String[] PG_TASKS_MODULES = {
+                ":system-tests:runtimes:e2e:e2e-controlplane-postgres-tasks",
+        };
+
         String[] PG_MODULES = {
                 ":system-tests:runtimes:e2e:e2e-controlplane-postgres",
+        };
+
+        String[] PG_NATS_TASKS_MODULES = {
+                ":system-tests:runtimes:e2e:e2e-controlplane-postgres-nats-tasks",
         };
 
         String[] DCP_PG_MODULES = {

--- a/system-tests/runtimes/e2e/e2e-controlplane-memory-tasks/build.gradle.kts
+++ b/system-tests/runtimes/e2e/e2e-controlplane-memory-tasks/build.gradle.kts
@@ -1,0 +1,39 @@
+/*
+ *  Copyright (c) 2025 Metaform Systems, Inc.
+ *
+ *  This program and the accompanying materials are made available under the
+ *  terms of the Apache License, Version 2.0 which is available at
+ *  https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Contributors:
+ *       Metaform Systems, Inc. - initial API and implementation
+ *
+ */
+
+plugins {
+    id("application")
+}
+
+dependencies {
+    implementation(libs.edc.iam.mock)
+    implementation(project(":dist:bom:virtual-controlplane-base-bom"))
+    implementation(project(":core:transfer-process-task-executor"))
+    implementation(project(":core:negotiation-task-executor"))
+    implementation(project(":core:v-task-core"))
+    implementation(project(":extensions:control-plane:tasks:listener:tasks-store-listener"))
+    implementation(project(":extensions:control-plane:tasks:listener:tasks-store-poll-executor"))
+
+    runtimeOnly(libs.edc.bom.dataplane) {
+        exclude(module = "data-plane-selector-client")
+    }
+}
+
+application {
+    mainClass.set("org.eclipse.edc.boot.system.runtime.BaseRuntime")
+}
+
+edcBuild {
+    publish.set(false)
+}

--- a/system-tests/runtimes/e2e/e2e-controlplane-postgres-nats-tasks/build.gradle.kts
+++ b/system-tests/runtimes/e2e/e2e-controlplane-postgres-nats-tasks/build.gradle.kts
@@ -1,0 +1,43 @@
+/*
+ *  Copyright (c) 2025 Metaform Systems, Inc.
+ *
+ *  This program and the accompanying materials are made available under the
+ *  terms of the Apache License, Version 2.0 which is available at
+ *  https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Contributors:
+ *       Metaform Systems, Inc. - initial API and implementation
+ *
+ */
+
+plugins {
+    id("application")
+}
+
+dependencies {
+    implementation(libs.edc.iam.mock)
+    implementation(project(":dist:bom:virtual-controlplane-base-bom"))
+    implementation(project(":dist:bom:virtual-controlplane-feature-sql-bom"))
+    implementation(project(":core:transfer-process-task-executor"))
+    implementation(project(":core:negotiation-task-executor"))
+    implementation(project(":core:v-task-core"))
+    implementation(project(":extensions:control-plane:tasks:listener:tasks-store-listener"))
+    implementation(project(":extensions:control-plane:tasks:publisher:tasks-publisher-nats"))
+    implementation(project(":extensions:control-plane:tasks:subscriber:negotiation-tasks-subscriber-nats"))
+    implementation(project(":extensions:control-plane:tasks:subscriber:transfer-tasks-subscriber-nats"))
+    implementation(project(":extensions:control-plane:tasks:store:tasks-store-sql"))
+
+    runtimeOnly(libs.edc.bom.dataplane) {
+        exclude(module = "data-plane-selector-client")
+    }
+}
+
+application {
+    mainClass.set("org.eclipse.edc.boot.system.runtime.BaseRuntime")
+}
+
+edcBuild {
+    publish.set(false)
+}

--- a/system-tests/runtimes/e2e/e2e-controlplane-postgres-tasks/build.gradle.kts
+++ b/system-tests/runtimes/e2e/e2e-controlplane-postgres-tasks/build.gradle.kts
@@ -1,0 +1,41 @@
+/*
+ *  Copyright (c) 2025 Metaform Systems, Inc.
+ *
+ *  This program and the accompanying materials are made available under the
+ *  terms of the Apache License, Version 2.0 which is available at
+ *  https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Contributors:
+ *       Metaform Systems, Inc. - initial API and implementation
+ *
+ */
+
+plugins {
+    id("application")
+}
+
+dependencies {
+    implementation(libs.edc.iam.mock)
+    implementation(project(":dist:bom:virtual-controlplane-base-bom"))
+    implementation(project(":dist:bom:virtual-controlplane-feature-sql-bom"))
+    implementation(project(":core:transfer-process-task-executor"))
+    implementation(project(":core:negotiation-task-executor"))
+    implementation(project(":core:v-task-core"))
+    implementation(project(":extensions:control-plane:tasks:listener:tasks-store-listener"))
+    implementation(project(":extensions:control-plane:tasks:listener:tasks-store-poll-executor"))
+    implementation(project(":extensions:control-plane:tasks:store:tasks-store-sql"))
+
+    runtimeOnly(libs.edc.bom.dataplane) {
+        exclude(module = "data-plane-selector-client")
+    }
+}
+
+application {
+    mainClass.set("org.eclipse.edc.boot.system.runtime.BaseRuntime")
+}
+
+edcBuild {
+    publish.set(false)
+}

--- a/system-tests/runtimes/tck/tck-controlplane-postgres-events/build.gradle.kts
+++ b/system-tests/runtimes/tck/tck-controlplane-postgres-events/build.gradle.kts
@@ -1,0 +1,42 @@
+/*
+ *  Copyright (c) 2025 Metaform Systems, Inc.
+ *
+ *  This program and the accompanying materials are made available under the
+ *  terms of the Apache License, Version 2.0 which is available at
+ *  https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Contributors:
+ *       Metaform Systems, Inc. - initial API and implementation
+ *
+ */
+
+plugins {
+    id("application")
+}
+
+dependencies {
+
+    implementation(project(":system-tests:extensions:v-tck-extension"));
+    implementation(project(":dist:bom:virtual-controlplane-base-bom"))
+    implementation(project(":dist:bom:virtual-controlplane-feature-sql-bom"))
+    implementation(project(":dist:bom:virtual-controlplane-feature-nats-bom"))
+    implementation(project(":extensions:control-plane:tasks:listener:tasks-store-listener"))
+    implementation(project(":extensions:control-plane:tasks:publisher:tasks-publisher-nats"))
+    implementation(project(":extensions:control-plane:tasks:store:tasks-store-sql"))
+    runtimeOnly(libs.edc.tck.extension)
+    runtimeOnly(libs.edc.core.participantcontext.single)
+    runtimeOnly(libs.edc.bom.dataplane) {
+        exclude(module = "data-plane-selector-client")
+    }
+    runtimeOnly(libs.edc.iam.mock)
+}
+
+application {
+    mainClass.set("org.eclipse.edc.boot.system.runtime.BaseRuntime")
+}
+
+edcBuild {
+    publish.set(false)
+}


### PR DESCRIPTION
## What this PR changes/adds

Add experimental state machine based on tasks and task store.

The design document is in this PR with the first implementation of:

- InMem and Postgres task store
- Plugs into current EDC core codebase for storing tasks
- Default implementation for task executors for CN and TP
- Naive poll-based task executor 
- Nats publish and subscriber for tasks execution

This is an experimental work and it will replace the current CDC approach once the TCK compliance
is in place.

## Why it does that

_Briefly state why the change was necessary._

## Further notes

_List other areas of code that have changed but are not necessarily linked to the main feature. This could be method
signature changes, package declarations, bugs that were encountered and were fixed inline, etc._


## Who will sponsor this feature?

_Please @-mention the committer that will sponsor your feature_.


## Linked Issue(s)

Closes #121 

_Please be sure to take a look at the [contributing guidelines](https://github.com/eclipse-edc/.github/blob/main/CONTRIBUTING.md#submit-a-pull-request) and our [etiquette for pull requests](https://github.com/eclipse-edc/.github/blob/main/contributing/pr_etiquette.md)._
