### PR TITLE
fix: add message type filter on dynamic scope extractor

### DIFF
--- a/extensions/iam/decentralized-claims/dcp-scope-core/build.gradle.kts
+++ b/extensions/iam/decentralized-claims/dcp-scope-core/build.gradle.kts
@@ -19,6 +19,8 @@ plugins {
 dependencies {
     api(project(":spi:iam:decentralized-claims:dcp-scope-spi"))
     api(libs.edc.spi.core)
+    api(libs.edc.spi.catalog)
+    api(libs.edc.spi.transfer)
     api(libs.edc.spi.dcp)
     api(libs.edc.spi.transaction)
     api(libs.edc.spi.policy.context)


### PR DESCRIPTION
## What this PR changes/adds

add message type filter on dynamic scope extractor

## Why it does that

_Briefly state why the change was necessary._

## Further notes

_List other areas of code that have changed but are not necessarily linked to the main feature. This could be method
signature changes, package declarations, bugs that were encountered and were fixed inline, etc._


## Who will sponsor this feature?

_Please @-mention the committer that will sponsor your feature_.


## Linked Issue(s)

Closes # <-- _insert Issue number if one exists_

_Please be sure to take a look at the [contributing guidelines](https://github.com/eclipse-edc/.github/blob/main/CONTRIBUTING.md#submit-a-pull-request) and our [etiquette for pull requests](https://github.com/eclipse-edc/.github/blob/main/contributing/pr_etiquette.md)._
