### PR TITLE
build: add configuration-filesystem module

### DIFF
--- a/dist/bom/virtual-controlplane-base-bom/build.gradle.kts
+++ b/dist/bom/virtual-controlplane-base-bom/build.gradle.kts
@@ -43,5 +43,6 @@ dependencies {
     runtimeOnly(libs.edc.core.dataplane.selector)
     runtimeOnly(libs.edc.encryption.aes)
     runtimeOnly(libs.edc.oauth2.client)
+    runtimeOnly(libs.edc.configuration.filesystem)
 }
 

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -70,6 +70,7 @@ edc-tasks-nats-subscriber-transfer = { module = "org.eclipse.edc:transfer-tasks-
 edc-mgmtapi-authn-oauth2 = { module = "org.eclipse.edc:management-api-oauth2-authentication", version.ref = "edc" }
 edc-mgmtapi-authz = { module = "org.eclipse.edc:management-api-authorization", version.ref = "edc" }
 edc-mgmtapi-v5 = { module = "org.eclipse.edc:management-api-v5", version.ref = "edc" }
+edc-configuration-filesystem = { module = "org.eclipse.edc:configuration-filesystem", version.ref = "edc" }
 
 # EDC DCP modules
 edc-iam-dcp-core = { module = "org.eclipse.edc:decentralized-claims-core", version.ref = "edc" }


### PR DESCRIPTION
## What this PR changes/adds

Adds `configuration-filesystem` module to the edc-v control plane dist/bom module. 

## Why it does that

Without it, any runtimes using the module cannot read a config properties file. 

## Further notes

_List other areas of code that have changed but are not necessarily linked to the main feature. This could be method
signature changes, package declarations, bugs that were encountered and were fixed inline, etc._


## Who will sponsor this feature?

@wolf4ood 


## Linked Issue(s)

Closes  #192 

_Please be sure to take a look at the [contributing guidelines](https://github.com/eclipse-edc/.github/blob/main/CONTRIBUTING.md#submit-a-pull-request) and our [etiquette for pull requests](https://github.com/eclipse-edc/.github/blob/main/contributing/pr_etiquette.md)._
